### PR TITLE
Decouple JLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,11 @@ canvas(-10, 10, -10, 10)
 For more control, use the terminal directly:
 
 ```java
-import ink.glimt.backend.jline.JLineBackend;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Terminal;
 
-try (var backend = new JLineBackend()) {
+try (var backend = BackendFactory.create()) {
     backend.enableRawMode();
     backend.enterAlternateScreen();
 

--- a/buildSrc/src/main/kotlin/ink.glimt.demo-project.gradle.kts
+++ b/buildSrc/src/main/kotlin/ink.glimt.demo-project.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 dependencies {
     implementation(project(":glimt-core"))
     implementation(project(":glimt-widgets"))
-    implementation(project(":glimt-jline"))
+    runtimeOnly(project(":glimt-jline"))
 }
 
 tasks.named<JavaExec>("run") {

--- a/demos/barchart-demo/src/main/java/ink/glimt/demo/BarChartDemo.java
+++ b/demos/barchart-demo/src/main/java/ink/glimt/demo/BarChartDemo.java
@@ -4,13 +4,14 @@
  */
 package ink.glimt.demo;
 
-import ink.glimt.backend.jline.JLineBackend;
 import ink.glimt.layout.Constraint;
 import ink.glimt.layout.Direction;
 import ink.glimt.layout.Layout;
 import ink.glimt.layout.Rect;
 import ink.glimt.style.Color;
 import ink.glimt.style.Style;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Frame;
 import ink.glimt.terminal.Terminal;
 import ink.glimt.text.Line;
@@ -24,8 +25,6 @@ import ink.glimt.widgets.barchart.Bar;
 import ink.glimt.widgets.barchart.BarChart;
 import ink.glimt.widgets.barchart.BarGroup;
 import ink.glimt.widgets.paragraph.Paragraph;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.util.Random;
@@ -51,14 +50,14 @@ public class BarChartDemo {
     }
 
     public void run() throws Exception {
-        try (JLineBackend backend = new JLineBackend()) {
+        try (Backend backend = BackendFactory.create()) {
             backend.enableRawMode();
             backend.enterAlternateScreen();
             backend.hideCursor();
 
-            Terminal<JLineBackend> terminal = new Terminal<>(backend);
+            Terminal<Backend> terminal = new Terminal<>(backend);
 
-            backend.jlineTerminal().handle(Signal.WINCH, signal -> {
+            backend.onResize(() -> {
                 try {
                     terminal.draw(this::ui);
                 } catch (IOException e) {
@@ -66,12 +65,10 @@ public class BarChartDemo {
                 }
             });
 
-            NonBlockingReader reader = backend.jlineTerminal().reader();
-
             while (running) {
                 terminal.draw(this::ui);
 
-                int c = reader.read(100);
+                int c = backend.read(100);
                 if (c == -2 || c == -1) {
                     continue;
                 }

--- a/demos/calendar-demo/src/main/java/ink/glimt/demo/CalendarDemo.java
+++ b/demos/calendar-demo/src/main/java/ink/glimt/demo/CalendarDemo.java
@@ -4,12 +4,13 @@
  */
 package ink.glimt.demo;
 
-import ink.glimt.backend.jline.JLineBackend;
 import ink.glimt.layout.Constraint;
 import ink.glimt.layout.Layout;
 import ink.glimt.layout.Rect;
 import ink.glimt.style.Color;
 import ink.glimt.style.Style;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Frame;
 import ink.glimt.terminal.Terminal;
 import ink.glimt.text.Line;
@@ -22,8 +23,6 @@ import ink.glimt.widgets.block.Title;
 import ink.glimt.widgets.calendar.CalendarEventStore;
 import ink.glimt.widgets.calendar.Monthly;
 import ink.glimt.widgets.paragraph.Paragraph;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.time.DayOfWeek;
@@ -51,15 +50,15 @@ public class CalendarDemo {
     }
 
     public void run() throws Exception {
-        try (JLineBackend backend = new JLineBackend()) {
+        try (Backend backend = BackendFactory.create()) {
             backend.enableRawMode();
             backend.enterAlternateScreen();
             backend.hideCursor();
 
-            Terminal<JLineBackend> terminal = new Terminal<>(backend);
+            Terminal<Backend> terminal = new Terminal<>(backend);
 
             // Handle resize
-            backend.jlineTerminal().handle(Signal.WINCH, signal -> {
+            backend.onResize(() -> {
                 try {
                     terminal.draw(this::ui);
                 } catch (IOException e) {
@@ -67,13 +66,11 @@ public class CalendarDemo {
                 }
             });
 
-            NonBlockingReader reader = backend.jlineTerminal().reader();
-
             // Event loop
             while (running) {
                 terminal.draw(this::ui);
 
-                int c = reader.read(100);
+                int c = backend.read(100);
                 handleInput(c);
             }
         }

--- a/demos/canvas-demo/src/main/java/ink/glimt/demo/CanvasDemo.java
+++ b/demos/canvas-demo/src/main/java/ink/glimt/demo/CanvasDemo.java
@@ -4,12 +4,13 @@
  */
 package ink.glimt.demo;
 
-import ink.glimt.backend.jline.JLineBackend;
 import ink.glimt.layout.Constraint;
 import ink.glimt.layout.Layout;
 import ink.glimt.layout.Rect;
 import ink.glimt.style.Color;
 import ink.glimt.style.Style;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Frame;
 import ink.glimt.terminal.Terminal;
 import ink.glimt.text.Line;
@@ -25,8 +26,6 @@ import ink.glimt.widgets.canvas.shapes.Circle;
 import ink.glimt.widgets.canvas.shapes.Points;
 import ink.glimt.widgets.canvas.shapes.Rectangle;
 import ink.glimt.widgets.paragraph.Paragraph;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.util.Random;
@@ -68,15 +67,15 @@ public class CanvasDemo {
     }
 
     public void run() throws Exception {
-        try (JLineBackend backend = new JLineBackend()) {
+        try (Backend backend = BackendFactory.create()) {
             backend.enableRawMode();
             backend.enterAlternateScreen();
             backend.hideCursor();
 
-            Terminal<JLineBackend> terminal = new Terminal<>(backend);
+            Terminal<Backend> terminal = new Terminal<>(backend);
 
             // Handle resize
-            backend.jlineTerminal().handle(Signal.WINCH, signal -> {
+            backend.onResize(() -> {
                 try {
                     terminal.draw(this::ui);
                 } catch (IOException e) {
@@ -84,13 +83,11 @@ public class CanvasDemo {
                 }
             });
 
-            NonBlockingReader reader = backend.jlineTerminal().reader();
-
             // Event loop with animation
             while (running) {
                 terminal.draw(this::ui);
 
-                int c = reader.read(50);
+                int c = backend.read(50);
                 if (c == 'q' || c == 'Q' || c == 3) {
                     running = false;
                 } else if (c == ' ' || c == 'm' || c == 'M') {

--- a/demos/chart-demo/src/main/java/ink/glimt/demo/ChartDemo.java
+++ b/demos/chart-demo/src/main/java/ink/glimt/demo/ChartDemo.java
@@ -4,12 +4,13 @@
  */
 package ink.glimt.demo;
 
-import ink.glimt.backend.jline.JLineBackend;
 import ink.glimt.layout.Constraint;
 import ink.glimt.layout.Layout;
 import ink.glimt.layout.Rect;
 import ink.glimt.style.Color;
 import ink.glimt.style.Style;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Frame;
 import ink.glimt.terminal.Terminal;
 import ink.glimt.text.Line;
@@ -25,8 +26,6 @@ import ink.glimt.widgets.chart.Dataset;
 import ink.glimt.widgets.chart.GraphType;
 import ink.glimt.widgets.chart.LegendPosition;
 import ink.glimt.widgets.paragraph.Paragraph;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.util.Random;
@@ -78,15 +77,15 @@ public class ChartDemo {
     }
 
     public void run() throws Exception {
-        try (JLineBackend backend = new JLineBackend()) {
+        try (Backend backend = BackendFactory.create()) {
             backend.enableRawMode();
             backend.enterAlternateScreen();
             backend.hideCursor();
 
-            Terminal<JLineBackend> terminal = new Terminal<>(backend);
+            Terminal<Backend> terminal = new Terminal<>(backend);
 
             // Handle resize
-            backend.jlineTerminal().handle(Signal.WINCH, signal -> {
+            backend.onResize(() -> {
                 try {
                     terminal.draw(this::ui);
                 } catch (IOException e) {
@@ -94,13 +93,11 @@ public class ChartDemo {
                 }
             });
 
-            NonBlockingReader reader = backend.jlineTerminal().reader();
-
             // Event loop with animation
             while (running) {
                 terminal.draw(this::ui);
 
-                int c = reader.read(100);
+                int c = backend.read(100);
                 if (c == 'q' || c == 'Q' || c == 3) {
                     running = false;
                 }

--- a/demos/sparkline-demo/src/main/java/ink/glimt/demo/SparklineDemo.java
+++ b/demos/sparkline-demo/src/main/java/ink/glimt/demo/SparklineDemo.java
@@ -4,12 +4,13 @@
  */
 package ink.glimt.demo;
 
-import ink.glimt.backend.jline.JLineBackend;
 import ink.glimt.layout.Constraint;
 import ink.glimt.layout.Layout;
 import ink.glimt.layout.Rect;
 import ink.glimt.style.Color;
 import ink.glimt.style.Style;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Frame;
 import ink.glimt.terminal.Terminal;
 import ink.glimt.text.Line;
@@ -21,8 +22,6 @@ import ink.glimt.widgets.block.Borders;
 import ink.glimt.widgets.block.Title;
 import ink.glimt.widgets.paragraph.Paragraph;
 import ink.glimt.widgets.sparkline.Sparkline;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.util.Random;
@@ -60,15 +59,15 @@ public class SparklineDemo {
     }
 
     public void run() throws Exception {
-        try (JLineBackend backend = new JLineBackend()) {
+        try (Backend backend = BackendFactory.create()) {
             backend.enableRawMode();
             backend.enterAlternateScreen();
             backend.hideCursor();
 
-            Terminal<JLineBackend> terminal = new Terminal<>(backend);
+            Terminal<Backend> terminal = new Terminal<>(backend);
 
             // Handle resize
-            backend.jlineTerminal().handle(Signal.WINCH, signal -> {
+            backend.onResize(() -> {
                 try {
                     terminal.draw(this::ui);
                 } catch (IOException e) {
@@ -76,13 +75,11 @@ public class SparklineDemo {
                 }
             });
 
-            NonBlockingReader reader = backend.jlineTerminal().reader();
-
             // Event loop with animation
             while (running) {
                 terminal.draw(this::ui);
 
-                int c = reader.read(100);
+                int c = backend.read(100);
                 if (c == 'q' || c == 'Q' || c == 3) {
                     running = false;
                 }

--- a/demos/table-demo/src/main/java/ink/glimt/demo/TableDemo.java
+++ b/demos/table-demo/src/main/java/ink/glimt/demo/TableDemo.java
@@ -4,12 +4,13 @@
  */
 package ink.glimt.demo;
 
-import ink.glimt.backend.jline.JLineBackend;
 import ink.glimt.layout.Constraint;
 import ink.glimt.layout.Layout;
 import ink.glimt.layout.Rect;
 import ink.glimt.style.Color;
 import ink.glimt.style.Style;
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendFactory;
 import ink.glimt.terminal.Frame;
 import ink.glimt.terminal.Terminal;
 import ink.glimt.text.Line;
@@ -24,8 +25,6 @@ import ink.glimt.widgets.table.Cell;
 import ink.glimt.widgets.table.Row;
 import ink.glimt.widgets.table.Table;
 import ink.glimt.widgets.table.TableState;
-import org.jline.terminal.Terminal.Signal;
-import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,23 +58,21 @@ public class TableDemo {
     }
 
     public void run() throws Exception {
-        try (JLineBackend backend = new JLineBackend()) {
+        try (Backend backend = BackendFactory.create()) {
             backend.enableRawMode();
             backend.enterAlternateScreen();
             backend.hideCursor();
 
-            Terminal<JLineBackend> terminal = new Terminal<>(backend);
+            Terminal<Backend> terminal = new Terminal<>(backend);
 
             // Handle resize
-            backend.jlineTerminal().handle(Signal.WINCH, signal -> {
+            backend.onResize(() -> {
                 try {
                     terminal.draw(this::ui);
                 } catch (IOException e) {
                     // Ignore
                 }
             });
-
-            NonBlockingReader reader = backend.jlineTerminal().reader();
 
             // Select first row
             tableState.selectFirst();
@@ -85,12 +82,12 @@ public class TableDemo {
 
             // Event loop
             while (running) {
-                int c = reader.read(100);
+                int c = backend.read(100);
                 if (c == -2 || c == -1) {
                     continue;
                 }
 
-                boolean needsRedraw = handleInput(c, reader);
+                boolean needsRedraw = handleInput(c, backend);
                 if (needsRedraw) {
                     terminal.draw(this::ui);
                 }
@@ -98,13 +95,13 @@ public class TableDemo {
         }
     }
 
-    private boolean handleInput(int c, NonBlockingReader reader) throws IOException {
+    private boolean handleInput(int c, Backend backend) throws IOException {
         // Handle escape sequences
         if (c == 27) {
-            int next = reader.peek(50);
+            int next = backend.peek(50);
             if (next == '[') {
-                reader.read();
-                int code = reader.read();
+                backend.read(50);
+                int code = backend.read(50);
                 return handleEscapeSequence(code);
             }
             return false;

--- a/glimt-core/src/main/java/ink/glimt/terminal/Backend.java
+++ b/glimt-core/src/main/java/ink/glimt/terminal/Backend.java
@@ -105,6 +105,31 @@ public interface Backend extends AutoCloseable {
     }
 
     /**
+     * Registers a handler to be called when the terminal is resized.
+     *
+     * @param handler the handler to call on resize
+     */
+    void onResize(Runnable handler);
+
+    /**
+     * Reads a single character from the terminal input with timeout.
+     *
+     * @param timeoutMs timeout in milliseconds
+     * @return the character read, -1 for EOF, or -2 for timeout
+     * @throws IOException if an I/O error occurs
+     */
+    int read(int timeoutMs) throws IOException;
+
+    /**
+     * Peeks at the next character without consuming it.
+     *
+     * @param timeoutMs timeout in milliseconds
+     * @return the character peeked, -1 for EOF, or -2 for timeout
+     * @throws IOException if an I/O error occurs
+     */
+    int peek(int timeoutMs) throws IOException;
+
+    /**
      * Closes this backend and releases any resources.
      */
     @Override

--- a/glimt-core/src/main/java/ink/glimt/terminal/BackendFactory.java
+++ b/glimt-core/src/main/java/ink/glimt/terminal/BackendFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Glimt Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package ink.glimt.terminal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * Factory for creating {@link Backend} instances using the {@link ServiceLoader} mechanism.
+ * <p>
+ * This factory discovers {@link BackendProvider} implementations on the classpath
+ * and uses them to create backend instances. Applications should include exactly
+ * one backend provider on the classpath (e.g., glimt-jline or glimt-jline4).
+ *
+ * @see BackendProvider
+ * @see Backend
+ */
+public final class BackendFactory {
+
+    private BackendFactory() {
+        // Utility class
+    }
+
+    /**
+     * Creates a new backend instance using the discovered provider.
+     * <p>
+     * This method expects exactly one {@link BackendProvider} to be present
+     * on the classpath. If none or multiple providers are found, an exception is thrown.
+     *
+     * @return a new backend instance
+     * @throws IOException if backend creation fails
+     * @throws IllegalStateException if no provider is found or multiple providers are found
+     */
+    public static Backend create() throws IOException {
+        ServiceLoader<BackendProvider> loader = ServiceLoader.load(BackendProvider.class);
+        List<BackendProvider> providers = new ArrayList<>();
+        loader.forEach(providers::add);
+
+        if (providers.isEmpty()) {
+            throw new IllegalStateException(
+                "No BackendProvider found on classpath. " +
+                "Add a backend dependency such as glimt-jline or glimt-jline4."
+            );
+        }
+
+        if (providers.size() > 1) {
+            throw new IllegalStateException(
+                "Multiple BackendProviders found on classpath: " + providers +
+                ". Include only one backend dependency."
+            );
+        }
+
+        return providers.get(0).create();
+    }
+}

--- a/glimt-core/src/main/java/ink/glimt/terminal/BackendProvider.java
+++ b/glimt-core/src/main/java/ink/glimt/terminal/BackendProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 Glimt Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package ink.glimt.terminal;
+
+import java.io.IOException;
+
+/**
+ * Service provider interface for creating {@link Backend} instances.
+ * <p>
+ * Implementations of this interface should be registered via the
+ * Java {@link java.util.ServiceLoader} mechanism by creating a file
+ * {@code META-INF/services/ink.glimt.terminal.BackendProvider} containing
+ * the fully qualified class name of the implementation.
+ * <p>
+ * Applications should include exactly one backend provider on the classpath
+ * (e.g., either glimt-jline or glimt-jline4, but not both).
+ *
+ * @see BackendFactory
+ * @see Backend
+ */
+public interface BackendProvider {
+
+    /**
+     * Creates a new backend instance.
+     *
+     * @return a new backend instance
+     * @throws IOException if the backend cannot be created
+     */
+    Backend create() throws IOException;
+}

--- a/glimt-jline/src/main/java/ink/glimt/backend/jline/JLineBackend.java
+++ b/glimt-jline/src/main/java/ink/glimt/backend/jline/JLineBackend.java
@@ -15,8 +15,10 @@ import ink.glimt.style.Style;
 import ink.glimt.terminal.Backend;
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Terminal;
+import org.jline.terminal.Terminal.Signal;
 import org.jline.terminal.TerminalBuilder;
 import org.jline.utils.InfoCmp;
+import org.jline.utils.NonBlockingReader;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -32,6 +34,7 @@ public class JLineBackend implements Backend {
 
     private final Terminal terminal;
     private final PrintWriter writer;
+    private final NonBlockingReader reader;
     private Attributes savedAttributes;
     private boolean inAlternateScreen;
     private boolean mouseEnabled;
@@ -42,6 +45,7 @@ public class JLineBackend implements Backend {
             .jansi(true)
             .build();
         this.writer = terminal.writer();
+        this.reader = terminal.reader();
         this.inAlternateScreen = false;
         this.mouseEnabled = false;
     }
@@ -169,6 +173,21 @@ public class JLineBackend implements Backend {
     public void scrollDown(int lines) throws IOException {
         writer.print(CSI + lines + "T");
         writer.flush();
+    }
+
+    @Override
+    public void onResize(Runnable handler) {
+        terminal.handle(Signal.WINCH, signal -> handler.run());
+    }
+
+    @Override
+    public int read(int timeoutMs) throws IOException {
+        return reader.read(timeoutMs);
+    }
+
+    @Override
+    public int peek(int timeoutMs) throws IOException {
+        return reader.peek(timeoutMs);
     }
 
     @Override

--- a/glimt-jline/src/main/java/ink/glimt/backend/jline/JLineBackendProvider.java
+++ b/glimt-jline/src/main/java/ink/glimt/backend/jline/JLineBackendProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Glimt Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package ink.glimt.backend.jline;
+
+import ink.glimt.terminal.Backend;
+import ink.glimt.terminal.BackendProvider;
+
+import java.io.IOException;
+
+/**
+ * {@link BackendProvider} implementation for JLine 3.
+ * <p>
+ * This provider is registered via the Java {@link java.util.ServiceLoader} mechanism.
+ */
+public class JLineBackendProvider implements BackendProvider {
+
+    @Override
+    public Backend create() throws IOException {
+        return new JLineBackend();
+    }
+}

--- a/glimt-jline/src/main/resources/META-INF/services/ink.glimt.terminal.BackendProvider
+++ b/glimt-jline/src/main/resources/META-INF/services/ink.glimt.terminal.BackendProvider
@@ -1,0 +1,1 @@
+ink.glimt.backend.jline.JLineBackendProvider

--- a/glimt-tui/build.gradle.kts
+++ b/glimt-tui/build.gradle.kts
@@ -7,5 +7,4 @@ description = "High-level TUI application framework for Glimt"
 dependencies {
     api(projects.glimtCore)
     api(projects.glimtWidgets)
-    api(projects.glimtJline)
 }


### PR DESCRIPTION
  - Add onResize(), read(), peek() methods to Backend interface
  - Create BackendProvider SPI and BackendFactory with ServiceLoader discovery
  - Update all demos to use BackendFactory instead of JLineBackend
  - Change glimt-jline to runtimeOnly dependency

This allows swapping terminal backends transparently since the backend will be loaded via service loading.

Demos have been updated accordingly

Fixes #6