### PR TITLE
Add support for Java modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("dev.tamboui.maven-central-publishing")
+    id("dev.tamboui.parent")
 }
 

--- a/buildSrc/src/main/java/dev/tamboui/build/SplitPackageCheckTask.java
+++ b/buildSrc/src/main/java/dev/tamboui/build/SplitPackageCheckTask.java
@@ -1,0 +1,217 @@
+package dev.tamboui.build;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+/**
+ * A task that checks for split packages across source sets.
+ * <p>
+ * Split packages occur when the same Java package exists in multiple modules,
+ * which causes problems with the Java Platform Module System. This task
+ * analyzes source directories and reports any packages that appear in more than one module.
+ */
+@CacheableTask
+public abstract class SplitPackageCheckTask extends DefaultTask {
+
+    /**
+     * Represents a source set entry with its name and source files.
+     */
+    public interface SourceSetEntry {
+        /**
+         * Returns the name of the source set (typically the module/project name).
+         *
+         * @return the source set name
+         */
+        @Input
+        String getName();
+
+        /**
+         * Returns the Java source files in this source set.
+         *
+         * @return the file tree of Java sources
+         */
+        @InputFiles
+        @PathSensitive(PathSensitivity.RELATIVE)
+        FileTree getSources();
+    }
+
+    /**
+     * The source set entries to analyze for split packages.
+     *
+     * @return the list of source set entries
+     */
+    @Nested
+    public abstract ListProperty<SourceSetEntry> getSourceSets();
+
+    /**
+     * The output report file containing the split package analysis results.
+     *
+     * @return the regular file property for the report
+     */
+    @OutputFile
+    public abstract RegularFileProperty getReportFile();
+
+    /**
+     * Adds a source set entry to be analyzed.
+     *
+     * @param name    the name of the source set (module/project name)
+     * @param sources the file tree of Java sources
+     */
+    public void sourceSet(String name, FileTree sources) {
+        getSourceSets().add(new SourceSetEntryImpl(name, sources));
+    }
+
+    /**
+     * Executes the split package check.
+     * <p>
+     * Analyzes all source sets, identifies packages in each, and reports
+     * any packages that exist in multiple modules. The task fails if split packages
+     * are detected.
+     */
+    @TaskAction
+    public void checkSplitPackages() {
+        Map<String, Set<String>> packageToModules = new HashMap<>();
+
+        for (SourceSetEntry entry : getSourceSets().get()) {
+            String moduleName = entry.getName();
+            Set<String> packages = extractPackagesFromSources(entry.getSources());
+            for (String pkg : packages) {
+                packageToModules.computeIfAbsent(pkg, k -> new HashSet<>()).add(moduleName);
+            }
+        }
+
+        // Find split packages (packages in more than one module)
+        Map<String, Set<String>> splitPackages = new TreeMap<>();
+        for (Map.Entry<String, Set<String>> entry : packageToModules.entrySet()) {
+            if (entry.getValue().size() > 1) {
+                splitPackages.put(entry.getKey(), new TreeSet<>(entry.getValue()));
+            }
+        }
+
+        // Write report
+        writeReport(splitPackages);
+
+        // Fail if split packages found
+        if (!splitPackages.isEmpty()) {
+            StringBuilder message = new StringBuilder();
+            message.append("Split packages detected:\n");
+            for (Map.Entry<String, Set<String>> entry : splitPackages.entrySet()) {
+                message.append("  Package '")
+                        .append(entry.getKey())
+                        .append("' found in: ")
+                        .append(String.join(", ", entry.getValue()))
+                        .append("\n");
+            }
+            message.append("\nSplit packages are not allowed as they cause issues with the Java Module System.");
+            throw new GradleException(message.toString());
+        }
+    }
+
+    private Set<String> extractPackagesFromSources(FileTree sources) {
+        Set<String> packages = new HashSet<>();
+        for (File file : sources) {
+            if (file.getName().endsWith(".java") && !file.getName().equals("module-info.java")) {
+                String pkg = extractPackageFromFile(file);
+                if (pkg != null && !pkg.isEmpty()) {
+                    packages.add(pkg);
+                }
+            }
+        }
+        return packages;
+    }
+
+    private String extractPackageFromFile(File javaFile) {
+        try (Stream<String> lines = Files.lines(javaFile.toPath())) {
+            return lines
+                    .map(String::trim)
+                    .filter(line -> line.startsWith("package "))
+                    .findFirst()
+                    .map(line -> {
+                        // Extract package name: "package com.example;" -> "com.example"
+                        String pkg = line.substring("package ".length());
+                        int semicolon = pkg.indexOf(';');
+                        if (semicolon > 0) {
+                            pkg = pkg.substring(0, semicolon);
+                        }
+                        return pkg.trim();
+                    })
+                    .orElse(null);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read Java file: " + javaFile, e);
+        }
+    }
+
+    private void writeReport(Map<String, Set<String>> splitPackages) {
+        File reportFile = getReportFile().get().getAsFile();
+        try {
+            Files.createDirectories(reportFile.getParentFile().toPath());
+            StringBuilder report = new StringBuilder();
+            report.append("Split Package Check Report\n");
+            report.append("==========================\n\n");
+
+            if (splitPackages.isEmpty()) {
+                report.append("No split packages detected.\n");
+            } else {
+                report.append("Split packages found:\n\n");
+                for (Map.Entry<String, Set<String>> entry : splitPackages.entrySet()) {
+                    report.append("Package: ").append(entry.getKey()).append("\n");
+                    report.append("  Found in:\n");
+                    for (String module : entry.getValue()) {
+                        report.append("    - ").append(module).append("\n");
+                    }
+                    report.append("\n");
+                }
+            }
+
+            Files.writeString(reportFile.toPath(), report.toString());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write report file: " + reportFile, e);
+        }
+    }
+
+    /**
+     * Implementation of SourceSetEntry.
+     */
+    private static final class SourceSetEntryImpl implements SourceSetEntry {
+        private final String name;
+        private final FileTree sources;
+
+        SourceSetEntryImpl(String name, FileTree sources) {
+            this.name = name;
+            this.sources = sources;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public FileTree getSources() {
+            return sources;
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/dev.tamboui.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.java-library.gradle.kts
@@ -4,11 +4,71 @@ plugins {
     id("ru.vyarus.animalsniffer")
 }
 
+val isIDEASync = providers.systemProperty("idea.sync.active").isPresent
+
+/**
+ * Since we're using Java 8 as baseline, this creates a java11 source set
+ * for compiling the module-info.java descriptor.
+ * The compiled module-info.class is placed in META-INF/versions/11 to create
+ * a Multi-Release JAR that provides module information for Java 11+ while
+ * maintaining Java 8 compatibility for the main codebase.
+ */
+val java11 by sourceSets.creating {
+    java {
+        srcDir("src/main/java11")
+    }
+}
+
+tasks.named<JavaCompile>("compileJava11Java") {
+    options.release = 11
+    // Remove -Werror for module-info compilation as it may have different warnings
+    options.compilerArgs.remove("-Werror")
+
+    // Configure module path for module-info.java compilation
+    // The main classes and all dependencies need to be on the module path
+    modularity.inferModulePath = true
+    val moduleName = project.name.replace("tamboui-", "dev.tamboui.")
+    doFirst {
+        options.compilerArgs.addAll(
+            listOf(
+                "--module-path", classpath.asPath,
+                "--patch-module", "${moduleName}=${sourceSets.main.get().output.classesDirs.asPath}"
+            )
+        )
+        classpath = files()
+    }
+}
+
+tasks.named<Jar>("jar") {
+    into("META-INF/versions/11") {
+        from(java11.output)
+    }
+    manifest {
+        attributes("Multi-Release" to "true")
+    }
+}
+
+configurations.named("java11Implementation") {
+    extendsFrom(configurations.getByName("implementation"))
+    extendsFrom(configurations.getByName("api"))
+}
+
 dependencies {
     val libs = versionCatalogs.named("libs")
     testImplementation(platform(libs.findLibrary("junit.bom").orElseThrow()))
     testImplementation(libs.findBundle("testing").orElseThrow())
     signature(libs.findLibrary("sniffer18-signature").orElseThrow()) {
         artifact { type = "signature" }
+    }
+    // java11 source set needs access to main classes for module-info compilation
+    "java11Implementation"(sourceSets.main.get().output)
+}
+
+// This is not how the app will be built, but it allows IntelliJ to properly "see" the modules
+// and avoids false-positive errors in the IDE.
+if (isIDEASync) {
+    sourceSets.main.get().java.srcDir("src/main/java11")
+    tasks.withType<JavaCompile>().configureEach {
+        options.release = 11
     }
 }

--- a/buildSrc/src/main/kotlin/dev.tamboui.parent.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.parent.gradle.kts
@@ -1,0 +1,27 @@
+import dev.tamboui.build.SplitPackageCheckTask
+
+plugins {
+    base
+    id("dev.tamboui.maven-central-publishing")
+}
+
+val splitPackageCheck = tasks.register<SplitPackageCheckTask>("splitPackageCheck") {
+    description = "Checks for split packages across library modules"
+    group = "verification"
+
+    // Discover all modules by looking for top-level directories with build.gradle.kts
+    rootDir.listFiles()
+        ?.filter { it.isDirectory && file("${it.name}/build.gradle.kts").exists() }
+        ?.forEach { moduleDir ->
+            val sourceDir = file("${moduleDir.name}/src/main/java")
+            if (sourceDir.exists()) {
+                sourceSet(moduleDir.name, fileTree(sourceDir) { include("**/*.java") })
+            }
+        }
+
+    reportFile.set(layout.buildDirectory.file("reports/split-packages/report.txt"))
+}
+
+tasks.named("check") {
+    dependsOn(splitPackageCheck)
+}

--- a/demos/modular-demo/build.gradle.kts
+++ b/demos/modular-demo/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Demo showcasing the toolkit module using the Java module path"
+
+dependencies {
+    implementation(projects.tambouiToolkit)
+    runtimeOnly(projects.tambouiJline)
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.modular.ModularDemo")
+    mainModule.set("dev.tamboui.demo.modular")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    modularity.inferModulePath = true
+}

--- a/demos/modular-demo/src/main/java/dev/tamboui/demo/modular/ModularDemo.java
+++ b/demos/modular-demo/src/main/java/dev/tamboui/demo/modular/ModularDemo.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.modular;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.toolkit.app.ToolkitRunner;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.widgets.text.Overflow;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+/**
+ * A demo application that runs on the Java module path using JPMS.
+ * <p>
+ * This demo showcases that TamboUI works correctly when running
+ * as a modular application with explicit module dependencies.
+ */
+public class ModularDemo {
+
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    /**
+     * Entry point for the modular demo application.
+     *
+     * @param args command line arguments (not used)
+     * @throws Exception if an error occurs during execution
+     */
+    public static void main(String[] args) throws Exception {
+        var config = TuiConfig.builder()
+                .mouseCapture(true)
+                .tickRate(Duration.ofMillis(100))
+                .build();
+
+        try (var runner = ToolkitRunner.create(config)) {
+            runner.run(() -> column(
+                    panel(() -> row(
+                            text(" TamboUI Modular Demo ").bold().cyan(),
+                            spacer(),
+                            text(" Running on Java Module Path ").dim(),
+                            text(" [q] Quit ").dim()
+                    )).rounded().borderColor(Color.DARK_GRAY).length(3),
+
+                    row(
+                            panel(() -> column(
+                                    text("Module Information").bold().yellow(),
+                                    text(""),
+                                    text("This application runs using JPMS (Java Platform Module System).").overflow(Overflow.WRAP_WORD),
+                                    text(""),
+                                    text("Required modules:").cyan(),
+                                    text("  • dev.tamboui.demo.modular"),
+                                    text("  • dev.tamboui.toolkit"),
+                                    text("  • dev.tamboui.tui"),
+                                    text("  • dev.tamboui.widgets"),
+                                    text("  • dev.tamboui.css"),
+                                    text("  • dev.tamboui.core")
+                            )).title("Modules").rounded().borderColor(Color.BLUE).fill(),
+
+                            panel(() -> column(
+                                    text("Current Time").bold().green(),
+                                    text(""),
+                                    text(LocalTime.now().format(TIME_FORMAT)).bold(),
+                                    text(""),
+                                    text("The time updates on each render,"),
+                                    text("demonstrating reactive rendering.")
+                            )).title("Clock").rounded().borderColor(Color.GREEN)
+                    ).fill()
+            ));
+        }
+    }
+}

--- a/demos/modular-demo/src/main/java/module-info.java
+++ b/demos/modular-demo/src/main/java/module-info.java
@@ -1,0 +1,6 @@
+/**
+ * Demo module showcasing the TamboUI toolkit using the Java module path.
+ */
+module dev.tamboui.demo.modular {
+    requires dev.tamboui.toolkit;
+}

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
@@ -7,8 +7,8 @@ package dev.tamboui.terminal;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.widgets.StatefulWidget;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.StatefulWidget;
+import dev.tamboui.widget.Widget;
 
 import java.util.Optional;
 

--- a/tamboui-core/src/main/java/dev/tamboui/widget/StatefulWidget.java
+++ b/tamboui-core/src/main/java/dev/tamboui/widget/StatefulWidget.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 TamboUI Contributors
  * SPDX-License-Identifier: MIT
  */
-package dev.tamboui.widgets;
+package dev.tamboui.widget;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;

--- a/tamboui-core/src/main/java/dev/tamboui/widget/Widget.java
+++ b/tamboui-core/src/main/java/dev/tamboui/widget/Widget.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2025 TamboUI Contributors
  * SPDX-License-Identifier: MIT
  */
-package dev.tamboui.widgets;
+package dev.tamboui.widget;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;

--- a/tamboui-core/src/main/java11/module-info.java
+++ b/tamboui-core/src/main/java11/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * Core types and abstractions for TamboUI TUI library.
+ * <p>
+ * This module provides the fundamental building blocks for terminal user interfaces:
+ * buffers, cells, layouts, styles, text, and widget interfaces.
+ */
+module dev.tamboui.core {
+    exports dev.tamboui.buffer;
+    exports dev.tamboui.layout;
+    exports dev.tamboui.style;
+    exports dev.tamboui.symbols.merge;
+    exports dev.tamboui.terminal;
+    exports dev.tamboui.text;
+    exports dev.tamboui.util;
+    exports dev.tamboui.widget;
+
+    uses dev.tamboui.terminal.BackendProvider;
+}

--- a/tamboui-css/src/main/java11/module-info.java
+++ b/tamboui-css/src/main/java11/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * CSS styling support for TamboUI TUI library.
+ * <p>
+ * This module provides CSS-based styling capabilities for TamboUI widgets,
+ * including a CSS parser, selector matching, and style cascading.
+ */
+module dev.tamboui.css {
+    requires transitive dev.tamboui.core;
+    requires transitive dev.tamboui.widgets;
+
+    exports dev.tamboui.css;
+    exports dev.tamboui.css.cascade;
+    exports dev.tamboui.css.engine;
+    exports dev.tamboui.css.model;
+    exports dev.tamboui.css.parser;
+    exports dev.tamboui.css.property;
+    exports dev.tamboui.css.selector;
+}

--- a/tamboui-jline/src/main/java11/module-info.java
+++ b/tamboui-jline/src/main/java11/module-info.java
@@ -1,0 +1,18 @@
+import dev.tamboui.backend.jline.JLineBackendProvider;
+import dev.tamboui.terminal.BackendProvider;
+
+/**
+ * JLine 3 backend for TamboUI TUI library.
+ * <p>
+ * This module provides a terminal backend implementation using JLine 3,
+ * enabling TamboUI applications to run in standard terminals.
+ */
+@SuppressWarnings({"requires-transitive-automatic", "requires-automatic"})
+module dev.tamboui.jline {
+    requires transitive dev.tamboui.core;
+    requires transitive org.jline;
+
+    exports dev.tamboui.backend.jline;
+
+    provides BackendProvider with JLineBackendProvider;
+}

--- a/tamboui-picocli/src/main/java11/module-info.java
+++ b/tamboui-picocli/src/main/java11/module-info.java
@@ -1,0 +1,12 @@
+/**
+ * PicoCLI integration for TamboUI TUI applications.
+ * <p>
+ * This module provides integration between PicoCLI command-line parsing
+ * and TamboUI terminal user interfaces.
+ */
+module dev.tamboui.picocli {
+    requires transitive dev.tamboui.tui;
+    requires transitive info.picocli;
+
+    exports dev.tamboui.picocli;
+}

--- a/tamboui-toolkit/src/main/java11/module-info.java
+++ b/tamboui-toolkit/src/main/java11/module-info.java
@@ -1,0 +1,20 @@
+/**
+ * Fluent DSL for building TUI applications with TamboUI.
+ * <p>
+ * This module provides a declarative, retained-mode API for building
+ * terminal user interfaces with focus management and event routing.
+ */
+module dev.tamboui.toolkit {
+    requires transitive dev.tamboui.core;
+    requires transitive dev.tamboui.widgets;
+    requires transitive dev.tamboui.tui;
+    requires transitive dev.tamboui.css;
+
+    exports dev.tamboui.toolkit;
+    exports dev.tamboui.toolkit.app;
+    exports dev.tamboui.toolkit.component;
+    exports dev.tamboui.toolkit.element;
+    exports dev.tamboui.toolkit.elements;
+    exports dev.tamboui.toolkit.event;
+    exports dev.tamboui.toolkit.focus;
+}

--- a/tamboui-tui/src/main/java11/module-info.java
+++ b/tamboui-tui/src/main/java11/module-info.java
@@ -1,0 +1,13 @@
+/**
+ * High-level TUI application framework for TamboUI.
+ * <p>
+ * This module provides the TuiRunner and event handling infrastructure
+ * for building interactive terminal applications.
+ */
+module dev.tamboui.tui {
+    requires transitive dev.tamboui.core;
+    requires transitive dev.tamboui.widgets;
+
+    exports dev.tamboui.tui;
+    exports dev.tamboui.tui.event;
+}

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/Clear.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/Clear.java
@@ -8,6 +8,7 @@ import dev.tamboui.terminal.Terminal;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.layout.Rect;
+import dev.tamboui.widget.Widget;
 
 /**
  * A widget that clears/resets the area it is rendered to.

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/barchart/BarChart.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/barchart/BarChart.java
@@ -8,7 +8,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Direction;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 import static dev.tamboui.util.CollectionUtil.listCopyOf;
 

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/block/Block.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/block/Block.java
@@ -11,7 +11,7 @@ import dev.tamboui.style.Style;
 import dev.tamboui.symbols.merge.MergeStrategy;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.text.Overflow;
 
 import java.util.EnumSet;

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/calendar/Monthly.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/calendar/Monthly.java
@@ -7,7 +7,7 @@ package dev.tamboui.widgets.calendar;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 
 import java.time.DayOfWeek;

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/canvas/Canvas.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/canvas/Canvas.java
@@ -10,7 +10,7 @@ import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 
 import java.util.List;

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/chart/Chart.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/chart/Chart.java
@@ -9,7 +9,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 import static dev.tamboui.util.CollectionUtil.listCopyOf;
 

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/gauge/Gauge.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/gauge/Gauge.java
@@ -10,7 +10,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 
 /**

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/gauge/LineGauge.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/gauge/LineGauge.java
@@ -10,7 +10,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 
 /**
  * A progress indicator that renders as a horizontal line.

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
@@ -10,7 +10,7 @@ import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
-import dev.tamboui.widgets.StatefulWidget;
+import dev.tamboui.widget.StatefulWidget;
 import dev.tamboui.widgets.block.Block;
 
 /**

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextInput.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextInput.java
@@ -10,7 +10,7 @@ import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
-import dev.tamboui.widgets.StatefulWidget;
+import dev.tamboui.widget.StatefulWidget;
 import dev.tamboui.widgets.block.Block;
 
 /**

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/list/ListWidget.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/list/ListWidget.java
@@ -16,7 +16,7 @@ import dev.tamboui.style.Style;
 import dev.tamboui.style.Width;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.StatefulWidget;
+import dev.tamboui.widget.StatefulWidget;
 import dev.tamboui.widgets.block.Block;
 
 /**

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/logo/Logo.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/logo/Logo.java
@@ -8,7 +8,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Text;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 
 /**
  * A widget that renders the Tamboui logo.

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
@@ -15,7 +15,7 @@ import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.text.Overflow;
 

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/Scrollbar.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/Scrollbar.java
@@ -7,7 +7,7 @@ package dev.tamboui.widgets.scrollbar;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
-import dev.tamboui.widgets.StatefulWidget;
+import dev.tamboui.widget.StatefulWidget;
 
 import java.util.Objects;
 

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/sparkline/Sparkline.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/sparkline/Sparkline.java
@@ -7,7 +7,7 @@ package dev.tamboui.widgets.sparkline;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
-import dev.tamboui.widgets.Widget;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.block.Block;
 
 import java.util.Arrays;

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
@@ -12,7 +12,7 @@ import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Text;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.StatefulWidget;
+import dev.tamboui.widget.StatefulWidget;
 import dev.tamboui.widgets.block.Block;
 import static dev.tamboui.util.CollectionUtil.listCopyOf;
 

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/tabs/Tabs.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/tabs/Tabs.java
@@ -9,7 +9,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
-import dev.tamboui.widgets.StatefulWidget;
+import dev.tamboui.widget.StatefulWidget;
 import dev.tamboui.widgets.block.Block;
 import static dev.tamboui.util.CollectionUtil.listCopyOf;
 

--- a/tamboui-widgets/src/main/java11/module-info.java
+++ b/tamboui-widgets/src/main/java11/module-info.java
@@ -1,0 +1,26 @@
+/**
+ * Standard widgets for TamboUI TUI library.
+ * <p>
+ * This module provides a comprehensive set of widgets for building terminal user interfaces:
+ * blocks, paragraphs, lists, tables, charts, canvas, gauges, and more.
+ */
+module dev.tamboui.widgets {
+    requires transitive dev.tamboui.core;
+
+    exports dev.tamboui.widgets.barchart;
+    exports dev.tamboui.widgets.block;
+    exports dev.tamboui.widgets.calendar;
+    exports dev.tamboui.widgets.canvas;
+    exports dev.tamboui.widgets.canvas.shapes;
+    exports dev.tamboui.widgets.chart;
+    exports dev.tamboui.widgets.gauge;
+    exports dev.tamboui.widgets.input;
+    exports dev.tamboui.widgets.list;
+    exports dev.tamboui.widgets.logo;
+    exports dev.tamboui.widgets.paragraph;
+    exports dev.tamboui.widgets.scrollbar;
+    exports dev.tamboui.widgets.sparkline;
+    exports dev.tamboui.widgets.table;
+    exports dev.tamboui.widgets.tabs;
+    exports dev.tamboui.widgets.text;
+}


### PR DESCRIPTION
This configures the build so that all libraries are declared as proper Java modules. The modules are found in a Java 11 source set, because our baseline is Java 8. This makes the build setup more complicated because IntelliJ will not understand the model properly, but it works both in the IDE and command line, which is what we expect.

In the process, a task to verify that we don't create split packages has been added. It actually discovered one, so the `widgets` package in the core module has been renamed to `widget`.

A specific demo has been implemented showing the configuration.

Fixes #42