### PR TITLE
feat: add assertj module for useful buffer assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It provides a comprehensive set of widgets and a layout system for building rich
 | `tamboui-tui` | High-level TUI framework with TuiRunner, event handling, and key helpers |
 | `tamboui-toolkit` | Fluent DSL for declarative UI construction with components and focus management |
 | `tamboui-picocli` | Optional PicoCLI integration for CLI argument parsing |
+| `tamboui-core-assertj` | AssertJ assertions for things like Buffer comparison |
 | `demos/*` | Demo applications showcasing widgets and features |
 
 ## Requirements

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "tamboui-parent"
 
 include(
     "tamboui-core",
+    "tamboui-core-assertj",
     "tamboui-widgets",
     "tamboui-jline",
     "tamboui-tui",

--- a/tamboui-core-assertj/build.gradle.kts
+++ b/tamboui-core-assertj/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("dev.tamboui.java-library")
+}
+
+description = "AssertJ custom assertions for TamboUI"
+
+dependencies {
+    val libs = versionCatalogs.named("libs")
+    
+    // Depend on tamboui-core for Buffer and related types
+    api(projects.tambouiCore)
+    
+    // AssertJ is needed as API dependency for custom assertions
+    api(libs.findLibrary("assertj-core").orElseThrow())
+}
+
+

--- a/tamboui-core-assertj/src/main/java/dev/tamboui/assertj/BufferAssert.java
+++ b/tamboui-core-assertj/src/main/java/dev/tamboui/assertj/BufferAssert.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.assertj;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * AssertJ custom assertion for {@link Buffer}.
+ * <p>
+ * Provides buffer-specific assertions with detailed diff output similar to ratatui.rs.
+ */
+public final class BufferAssert extends AbstractAssert<BufferAssert, Buffer> {
+
+    public BufferAssert(Buffer actual) {
+        super(actual, BufferAssert.class);
+    }
+
+    /**
+     * Asserts that the actual buffer is equal to the expected buffer.
+     * <p>
+     * If the buffers differ, a detailed diff is shown in the error message,
+     * displaying both buffers side-by-side with their content formatted as strings.
+     *
+     * @param expected the expected buffer
+     * @return this assertion object
+     * @throws AssertionError if the buffers are not equal
+     */
+    public BufferAssert isEqualTo(Buffer expected) {
+        isNotNull();
+
+        if (expected == null) {
+            failWithMessage("Expected buffer to be null, but was: %s", formatBuffer(actual));
+            return this;
+        }
+
+        if (!actual.equals(expected)) {
+            String diff = BufferDiffFormatter.formatDiff(actual, expected);
+            failWithMessage("Expected buffer to equal expected buffer, but they differ:%n%n%s", diff);
+        }
+
+        return this;
+    }
+
+    /**
+     * Asserts that the actual buffer is not equal to the expected buffer.
+     *
+     * @param expected the buffer that should not equal the actual buffer
+     * @return this assertion object
+     * @throws AssertionError if the buffers are equal
+     */
+    public BufferAssert isNotEqualTo(Buffer expected) {
+        isNotNull();
+
+        if (expected != null && actual.equals(expected)) {
+            failWithMessage("Expected buffer to not equal expected buffer, but they are equal:%n%n%s", formatBuffer(actual));
+        }
+
+        return this;
+    }
+
+    /**
+     * Asserts that the buffer has the given area.
+     *
+     * @param expectedArea the expected area
+     * @return this assertion object
+     */
+    public BufferAssert hasArea(dev.tamboui.layout.Rect expectedArea) {
+        isNotNull();
+
+        if (!actual.area().equals(expectedArea)) {
+            failWithMessage("Expected buffer area to be <%s>, but was <%s>", expectedArea, actual.area());
+        }
+
+        return this;
+    }
+
+    /**
+     * Asserts that the buffer has the given width.
+     *
+     * @param expectedWidth the expected width
+     * @return this assertion object
+     */
+    public BufferAssert hasWidth(int expectedWidth) {
+        isNotNull();
+
+        if (actual.width() != expectedWidth) {
+            failWithMessage("Expected buffer width to be <%d>, but was <%d>", expectedWidth, actual.width());
+        }
+
+        return this;
+    }
+
+    /**
+     * Asserts that the buffer has the given height.
+     *
+     * @param expectedHeight the expected height
+     * @return this assertion object
+     */
+    public BufferAssert hasHeight(int expectedHeight) {
+        isNotNull();
+
+        if (actual.height() != expectedHeight) {
+            failWithMessage("Expected buffer height to be <%d>, but was <%d>", expectedHeight, actual.height());
+        }
+
+        return this;
+    }
+
+    /**
+     * Asserts that the cell at the given position equals the expected cell.
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param expectedCell the expected cell
+     * @return this assertion object
+     */
+    public BufferAssert hasCellAt(int x, int y, Cell expectedCell) {
+        isNotNull();
+
+        Cell actualCell = actual.get(x, y);
+        if (!actualCell.equals(expectedCell)) {
+            failWithMessage("Expected cell at (%d, %d) to be <%s>, but was <%s>", x, y, expectedCell, actualCell);
+        }
+
+        return this;
+    }
+
+    private String formatBuffer(Buffer buffer) {
+        return BufferDiffFormatter.formatBuffer(buffer);
+    }
+}
+
+

--- a/tamboui-core-assertj/src/main/java/dev/tamboui/assertj/BufferAssertions.java
+++ b/tamboui-core-assertj/src/main/java/dev/tamboui/assertj/BufferAssertions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.assertj;
+
+import dev.tamboui.buffer.Buffer;
+
+/**
+ * Entry point for AssertJ custom assertions for {@link Buffer}.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * import static dev.tamboui.assertj.BufferAssertions.assertThat;
+ *
+ * Buffer actual = Buffer.empty(new Rect(0, 0, 10, 5));
+ * Buffer expected = Buffer.filled(new Rect(0, 0, 10, 5), Cell.EMPTY);
+ * assertThat(actual).isEqualTo(expected);
+ * }</pre>
+ */
+public final class BufferAssertions {
+
+    private BufferAssertions() {
+        // Utility class
+    }
+
+    /**
+     * Creates a new instance of {@link BufferAssert}.
+     *
+     * @param actual the buffer we want to make assertions on
+     * @return the created assertion object
+     */
+    public static BufferAssert assertThat(Buffer actual) {
+        return new BufferAssert(actual);
+    }
+
+}
+
+

--- a/tamboui-core-assertj/src/main/java/dev/tamboui/assertj/BufferDiffFormatter.java
+++ b/tamboui-core-assertj/src/main/java/dev/tamboui/assertj/BufferDiffFormatter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.assertj;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.layout.Rect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for formatting buffer differences in a readable way,
+ * similar to ratatui.rs assertion output.
+ */
+final class BufferDiffFormatter {
+
+    private BufferDiffFormatter() {
+        // Utility class
+    }
+
+    /**
+     * Formats a diff between two buffers, showing both buffers side-by-side.
+     *
+     * @param actual the actual buffer
+     * @param expected the expected buffer
+     * @return a formatted string showing the difference
+     */
+    static String formatDiff(Buffer actual, Buffer expected) {
+        StringBuilder sb = new StringBuilder();
+
+        // Format actual buffer
+        sb.append(" left: ").append(formatBuffer(actual)).append("\n");
+        sb.append(" right: ").append(formatBuffer(expected));
+
+        return sb.toString();
+    }
+
+    /**
+     * Formats a buffer for display, similar to ratatui.rs format.
+     *
+     * @param buffer the buffer to format
+     * @return a formatted string representation
+     */
+    static String formatBuffer(Buffer buffer) {
+        if (buffer == null) {
+            return "null";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        Rect area = buffer.area();
+
+        // Buffer header
+        sb.append("Buffer {\n");
+        sb.append("    area: ").append(formatRect(area)).append(",\n");
+
+        // Content lines
+        List<String> contentLines = formatContentLines(buffer);
+        sb.append("    content: [\n");
+        for (int i = 0; i < contentLines.size(); i++) {
+            sb.append("        \"").append(contentLines.get(i)).append("\"");
+            if (i < contentLines.size() - 1) {
+                sb.append(",");
+            }
+            sb.append("\n");
+        }
+        sb.append("    ],\n");
+
+        // Styles (simplified - could be enhanced to show style differences)
+        sb.append("    styles: [\n");
+        sb.append("        x: 0, y: 0, fg: Reset, bg: Reset, modifier: NONE,\n");
+        sb.append("    ]\n");
+        sb.append("}");
+
+        return sb.toString();
+    }
+
+    private static String formatRect(Rect rect) {
+        return String.format("Rect { x: %d, y: %d, width: %d, height: %d }",
+            rect.x(), rect.y(), rect.width(), rect.height());
+    }
+
+    private static List<String> formatContentLines(Buffer buffer) {
+        List<String> lines = new ArrayList<>();
+        Rect area = buffer.area();
+
+        for (int y = area.top(); y < area.bottom(); y++) {
+            StringBuilder line = new StringBuilder();
+            for (int x = area.left(); x < area.right(); x++) {
+                Cell cell = buffer.get(x, y);
+                String symbol = cell.symbol();
+                // Escape quotes in the symbol
+                symbol = symbol.replace("\"", "\\\"");
+                line.append(symbol);
+            }
+            lines.add(line.toString());
+        }
+
+        return lines;
+    }
+}
+
+

--- a/tamboui-core/build.gradle.kts
+++ b/tamboui-core/build.gradle.kts
@@ -3,3 +3,8 @@ plugins {
 }
 
 description = "Core types and abstractions for TamboUI TUI library"
+
+dependencies {
+    // Use tamboui-core-assertj only in tests
+    testImplementation(projects.tambouiCoreAssertj)
+}

--- a/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
+++ b/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
@@ -302,4 +302,31 @@ public final class Buffer {
     private int index(int x, int y) {
         return (y - area.y()) * area.width() + (x - area.x());
     }
+ 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Buffer)) {
+            return false;
+        }
+        Buffer buffer = (Buffer) o;
+        if (!area.equals(buffer.area)) {
+            return false;
+        }
+        return Arrays.equals(content, buffer.content);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = area.hashCode();
+        result = 31 * result + Arrays.hashCode(content);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Buffer[area=%s, width=%d, height=%d]", area, width(), height());
+    }
 }

--- a/tamboui-core/src/test/java/dev/tamboui/buffer/BufferTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/buffer/BufferTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
+import static dev.tamboui.assertj.BufferAssertions.*;
 
 class BufferTest {
 
@@ -118,5 +119,59 @@ class BufferTest {
 
         buffer.set(14, 14, cell);
         assertThat(buffer.get(14, 14)).isEqualTo(cell);
+    }
+
+    @Test
+    @DisplayName("BufferAssertions provides detailed diff output")
+    void bufferAssertionsDetailedDiff() {
+        Buffer actual = Buffer.empty(new Rect(0, 0, 15, 10));
+        actual.setString(2, 2, "██████████", Style.EMPTY);
+        actual.setString(2, 3, "██░░░░░░██", Style.EMPTY);
+        actual.setString(2, 4, "██░░░░░░██", Style.EMPTY);
+        actual.setString(2, 5, "██░░░░░░██", Style.EMPTY);
+        actual.setString(2, 6, "██░░░░░░██", Style.EMPTY);
+        actual.setString(2, 7, "██████████", Style.EMPTY);
+
+        Buffer expected = Buffer.empty(new Rect(0, 0, 16, 10));
+        expected.setString(2, 2, "█████████ █", Style.EMPTY);
+        expected.setString(2, 3, "██░░░░░░██    ", Style.EMPTY);
+        expected.setString(2, 4, "██░░░░░░██    ", Style.EMPTY);
+        expected.setString(2, 5, "██░░░░░░██    ", Style.EMPTY);
+        expected.setString(2, 6, "██░░░░░░██    ", Style.EMPTY);
+        expected.setString(2, 7, "██████████    ", Style.EMPTY);
+
+        // This will fail and show a nice diff
+        try {
+            assertThat(actual).isEqualTo(expected);
+        } catch (AssertionError e) {
+            // Verify the error message contains formatted buffer output
+            String message = e.getMessage();
+            assertThat(message).contains("left:");
+            assertThat(message).contains("right:");
+            assertThat(message).contains("Buffer {");
+            assertThat(message).contains("content:");
+        }
+    }
+
+    @Test
+    @DisplayName("BufferAssertions can assert buffer properties")
+    void bufferAssertionsProperties() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 5));
+        
+        assertThat(buffer)
+            .hasArea(new Rect(0, 0, 10, 5))
+            .hasWidth(10)
+            .hasHeight(5);
+    }
+
+    @Test
+    @DisplayName("BufferAssertions can assert individual cells")
+    void bufferAssertionsCells() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 5));
+        Cell cell = new Cell("X", Style.EMPTY);
+        buffer.set(5, 2, cell);
+        
+        assertThat(buffer).hasCellAt(5, 2, cell);
+        assertThat(buffer).hasCellAt(0, 0, Cell.EMPTY);
     }
 }


### PR DESCRIPTION
provides a way to do nice assert(j's) on buffers. 

something the current tests dont do much but really could use.

so instead of just "buffer not equal to buffer2" you get this:

```
java.lang.AssertionError: Expected buffer to equal expected buffer, but they differ:

 left: Buffer {
    area: Rect { x: 0, y: 0, width: 15, height: 10 },
    content: [
        "               ",
        "               ",
        "  ██████████   ",
        "  ██░░░░░░██   ",
        "  ██░░░░░░██   ",
        "  ██░░░░░░██   ",
        "  ██░░░░░░██   ",
        "  ██████████   ",
        "               ",
        "               "
    ],
    styles: [
        x: 0, y: 0, fg: Reset, bg: Reset, modifier: NONE,
    ]
}
 right: Buffer {
    area: Rect { x: 0, y: 0, width: 16, height: 10 },
    content: [
        "                ",
        "                ",
        "  █████████ █   ",
        "  ██░░░░░░██    ",
        "  ██░░░░░░██    ",
        "  ██░░░░░░██    ",
        "  ██░░░░░░██    ",
        "  ██████████    ",
        "                ",
        "                "
    ],
    styles: [
        x: 0, y: 0, fg: Reset, bg: Reset, modifier: NONE,
    ]
}
        at dev.tamboui.buffer.BufferTest.bufferAssertionsDetailedDiff(BufferTest.java:143)
        ```