### PR TITLE
First iteration on documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,15 @@ TamboUI is a Java library for building modern terminal user interfaces, inspired
 
 | Module | Purpose |
 |--------|---------|
-| `tamboui-core` | Core types: Buffer, Cell, Rect, Style, Layout, Text, Widget/StatefulWidget interfaces |
+| `tamboui-core` | Core types: Buffer, Cell, Rect, Style, Layout, Text, Widget/StatefulWidget interfaces, InlineDisplay |
 | `tamboui-widgets` | All widget implementations (Block, Paragraph, List, Table, Chart, Canvas, etc.) |
 | `tamboui-jline` | JLine 3 terminal backend implementation |
-| `tamboui-tui` | High-level TUI framework: TuiRunner, event handling, Keys utility |
+| `tamboui-tui` | High-level TUI framework: TuiRunner, event handling, bindings, action handlers |
 | `tamboui-toolkit` | Fluent DSL for declarative UI with retained-mode elements, focus management, event routing |
-| `tamboui-css` | CSS-based styling support |
+| `tamboui-css` | CSS-based styling with TCSS format, selectors, cascade resolution, theme switching |
+| `tamboui-annotations` | Annotation definitions (`@OnAction`) for action handling |
+| `tamboui-processor` | Annotation processor for compile-time action handler generation (avoids reflection) |
+| `tamboui-image` | Image rendering with multiple protocols (Kitty, iTerm, Sixel, HalfBlock, Braille) |
 | `tamboui-picocli` | PicoCLI integration for CLI argument parsing |
 | `demos/*` | Demo applications showcasing features |
 
@@ -94,7 +97,9 @@ class MyApp extends ToolkitApp {
 
 - `TuiRunner` provides the main event loop with `EventHandler` callback
 - Event types: `KeyEvent`, `MouseEvent`, `TickEvent`, `ResizeEvent`
-- `Keys` utility provides pattern matching helpers (`isQuit`, `isUp`, `isDown`, etc.)
+- `KeyEvent` provides semantic methods (`isQuit()`, `isUp()`, `isDown()`, `isSelect()`, etc.) that respect configured bindings
+- Bindings map physical inputs to semantic actions; use `BindingSets.standard()`, `BindingSets.vim()`, or custom bindings
+- `@OnAction` annotation on Component methods handles actions; use annotation processor for compile-time generation
 - Toolkit elements handle events via `handleKeyEvent()`/`handleMouseEvent()` or handler lambdas
 
 ### Key Packages
@@ -104,8 +109,12 @@ class MyApp extends ToolkitApp {
 - `dev.tamboui.style` - Style, Color, Modifier
 - `dev.tamboui.text` - Text, Span, Line for styled text
 - `dev.tamboui.widgets.*` - Widget implementations (block, paragraph, list, table, chart, canvas, etc.)
-- `dev.tamboui.tui` - TuiRunner, TuiConfig, Keys, event types
+- `dev.tamboui.tui` - TuiRunner, TuiConfig, event types
+- `dev.tamboui.tui.bindings` - Bindings, BindingSets, KeyTrigger, MouseTrigger, ActionHandler, @OnAction
 - `dev.tamboui.toolkit` - Toolkit DSL factory methods, Element interface, element implementations
+- `dev.tamboui.css` - StyleEngine, CssParser, selectors, cascade resolution
+- `dev.tamboui.inline` - InlineDisplay for progress/status output
+- `dev.tamboui.image` - Image widget and protocol implementations
 
 ## Code Style Guidelines
 
@@ -117,9 +126,9 @@ class MyApp extends ToolkitApp {
 - You MUST add braces on all control statements
 - You MUST follow conventional field/method declarations (fields on top, methods below)
 - You MUST avoid code duplication
-- Add MUST add javadocs to all public APIs
+- You MUST add javadocs to all public APIs
 - You MUST use imports instead of fully qualified names in code
-- Do SHOULD NOT name a method `getXXX` if it's not a simple getter returning a private field: prefer `computeXXX`, `fetchXXX`, `toXXX`, etc.
+- You SHOULD NOT name a method `getXXX` if it's not a simple getter returning a private field: prefer `computeXXX`, `fetchXXX`, `toXXX`, etc.
 - You MUST NOT add comments in source which cannot be understood without context
 
 ## Testing Instructions
@@ -129,6 +138,14 @@ class MyApp extends ToolkitApp {
 - Run `./gradlew -q test` for quiet output
 - Do not consider the task complete until all tests pass without errors
 - Run `./gradlew -q build` to ensure the project builds successfully
+
+## Documentation
+
+- Any API changes MUST be reflected in the documentation under `docs/src/docs/asciidoc/`
+- Build docs with `./gradlew :docs:asciidoctor` - output goes to `docs/build/docs/`
+- Key documentation files: `api-levels.adoc`, `widgets.adoc`, `bindings.adoc`, `styling.adoc`, `core-concepts.adoc`
+- Update `index.adoc` module overview when adding new modules
+- Keep AGENTS.md in sync with module structure and key packages
 
 ## PR Guidelines
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.graalvm.native)
     implementation(libs.nexus.publishing.plugin)
     implementation(libs.animal.sniffer.plugin)
+    implementation(libs.asciidoctor.plugin)
 }
 
 java {

--- a/buildSrc/src/main/kotlin/dev.tamboui.docs.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.docs.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    id("org.asciidoctor.jvm.convert")
+}
+
+repositories {
+    mavenCentral()
+}
+
+tasks.asciidoctor {
+    setSourceDir(file("src/docs/asciidoc"))
+    setBaseDir(file("src/docs/asciidoc"))
+    setOutputDir(layout.buildDirectory.dir("docs"))
+
+    // Copy theme resources
+    resources {
+        from("src/theme") {
+            into("_static")
+        }
+    }
+
+    attributes(
+        mapOf(
+            "source-highlighter" to "highlight.js",
+            "highlightjsdir" to "_static/highlight",
+            "highlightjs-theme" to "github-dark",
+            "stylesheet" to "_static/tamboui.css",
+            "linkcss" to true,
+            "icons" to "font",
+            "toc" to "left",
+            "toclevels" to 3,
+            "sectanchors" to true,
+            "sectlinks" to true,
+            "idprefix" to "",
+            "idseparator" to "-",
+            "source-indent" to 0,
+            "tabsize" to 4,
+            // Docinfo for theme toggle and navigation
+            "docinfo" to "shared",
+            // Project info
+            "project-version" to project.version,
+            "project-name" to "TamboUI",
+            "github-repo" to "tamboui/tamboui"
+        )
+    )
+}

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("dev.tamboui.docs")
+}

--- a/docs/src/docs/asciidoc/_attributes.adoc
+++ b/docs/src/docs/asciidoc/_attributes.adoc
@@ -1,0 +1,25 @@
+// Shared attributes for TamboUI documentation
+:project-name: TamboUI
+:project-version: 1.0.0-SNAPSHOT
+:github-repo: tamboui/tamboui
+:github-url: https://github.com/{github-repo}
+
+// URLs
+:ratatui-url: https://github.com/ratatui/ratatui
+:bubbletea-url: https://github.com/charmbracelet/bubbletea
+:jline-url: https://github.com/jline/jline3
+
+// Module names
+:core-module: tamboui-core
+:widgets-module: tamboui-widgets
+:tui-module: tamboui-tui
+:toolkit-module: tamboui-toolkit
+:jline-module: tamboui-jline
+:picocli-module: tamboui-picocli
+:annotations-module: tamboui-annotations
+:processor-module: tamboui-processor
+:css-module: tamboui-css
+
+// Maven coordinates
+:maven-group: dev.tamboui
+:maven-repo: https://central.sonatype.com/repository/maven-snapshots/

--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -1,0 +1,694 @@
+= API Levels
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+{project-name} is organized as a layered library.
+At the bottom sits the immediate-mode API for direct terminal control.
+On top of that, TuiRunner adds a managed event loop.
+At the highest level, the Toolkit DSL provides a declarative, component-based approach.
+
+You can use any layer directly, or mix them as needed.
+
+[cols="1,2,1",options="header"]
+|===
+|API |Description |Use When
+
+|<<immediate-mode,Immediate Mode>>
+|Direct terminal control - you manage the event loop, drawing, and all state
+|Building custom backends, game engines, or learning how things work
+
+|<<tuirunner,TuiRunner>>
+|Managed event loop with callbacks for events and rendering
+|Custom event handling, animations, widget-based UIs without Toolkit
+
+|<<toolkit-dsl,Toolkit DSL>>
+|Declarative, component-based UI with fluent builders
+|Most applications - fastest path to a working UI
+
+|<<inline-display-mode,Inline Display>>
+|Fixed status area that preserves terminal scroll history
+|CLI tools, build progress, package managers
+|===
+
+== Immediate Mode
+
+Direct control over the terminal backend, the buffer, and the event loop.
+Nothing is hidden - you decide when to poll for events, when to draw, and how to structure your main loop.
+
+=== Terminal and Backend
+
+The `Terminal` wraps a `Backend` that handles the actual terminal I/O:
+
+[source,java]
+----
+import dev.tamboui.jline.JLineBackend;
+import dev.tamboui.terminal.Terminal;
+
+try (var backend = new JLineBackend()) {
+    var terminal = new Terminal<>(backend);
+    // ...
+}
+----
+
+Before you can draw anything useful, you need to set up the terminal:
+
+[source,java]
+----
+// Raw mode disables line buffering - keys are available immediately
+backend.enableRawMode();
+
+// Alternate screen preserves the user's terminal content
+backend.enterAlternateScreen();
+
+// Hide the cursor for a cleaner look
+backend.hideCursor();
+
+// Mouse support is optional
+backend.enableMouseCapture();
+----
+
+The try-with-resources pattern ensures cleanup happens automatically.
+If you're not using it, remember to restore the terminal state before exiting.
+
+=== Drawing
+
+All rendering goes through `terminal.draw()`:
+
+[source,java]
+----
+terminal.draw(frame -> {
+    Rect area = frame.area();  // Full terminal size
+
+    var paragraph = Paragraph.builder()
+        .text(Text.from("Hello, TamboUI!"))
+        .style(Style.EMPTY.bold().fg(Color.CYAN))
+        .build();
+
+    frame.renderWidget(paragraph, area);
+});
+----
+
+The `Frame` gives you:
+
+- `area()` - the full renderable region
+- `buffer()` - direct access to the cell grid
+- `renderWidget()` / `renderStatefulWidget()` - render widgets to specific areas
+
+For pixel-level control, work with the buffer directly:
+
+[source,java]
+----
+terminal.draw(frame -> {
+    Buffer buffer = frame.buffer();
+    buffer.setCell(0, 0, Cell.of('X', Style.EMPTY.bold()));
+
+    Cell cell = buffer.cell(5, 5);
+    // ...
+});
+----
+
+=== Event Loop
+
+You own the event loop entirely:
+
+[source,java]
+----
+boolean running = true;
+
+while (running) {
+    Event event = backend.pollEvent(Duration.ofMillis(100));
+
+    if (event instanceof KeyEvent key) {
+        if (key.code() == KeyCode.CHAR && key.character() == 'q') {
+            running = false;
+        }
+    } else if (event instanceof ResizeEvent) {
+        // Terminal resized - might want to redraw
+    }
+
+    terminal.draw(frame -> renderUI(frame));
+}
+----
+
+=== Putting It Together
+
+[source,java]
+----
+public class ImmediateModeExample {
+    public static void main(String[] args) throws Exception {
+        try (var backend = new JLineBackend()) {
+            backend.enableRawMode();
+            backend.enterAlternateScreen();
+            backend.hideCursor();
+
+            var terminal = new Terminal<>(backend);
+            boolean running = true;
+
+            while (running) {
+                Event event = backend.pollEvent(Duration.ofMillis(100));
+                if (event instanceof KeyEvent key) {
+                    if (key.code() == KeyCode.CHAR && key.character() == 'q') {
+                        running = false;
+                    }
+                }
+
+                terminal.draw(frame -> {
+                    var widget = Paragraph.builder()
+                        .text(Text.from("Press 'q' to quit"))
+                        .style(Style.EMPTY.fg(Color.CYAN))
+                        .build();
+                    frame.renderWidget(widget, frame.area());
+                });
+            }
+        }
+    }
+}
+----
+
+This is verbose, but you have complete control.
+For most applications, you'll want one of the higher-level APIs.
+
+== TuiRunner
+
+TuiRunner takes over terminal setup and the event loop.
+You provide two callbacks: one for handling events, one for rendering.
+
+[source,java]
+----
+try (var tui = TuiRunner.create()) {
+    tui.run(
+        (event, runner) -> {
+            if (event instanceof KeyEvent key && key.isQuit()) {
+                runner.quit();
+                return false;
+            }
+            return handleEvent(event);
+        },
+        frame -> renderUI(frame)
+    );
+}
+----
+
+The event handler returns `true` to request a redraw, `false` otherwise.
+This avoids unnecessary redraws when nothing changed.
+
+=== Configuration
+
+[source,java]
+----
+var config = TuiConfig.builder()
+    .mouseCapture(true)
+    .tickRate(Duration.ofMillis(16))  // ~60fps for animations
+    .pollTimeout(Duration.ofMillis(50))
+    .build();
+
+try (var tui = TuiRunner.create(config)) {
+    tui.run(handler, renderer);
+}
+----
+
+Tick events fire at the configured rate - useful for animations, clocks, or any periodic updates.
+
+=== Semantic Key Checks
+
+`KeyEvent` provides semantic methods that respect the configured bindings:
+
+[source,java]
+----
+if (key.isQuit()) { }      // q, Q, Ctrl+C
+if (key.isUp()) { }        // Up arrow, k, Ctrl+P (with vim bindings)
+if (key.isDown()) { }      // Down arrow, j, Ctrl+N
+if (key.isSelect()) { }    // Enter, Space
+if (key.isCancel()) { }    // Escape
+if (key.isPageUp()) { }    // PageUp, Ctrl+B
+if (key.isPageDown()) { }  // PageDown, Ctrl+F
+----
+
+These delegate to the link:bindings.html[bindings system] - with vim bindings, `isUp()` matches `k`, with standard bindings it only matches the Up arrow.
+
+=== Event Handling Patterns
+
+Pattern matching works well with the event types:
+
+[source,java]
+----
+(event, runner) -> {
+    return switch (event) {
+        case KeyEvent k -> handleKey(k);
+        case MouseEvent m -> handleMouse(m);
+        case TickEvent t -> { animationFrame++; yield true; }
+        case ResizeEvent r -> true;  // Always redraw on resize
+        default -> false;
+    };
+}
+----
+
+=== Layout in the Renderer
+
+The renderer callback receives a `Frame`, just like immediate mode.
+Combine it with the layout system:
+
+[source,java]
+----
+frame -> {
+    var areas = Layout.builder()
+        .direction(Direction.VERTICAL)
+        .constraints(
+            Constraint.length(3),
+            Constraint.fill(),
+            Constraint.length(1)
+        )
+        .build()
+        .split(frame.area());
+
+    frame.renderWidget(header, areas.get(0));
+    frame.renderWidget(content, areas.get(1));
+    frame.renderWidget(statusBar, areas.get(2));
+}
+----
+
+=== Example: Counter with Animation
+
+[source,java]
+----
+public class CounterDemo {
+    private int counter = 0;
+    private int ticks = 0;
+
+    public void run() throws Exception {
+        var config = TuiConfig.builder()
+            .tickRate(Duration.ofMillis(100))
+            .build();
+
+        try (var tui = TuiRunner.create(config)) {
+            tui.run(this::handleEvent, this::render);
+        }
+    }
+
+    private boolean handleEvent(Event event, TuiRunner.Runner runner) {
+        if (event instanceof KeyEvent key && key.isQuit()) {
+            runner.quit();
+            return false;
+        }
+        if (event instanceof TickEvent) {
+            ticks++;
+            return true;
+        }
+        if (event instanceof KeyEvent key) {
+            if (key.isChar('+')) { counter++; return true; }
+            if (key.isChar('-')) { counter--; return true; }
+        }
+        return false;
+    }
+
+    private void render(Frame frame) {
+        var text = String.format("Counter: %d (ticks: %d)%n%nPress +/- to change, q to quit",
+            counter, ticks);
+
+        var widget = Paragraph.builder()
+            .text(Text.from(text))
+            .block(Block.builder()
+                .title(Text.from("Demo"))
+                .borders(Borders.ALL)
+                .borderType(BorderType.ROUNDED)
+                .build())
+            .build();
+
+        frame.renderWidget(widget, frame.area());
+    }
+}
+----
+
+TuiRunner hits a sweet spot: less boilerplate than immediate mode, but you still control the event handling and rendering logic.
+
+== Toolkit DSL
+
+The Toolkit DSL flips the model.
+Instead of writing render callbacks, you describe your UI declaratively and let the framework handle the rest.
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.*;
+import dev.tamboui.toolkit.app.ToolkitApp;
+
+public class MyApp extends ToolkitApp {
+
+    @Override
+    protected Element render() {
+        return panel("My App",
+            text("Hello!").bold().cyan(),
+            spacer(),
+            text("Press 'q' to quit").dim()
+        ).rounded();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new MyApp().run();
+    }
+}
+----
+
+The static import `dev.tamboui.toolkit.Toolkit.*` gives you all the element factories: `text()`, `panel()`, `row()`, `column()`, `list()`, `table()`, and more.
+
+=== Layout
+
+Rows and columns work as you'd expect:
+
+[source,java]
+----
+row(
+    panel("Left").fill(),
+    panel("Right").fill()
+)
+
+column(
+    text("Header"),
+    content().fill(),
+    text("Footer")
+)
+----
+
+Use `spacer()` to push things apart:
+
+[source,java]
+----
+row(
+    text("Left"),
+    spacer(),
+    text("Right")
+)
+----
+
+=== Styling
+
+Style methods chain naturally:
+
+[source,java]
+----
+text("Styled").bold().italic().cyan().onBlue()
+----
+
+Panels support border styling:
+
+[source,java]
+----
+panel("Title", content)
+    .rounded()
+    .borderColor(Color.CYAN)
+    .focusedBorderColor(Color.YELLOW)
+----
+
+=== Sizing
+
+Control how elements fill space:
+
+[source,java]
+----
+panel("Fixed width").length(30)
+panel("Half the space").percentage(50)
+panel("Take what's left").fill()
+panel("Twice the weight").fill(2)
+panel("One third").ratio(1, 3)
+panel("At least 10").min(10)
+panel("At most 50").max(50)
+----
+
+=== Stateful Widgets
+
+Lists, tables, and inputs need state objects:
+
+[source,java]
+----
+private ListState listState = new ListState();
+private TableState tableState = new TableState();
+private TextInputState inputState = new TextInputState();
+
+// In render():
+list("Apple", "Banana", "Cherry")
+    .state(listState)
+    .highlightColor(Color.CYAN)
+
+table()
+    .header("Name", "Age")
+    .row("Alice", "30")
+    .row("Bob", "25")
+    .state(tableState)
+
+textInput(inputState)
+    .placeholder("Type here...")
+----
+
+=== Event Handling
+
+Attach handlers to elements:
+
+[source,java]
+----
+panel("Interactive")
+    .id("main")
+    .focusable()
+    .onKeyEvent(event -> {
+        if (event.isChar('a')) {
+            addItem();
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    })
+----
+
+Return `EventResult.HANDLED` to stop propagation, `UNHANDLED` to let it bubble up.
+
+=== Focus
+
+For Tab/Shift+Tab navigation, elements need both an ID and the focusable flag:
+
+[source,java]
+----
+column(
+    panel("First").id("first").focusable(),
+    panel("Second").id("second").focusable()
+)
+----
+
+The `focusedBorderColor()` method lets you provide visual feedback.
+
+=== Data Visualization
+
+[source,java]
+----
+gauge(0.75).label("Progress").gaugeColor(Color.GREEN)
+
+sparkline(1, 4, 2, 8, 5, 7).color(Color.CYAN)
+
+barChart(10, 20, 30)
+    .labels("A", "B", "C")
+    .barColor(Color.BLUE)
+----
+
+=== Using ToolkitRunner Directly
+
+`ToolkitApp` is convenient, but `ToolkitRunner` gives more control:
+
+[source,java]
+----
+var config = TuiConfig.builder()
+    .mouseCapture(true)
+    .tickRate(Duration.ofMillis(50))
+    .build();
+
+try (var runner = ToolkitRunner.create(config)) {
+    runner.run(() -> panel("App", content()));
+}
+----
+
+=== Example: Todo List
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.*;
+
+public class TodoApp extends ToolkitApp {
+    private final List<String> items = new ArrayList<>(List.of(
+        "Learn TamboUI",
+        "Build something cool"
+    ));
+    private final ListState listState = new ListState();
+
+    @Override
+    protected Element render() {
+        return panel("Todo",
+            items.isEmpty()
+                ? text("Empty - press 'a' to add").dim()
+                : list(items.toArray(new String[0]))
+                    .state(listState)
+                    .highlightColor(Color.CYAN),
+            spacer(),
+            text("[a]dd [d]elete [q]uit").dim()
+        )
+        .rounded()
+        .id("main")
+        .focusable()
+        .onKeyEvent(this::handleKey);
+    }
+
+    private EventResult handleKey(KeyEvent event) {
+        if (event.isChar('a')) {
+            items.add("New item");
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('d') && !items.isEmpty()) {
+            items.remove(listState.selected());
+            return EventResult.HANDLED;
+        }
+        if (event.isDown()) {
+            listState.selectNext(items.size());
+            return EventResult.HANDLED;
+        }
+        if (event.isUp()) {
+            listState.selectPrevious();
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    }
+
+    public static void main(String[] args) throws Exception {
+        new TodoApp().run();
+    }
+}
+----
+
+== Inline Display Mode
+
+The APIs above all use the alternate screen buffer - your application takes over the entire terminal, and the previous content is restored when it exits.
+
+For CLI tools that need to show progress while preserving scroll history, use `InlineDisplay` instead.
+This is the pattern used by Gradle, npm, and other build tools: a fixed status area at the bottom while log output scrolls above.
+
+=== When to Use Inline Mode
+
+* Build tools showing compilation progress
+* Package managers displaying download status
+* Long-running scripts with progress indicators
+* Any tool where you want output history preserved
+
+=== Basic Usage
+
+[source,java]
+----
+try (var display = InlineDisplay.create(3)) {  // Reserve 3 lines
+    for (int i = 0; i <= 100; i += 10) {
+        display.render((area, buffer) -> {
+            var gauge = Gauge.builder()
+                .ratio(i / 100.0)
+                .label("Processing: " + i + "%")
+                .build();
+            gauge.render(area, buffer);
+        });
+        Thread.sleep(100);
+    }
+}
+----
+
+The display reserves lines at the current cursor position.
+When closed, it moves the cursor below and optionally clears the status area.
+
+=== Logging Above the Status Area
+
+Use `println()` to add output that scrolls above the fixed status:
+
+[source,java]
+----
+try (var display = InlineDisplay.create(4)) {
+    for (var task : tasks) {
+        // Update status area
+        display.render((area, buffer) -> {
+            renderProgress(area, buffer, task, progress);
+        });
+
+        processTask(task);
+
+        // Log completion - scrolls above, status stays fixed
+        display.println(Text.from(Line.from(
+            Span.styled("✓ ", Style.EMPTY.fg(Color.GREEN)),
+            Span.raw(task.name())
+        )));
+    }
+}
+----
+
+=== Configuration Options
+
+[source,java]
+----
+// Fixed height (width matches terminal)
+var display = InlineDisplay.create(4);
+
+// Fixed height and width
+var display = InlineDisplay.create(4, 80);
+
+// Clear the status area when done
+var display = InlineDisplay.create(4).clearOnClose();
+----
+
+=== Setting Lines Directly
+
+For simple status updates, set lines without a full render:
+
+[source,java]
+----
+display.setLine(0, "Building module: core");
+display.setLine(1, "Progress: 45%");
+display.setLine(2, Text.from(Span.styled("No errors", Style.EMPTY.fg(Color.GREEN))));
+----
+
+=== Inline vs Alternate Screen
+
+[cols="1,2,2",options="header"]
+|===
+|Feature |InlineDisplay |TuiRunner / Toolkit
+
+|Screen buffer
+|Main buffer (preserved)
+|Alternate buffer (replaced)
+
+|Cursor
+|Visible
+|Hidden
+
+|Terminal capture
+|Partial (reserved lines)
+|Full terminal
+
+|Previous content
+|Preserved above
+|Restored on exit
+
+|Best for
+|Progress, logs, status
+|Interactive full-screen apps
+|===
+
+== Choosing a Level
+
+**Start with the Toolkit DSL** for most applications.
+It handles focus, provides a clean declarative API, and gets you productive quickly.
+
+**Drop to TuiRunner** when you need custom event handling, animations, or want to use the widget layer directly without the Toolkit abstractions.
+
+**Use Immediate Mode** when you're building something unusual - a custom backend, a game engine, or when you want to understand exactly what's happening under the hood.
+
+The levels compose well.
+You can use Toolkit elements inside a TuiRunner application, or drop down to direct buffer manipulation when needed.
+
+== Next Steps
+
+* link:styling.html[CSS Styling] - external stylesheets and theming
+* link:bindings.html[Bindings and Actions] - key bindings and action handling
+* link:mvc-architecture.html[Application Structure] - patterns for larger applications
+* link:widgets.html[Widgets Reference] - all available widgets
+* link:developer-guide.html[Developer Guide] - building custom widgets

--- a/docs/src/docs/asciidoc/bindings.adoc
+++ b/docs/src/docs/asciidoc/bindings.adoc
@@ -1,0 +1,260 @@
+= Bindings and Actions
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+{project-name} separates physical input (keys, mouse clicks) from semantic actions.
+Instead of checking for specific keys everywhere, you define bindings that map inputs to actions like "moveUp" or "delete".
+
+== Predefined Binding Sets
+
+Several binding presets are available:
+
+[source,java]
+----
+Bindings standard = BindingSets.standard();  // Arrow keys, Enter, Escape
+Bindings vim = BindingSets.vim();            // hjkl navigation, Ctrl+u/d
+Bindings emacs = BindingSets.emacs();        // Ctrl+n/p/f/b navigation
+----
+
+== Matching Actions in Events
+
+Events carry binding information. Use semantic checks instead of hardcoding keys:
+
+[source,java]
+----
+// Semantic - works with any binding set
+if (event.isUp()) { }
+if (event.isSelect()) { }
+if (event.matches("delete")) { }
+
+// Low-level - when you need specific keys
+if (event.isChar('x')) { }
+if (event.isKey(KeyCode.F1)) { }
+----
+
+The `is*()` methods delegate to the current bindings.
+With vim bindings, `isUp()` matches Up arrow, `k`, or `Ctrl+p`.
+With standard bindings, it only matches the Up arrow.
+
+== Key Triggers
+
+`KeyTrigger` defines what input triggers an action:
+
+[source,java]
+----
+KeyTrigger.key(KeyCode.UP)           // Arrow key
+KeyTrigger.ch('j')                   // Character
+KeyTrigger.chIgnoreCase('j')         // j or J
+KeyTrigger.ctrl('u')                 // Ctrl+U
+KeyTrigger.alt('x')                  // Alt+X
+----
+
+== Mouse Triggers
+
+[source,java]
+----
+MouseTrigger.click()                 // Left click
+MouseTrigger.rightClick()            // Right click
+MouseTrigger.ctrlClick()             // Ctrl+click
+MouseTrigger.scrollUp()              // Scroll wheel
+MouseTrigger.drag(MouseButton.LEFT)  // Dragging
+----
+
+== Custom Bindings
+
+Start from a preset and customize:
+
+[source,java]
+----
+Bindings custom = BindingSets.standard()
+    .toBuilder()
+    .bind("delete", KeyTrigger.ch('d'), KeyTrigger.key(KeyCode.DELETE))
+    .bind("save", KeyTrigger.ctrl('s'))
+    .bind("contextMenu", MouseTrigger.rightClick())
+    .build();
+----
+
+== ActionHandler
+
+For centralized action handling, use `ActionHandler`:
+
+[source,java]
+----
+ActionHandler actions = new ActionHandler(BindingSets.vim())
+    .on(Actions.QUIT, e -> runner.quit())
+    .on("save", e -> save())
+    .on("delete", e -> deleteSelected());
+
+// In your event handler:
+(event, runner) -> {
+    if (actions.dispatch(event)) {
+        return true;  // Action was handled
+    }
+    // Handle other events...
+    return false;
+}
+----
+
+== @OnAction Annotation
+
+In Toolkit components, annotate methods to handle actions:
+
+[source,java]
+----
+public class EditorComponent extends Component<EditorComponent> {
+    private List<String> lines = new ArrayList<>();
+    private int cursor = 0;
+
+    @OnAction(Actions.MOVE_UP)
+    void moveCursorUp(Event event) {
+        if (cursor > 0) cursor--;
+    }
+
+    @OnAction(Actions.MOVE_DOWN)
+    void moveCursorDown(Event event) {
+        if (cursor < lines.size() - 1) cursor++;
+    }
+
+    @OnAction("delete")
+    void deleteLine(Event event) {
+        if (!lines.isEmpty()) {
+            lines.remove(cursor);
+        }
+    }
+}
+----
+
+The component framework discovers these methods and dispatches events automatically.
+
+=== Annotation Processing
+
+By default, `@OnAction` methods are discovered at runtime using reflection.
+For better startup performance and GraalVM native image compatibility, use the annotation processor to generate action handler registrations at compile time.
+
+==== Gradle (Kotlin DSL)
+
+[source,kotlin,subs="+attributes"]
+----
+dependencies {
+    implementation("{maven-group}:{toolkit-module}:{project-version}")
+    annotationProcessor("{maven-group}:{processor-module}:{project-version}")
+}
+----
+
+==== Gradle (Groovy DSL)
+
+[source,groovy,subs="+attributes"]
+----
+dependencies {
+    implementation '{maven-group}:{toolkit-module}:{project-version}'
+    annotationProcessor '{maven-group}:{processor-module}:{project-version}'
+}
+----
+
+==== Maven
+
+[source,xml,subs="+attributes"]
+----
+<dependencies>
+    <dependency>
+        <groupId>{maven-group}</groupId>
+        <artifactId>{toolkit-module}</artifactId>
+        <version>{project-version}</version>
+    </dependency>
+</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.13.0</version>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>{maven-group}</groupId>
+                        <artifactId>{processor-module}</artifactId>
+                        <version>{project-version}</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+----
+
+The processor generates a `_ActionHandlerRegistrar` class for each component with `@OnAction` methods.
+These registrars are discovered via `ServiceLoader` and register action handlers without reflection.
+
+== Loading Bindings from Files
+
+Bindings can be externalized to properties files:
+
+[source,java]
+----
+// From classpath
+Bindings bindings = BindingSets.loadResource("/my-bindings.properties");
+
+// From filesystem
+Bindings bindings = BindingSets.load(Paths.get("~/.config/myapp/bindings.properties"));
+----
+
+Property file format:
+
+[source,properties]
+----
+# Navigation
+moveUp = Up, k
+moveDown = Down, j
+pageUp = PageUp, Ctrl+u
+pageDown = PageDown, Ctrl+d
+
+# Actions
+select = Enter, Space
+cancel = Escape
+delete = d, Delete
+
+# Mouse
+click = Mouse.Left.Press
+contextMenu = Mouse.Right.Press
+----
+
+Multiple triggers for the same action are comma-separated.
+Modifiers use `Ctrl+`, `Alt+`, `Shift+` prefixes.
+
+== Standard Actions
+
+The `Actions` class defines common action names:
+
+[cols="1,2",options="header"]
+|===
+|Action |Description
+
+|`MOVE_UP`, `MOVE_DOWN`, `MOVE_LEFT`, `MOVE_RIGHT`
+|Navigation
+
+|`PAGE_UP`, `PAGE_DOWN`, `HOME`, `END`
+|Page navigation
+
+|`SELECT`, `CONFIRM`, `CANCEL`
+|Selection and confirmation
+
+|`FOCUS_NEXT`, `FOCUS_PREVIOUS`
+|Focus navigation (Tab/Shift+Tab)
+
+|`DELETE_BACKWARD`, `DELETE_FORWARD`
+|Text editing
+
+|`QUIT`
+|Application exit
+|===
+
+== Next Steps
+
+* link:api-levels.html[API Levels] - choosing between immediate mode, TuiRunner, and Toolkit
+* link:mvc-architecture.html[Application Structure] - patterns for larger applications

--- a/docs/src/docs/asciidoc/core-concepts.adoc
+++ b/docs/src/docs/asciidoc/core-concepts.adoc
@@ -1,0 +1,393 @@
+= Core Concepts
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+{project-name}'s architecture follows https://ratatui.rs[ratatui] closely.
+If you've used ratatui before, the concepts here will be familiar - `Buffer`, `Cell`, `Frame`, `Widget`, `Layout` all work the same way.
+
+== Rendering Model
+
+{project-name} uses *immediate-mode rendering* with an *intermediate buffer system*:
+
+1. **Widgets render to a Buffer** - not directly to the terminal
+2. **Buffer is diffed** - only changed cells are sent to the terminal
+3. **Each frame is a full redraw** - simple state management, no retained state in widgets
+
+[source]
+----
+Application State
+       │
+       ▼
+┌─────────────┐      ┌─────────────┐      ┌─────────────┐
+│   Widgets   │ ───▶ │   Buffer    │ ───▶ │  Terminal   │
+│   render()  │      │  (diff)     │      │  (output)   │
+└─────────────┘      └─────────────┘      └─────────────┘
+----
+
+This model makes {project-name} applications easy to reason about: the UI is always a pure function of your application state.
+
+== Buffer System
+
+=== Buffer
+
+A `Buffer` is a 2D grid of `Cell` objects representing the terminal screen:
+
+[source,java]
+----
+// A Buffer is created for each frame
+Buffer buffer = new Buffer(width, height);
+
+// Set a cell at position (x, y)
+buffer.setCell(x, y, Cell.of('A', Style.EMPTY.fg(Color.RED)));
+
+// Get a cell
+Cell cell = buffer.cell(x, y);
+----
+
+=== Cell
+
+A `Cell` represents a single character with styling:
+
+[source,java]
+----
+// Create a cell with character and style
+Cell cell = Cell.of('X', Style.EMPTY.bold().fg(Color.CYAN));
+
+// Get properties
+char symbol = cell.symbol();
+Style style = cell.style();
+----
+
+=== Frame
+
+A `Frame` wraps a buffer and provides rendering helpers:
+
+[source,java]
+----
+terminal.draw(frame -> {
+    // Get the renderable area
+    Rect area = frame.area();
+
+    // Render a widget to the frame
+    frame.renderWidget(myWidget, area);
+
+    // Or render to a sub-area
+    Rect subArea = new Rect(0, 0, 40, 10);
+    frame.renderWidget(headerWidget, subArea);
+});
+----
+
+== Layout System
+
+=== Rect
+
+A `Rect` defines a rectangular region with position and size:
+
+[source,java]
+----
+// Create a rectangle
+Rect rect = new Rect(x, y, width, height);
+
+// Properties
+int x = rect.x();
+int y = rect.y();
+int width = rect.width();
+int height = rect.height();
+
+// Derived values
+int right = rect.right();    // x + width
+int bottom = rect.bottom();  // y + height
+Position center = rect.center();
+----
+
+=== Constraints
+
+Constraints define how space is allocated in layouts:
+
+[cols="1,2,2",options="header"]
+|===
+|Constraint |Description |Example
+
+|`Length(n)`
+|Fixed size of n cells
+|`Constraint.length(20)`
+
+|`Percentage(n)`
+|n% of available space
+|`Constraint.percentage(50)`
+
+|`Ratio(num, denom)`
+|Fractional size
+|`Constraint.ratio(1, 3)`
+
+|`Min(n)`
+|At least n cells
+|`Constraint.min(10)`
+
+|`Max(n)`
+|At most n cells
+|`Constraint.max(50)`
+
+|`Fill(weight)`
+|Fill remaining space with weight
+|`Constraint.fill()` or `Constraint.fill(2)`
+|===
+
+=== Layout
+
+A `Layout` splits an area according to constraints:
+
+[source,java]
+----
+// Split vertically into header (3 lines) and content (rest)
+List<Rect> areas = Layout.builder()
+    .direction(Direction.VERTICAL)
+    .constraints(
+        Constraint.length(3),
+        Constraint.fill()
+    )
+    .build()
+    .split(frame.area());
+
+Rect headerArea = areas.get(0);
+Rect contentArea = areas.get(1);
+
+// Split horizontally with percentages
+List<Rect> columns = Layout.builder()
+    .direction(Direction.HORIZONTAL)
+    .constraints(
+        Constraint.percentage(30),
+        Constraint.percentage(70)
+    )
+    .build()
+    .split(contentArea);
+----
+
+=== Direction
+
+Layouts can split in two directions:
+
+* `Direction.VERTICAL` - stack elements top to bottom
+* `Direction.HORIZONTAL` - place elements left to right
+
+=== Margin
+
+Add spacing around layouts:
+
+[source,java]
+----
+Layout.builder()
+    .margin(new Margin(1, 2, 1, 2))  // top, right, bottom, left
+    .constraints(...)
+    .build()
+----
+
+== Styling
+
+=== Style
+
+`Style` is an immutable object that defines text appearance:
+
+[source,java]
+----
+// Create a style
+Style style = Style.EMPTY
+    .fg(Color.CYAN)
+    .bg(Color.BLACK)
+    .bold()
+    .underlined();
+
+// Styles are immutable - methods return new instances
+Style dimStyle = style.dim();
+----
+
+=== Color
+
+Colors can be specified in multiple ways:
+
+[source,java]
+----
+// Named ANSI colors
+Color.RED
+Color.GREEN
+Color.CYAN
+Color.WHITE
+Color.GRAY
+
+// Indexed colors (0-255)
+Color.indexed(196)
+
+// RGB colors (true color)
+Color.rgb(255, 128, 0)
+----
+
+=== Modifiers
+
+Text modifiers change how text is displayed:
+
+[source,java]
+----
+Style.EMPTY
+    .bold()       // Bold text
+    .dim()        // Dimmed/faint
+    .italic()     // Italic (terminal support varies)
+    .underlined() // Underlined
+    .slowBlink()  // Slow blinking
+    .rapidBlink() // Rapid blinking
+    .reversed()   // Swap fg/bg colors
+    .hidden()     // Hidden text
+    .crossedOut() // Strikethrough
+----
+
+== Text System
+
+=== Text
+
+`Text` represents multi-line styled text:
+
+[source,java]
+----
+// Simple text
+Text text = Text.from("Hello, World!");
+
+// Multi-line text
+Text multiLine = Text.of(
+    Line.from("First line"),
+    Line.from("Second line")
+);
+
+// With alignment
+Text centered = Text.from("Centered").centered();
+----
+
+=== Line
+
+A `Line` is a single line composed of `Span` objects:
+
+[source,java]
+----
+Line line = Line.from(
+    Span.styled("Bold", Style.EMPTY.bold()),
+    Span.raw(" and "),
+    Span.styled("Red", Style.EMPTY.fg(Color.RED))
+);
+----
+
+=== Span
+
+A `Span` is a styled piece of text:
+
+[source,java]
+----
+// Unstyled span
+Span plain = Span.raw("plain text");
+
+// Styled span
+Span styled = Span.styled("styled", Style.EMPTY.cyan().bold());
+----
+
+== Widget Interfaces
+
+=== Widget (Stateless)
+
+Stateless widgets implement the `Widget` interface:
+
+[source,java]
+----
+public interface Widget {
+    void render(Rect area, Buffer buffer);
+}
+----
+
+Examples: `Paragraph`, `Gauge`, `Block`, `Clear`
+
+=== StatefulWidget (Stateful)
+
+Stateful widgets carry external state:
+
+[source,java]
+----
+public interface StatefulWidget<S> {
+    void render(Rect area, Buffer buffer, S state);
+}
+----
+
+The state object tracks selection, scroll position, etc:
+
+[source,java]
+----
+// Create state
+ListState listState = new ListState();
+
+// Render with state
+listWidget.render(area, buffer, listState);
+
+// Modify state based on user input
+listState.selectNext(items.size());
+----
+
+Examples: `ListWidget`, `Table`, `Tabs`, `TextInput`
+
+== Event System
+
+{project-name} supports keyboard, mouse, and tick events:
+
+=== KeyEvent
+
+[source,java]
+----
+// Check specific keys
+if (event.code() == KeyCode.ENTER) { ... }
+if (event.code() == KeyCode.CHAR && event.character() == 'q') { ... }
+
+// Check modifiers
+if (event.modifiers().contains(KeyModifiers.CTRL)) { ... }
+
+// Using Keys utility
+if (event.isQuit()) { ... }
+if (event.isUp()) { ... }
+----
+
+=== MouseEvent
+
+[source,java]
+----
+int x = event.x();
+int y = event.y();
+MouseEventKind kind = event.kind();
+
+if (kind == MouseEventKind.DOWN && event.button() == MouseButton.LEFT) {
+    handleClick(x, y);
+}
+----
+
+=== TickEvent
+
+Tick events fire periodically for animations:
+
+[source,java]
+----
+// Configure tick rate
+TuiConfig config = TuiConfig.builder()
+    .tickRate(Duration.ofMillis(16))  // ~60fps
+    .build();
+
+// Handle tick
+if (event instanceof TickEvent) {
+    updateAnimation();
+    return true;  // redraw
+}
+----
+
+== Next Steps
+
+* Explore the link:widgets.html[Widgets Reference] for available components
+* Learn about link:api-levels.html[API Levels] in detail
+* Use link:styling.html[CSS Styling] for external style definitions
+* Understand link:bindings.html[Bindings and Actions] for input handling
+* Build maintainable apps with link:mvc-architecture.html[Application Structure]

--- a/docs/src/docs/asciidoc/developer-guide.adoc
+++ b/docs/src/docs/asciidoc/developer-guide.adoc
@@ -1,0 +1,243 @@
+= Developer Guide
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+This guide covers how to create custom widgets and components for {project-name}.
+
+== Creating Custom Widgets
+
+{project-name} provides two widget interfaces depending on whether your widget needs external state.
+
+=== Stateless Widgets
+
+For widgets that render the same output given the same inputs:
+
+[source,java]
+----
+public interface Widget {
+    void render(Rect area, Buffer buffer);
+}
+----
+
+Example: A custom separator widget:
+
+[source,java]
+----
+public class Separator implements Widget {
+    private final Style style;
+
+    public Separator(Style style) {
+        this.style = style;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        // Fill the entire width with a horizontal line
+        for (int x = area.x(); x < area.right(); x++) {
+            buffer.setCell(x, area.y(), Cell.of('─', style));
+        }
+    }
+}
+----
+
+=== Stateful Widgets
+
+For widgets that need to track selection, scroll position, or other state:
+
+[source,java]
+----
+public interface StatefulWidget<S> {
+    void render(Rect area, Buffer buffer, S state);
+}
+----
+
+Example: A custom counter widget:
+
+[source,java]
+----
+public class Counter implements StatefulWidget<Counter.State> {
+    private final Style style;
+
+    public static class State {
+        private int value = 0;
+
+        public int value() { return value; }
+        public void increment() { value++; }
+        public void decrement() { if (value > 0) value--; }
+    }
+
+    public Counter(Style style) {
+        this.style = style;
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer, State state) {
+        String text = "Count: " + state.value();
+        int x = area.x();
+        for (char c : text.toCharArray()) {
+            if (x < area.right()) {
+                buffer.setCell(x++, area.y(), Cell.of(c, style));
+            }
+        }
+    }
+}
+
+// Usage:
+Counter.State counterState = new Counter.State();
+Counter counter = new Counter(Style.EMPTY.bold());
+counter.render(area, buffer, counterState);
+----
+
+== Buffer Operations
+
+=== Setting Cells
+
+[source,java]
+----
+// Set a single cell
+buffer.setCell(x, y, Cell.of('X', style));
+
+// Set a string
+int col = x;
+for (char c : "Hello".toCharArray()) {
+    buffer.setCell(col++, y, Cell.of(c, style));
+}
+----
+
+=== Reading Cells
+
+[source,java]
+----
+Cell cell = buffer.cell(x, y);
+char symbol = cell.symbol();
+Style style = cell.style();
+----
+
+=== Filling Areas
+
+[source,java]
+----
+// Fill a rectangle with a character
+for (int row = area.y(); row < area.bottom(); row++) {
+    for (int col = area.x(); col < area.right(); col++) {
+        buffer.setCell(col, row, Cell.of(' ', bgStyle));
+    }
+}
+----
+
+=== Bounds Checking
+
+Always check bounds before writing:
+
+[source,java]
+----
+if (x >= area.x() && x < area.right() &&
+    y >= area.y() && y < area.bottom()) {
+    buffer.setCell(x, y, cell);
+}
+----
+
+== Creating Toolkit Components
+
+For Toolkit DSL integration, extend the `Component` class.
+Components use the link:bindings.html[@OnAction annotation] to handle input through the bindings system:
+
+[source,java]
+----
+import dev.tamboui.toolkit.component.Component;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.tui.bindings.OnAction;
+import dev.tamboui.tui.event.Event;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+public class CounterCard extends Component<CounterCard> {
+    private int count = 0;
+
+    @OnAction("increment")
+    void onIncrement(Event event) {
+        count++;
+    }
+
+    @OnAction("decrement")
+    void onDecrement(Event event) {
+        count--;
+    }
+
+    @Override
+    protected Element render() {
+        var borderColor = isFocused() ? Color.CYAN : Color.GRAY;
+
+        return panel(() -> column(
+                text("Count: " + count).bold(),
+                text("Press +/- to change").dim()
+        ))
+        .rounded()
+        .borderColor(borderColor)
+        .fill();
+    }
+}
+----
+
+=== Using Components
+
+Components require an ID:
+
+[source,java]
+----
+var counter1 = new CounterCard().id("counter-1");
+var counter2 = new CounterCard().id("counter-2");
+
+// Define bindings
+var bindings = BindingSets.standard()
+    .toBuilder()
+    .bind("increment", KeyTrigger.ch('+'), KeyTrigger.ch('='))
+    .bind("decrement", KeyTrigger.ch('-'), KeyTrigger.ch('_'))
+    .build();
+
+try (var runner = ToolkitRunner.builder()
+        .bindings(bindings)
+        .build()) {
+    runner.run(() -> row(counter1, counter2));
+}
+----
+
+== Best Practices
+
+=== Widget Design
+
+* Keep widgets focused on a single responsibility
+* Use the builder pattern for complex configuration
+* Respect the provided `Rect` bounds
+* Handle edge cases (empty area, no data)
+
+=== Performance
+
+* Minimize allocations in `render()` methods
+* Pre-compute strings and styles when possible
+* Use primitive arrays over collections for large data
+
+=== State Management
+
+* Keep state classes simple
+* Provide methods for all state modifications
+* Consider immutable state for thread safety
+
+== Next Steps
+
+* Review the link:widgets.html[Widgets Reference] to see existing implementations
+* Learn about link:bindings.html[Bindings and Actions] for handling input
+* Study link:mvc-architecture.html[Application Structure] for organizing larger apps
+
+== Further Reading
+
+For more details, explore the source code:
+
+* `tamboui-widgets/src/main/java/dev/tamboui/widgets/` - Widget implementations
+* `tamboui-toolkit/src/main/java/dev/tamboui/toolkit/` - Toolkit components
+* `tamboui-core/src/main/java/dev/tamboui/buffer/` - Buffer and Cell

--- a/docs/src/docs/asciidoc/docinfo-footer.html
+++ b/docs/src/docs/asciidoc/docinfo-footer.html
@@ -1,0 +1,159 @@
+<!-- Navigation data -->
+<script>
+var TAMBOUI_PAGES = [
+    { href: 'index.html', title: 'Home', short: 'Home' },
+    { href: 'getting-started.html', title: 'Getting Started', short: 'Getting Started' },
+    { href: 'core-concepts.html', title: 'Core Concepts', short: 'Core Concepts' },
+    { href: 'widgets.html', title: 'Widgets Reference', short: 'Widgets' },
+    { href: 'api-levels.html', title: 'API Levels', short: 'API Levels' },
+    { href: 'styling.html', title: 'CSS Styling', short: 'CSS Styling' },
+    { href: 'bindings.html', title: 'Bindings and Actions', short: 'Bindings' },
+    { href: 'mvc-architecture.html', title: 'Application Structure', short: 'App Structure' },
+    { href: 'developer-guide.html', title: 'Developer Guide', short: 'Developer Guide' }
+];
+</script>
+
+<!-- Theme toggle and navigation enhancement -->
+<script>
+(function() {
+    'use strict';
+
+    // ===== Theme Toggle =====
+    function getTheme() {
+        return localStorage.getItem('tamboui-theme') || 'auto';
+    }
+
+    function setTheme(theme) {
+        localStorage.setItem('tamboui-theme', theme);
+        applyTheme(theme);
+    }
+
+    function applyTheme(theme) {
+        if (theme === 'dark') {
+            document.documentElement.setAttribute('data-theme', 'dark');
+        } else if (theme === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+        } else {
+            document.documentElement.removeAttribute('data-theme');
+        }
+    }
+
+    function createThemeToggle() {
+        var header = document.getElementById('header');
+        if (!header) return;
+
+        var toggle = document.createElement('button');
+        toggle.className = 'theme-toggle';
+        toggle.setAttribute('aria-label', 'Toggle theme');
+        toggle.innerHTML = '<svg class="icon-sun" viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M12 7c-2.76 0-5 2.24-5 5s2.24 5 5 5 5-2.24 5-5-2.24-5-5-5zM2 13h2c.55 0 1-.45 1-1s-.45-1-1-1H2c-.55 0-1 .45-1 1s.45 1 1 1zm18 0h2c.55 0 1-.45 1-1s-.45-1-1-1h-2c-.55 0-1 .45-1 1s.45 1 1 1zM11 2v2c0 .55.45 1 1 1s1-.45 1-1V2c0-.55-.45-1-1-1s-1 .45-1 1zm0 18v2c0 .55.45 1 1 1s1-.45 1-1v-2c0-.55-.45-1-1-1s-1 .45-1 1zM5.99 4.58a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0s.39-1.03 0-1.41L5.99 4.58zm12.37 12.37a.996.996 0 00-1.41 0 .996.996 0 000 1.41l1.06 1.06c.39.39 1.03.39 1.41 0a.996.996 0 000-1.41l-1.06-1.06zm1.06-10.96a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06zM7.05 18.36a.996.996 0 000-1.41.996.996 0 00-1.41 0l-1.06 1.06c-.39.39-.39 1.03 0 1.41s1.03.39 1.41 0l1.06-1.06z"/></svg><svg class="icon-moon" viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M12 3a9 9 0 109 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 01-4.4 2.26 5.403 5.403 0 01-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/></svg>';
+
+        toggle.addEventListener('click', function() {
+            var current = getTheme();
+            var next;
+            if (current === 'auto') {
+                next = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'light' : 'dark';
+            } else if (current === 'dark') {
+                next = 'light';
+            } else {
+                next = 'dark';
+            }
+            setTheme(next);
+        });
+
+        // Insert before details element
+        var details = header.querySelector('.details');
+        if (details) {
+            header.insertBefore(toggle, details);
+        } else {
+            header.appendChild(toggle);
+        }
+    }
+
+    // ===== Cross-page Navigation =====
+    function getCurrentPage() {
+        var path = window.location.pathname;
+        var page = path.substring(path.lastIndexOf('/') + 1) || 'index.html';
+        return page;
+    }
+
+    function createTopNavigation() {
+        var toc = document.getElementById('toc');
+        if (!toc) return;
+
+        var currentPage = getCurrentPage();
+
+        // Create navigation section
+        var nav = document.createElement('nav');
+        nav.className = 'page-nav';
+        nav.innerHTML = '<div class="page-nav-title">Documentation</div>';
+
+        var ul = document.createElement('ul');
+        ul.className = 'page-nav-list';
+
+        TAMBOUI_PAGES.forEach(function(page) {
+            var li = document.createElement('li');
+            var a = document.createElement('a');
+            a.href = page.href;
+            a.textContent = page.short;
+            if (page.href === currentPage) {
+                a.className = 'current';
+                li.className = 'current';
+            }
+            li.appendChild(a);
+            ul.appendChild(li);
+        });
+
+        nav.appendChild(ul);
+
+        // Insert at top of TOC
+        toc.insertBefore(nav, toc.firstChild);
+    }
+
+    function createPrevNextNavigation() {
+        var content = document.getElementById('content');
+        var footer = document.getElementById('footer');
+        if (!content || !footer) return;
+
+        var currentPage = getCurrentPage();
+        var currentIndex = -1;
+
+        TAMBOUI_PAGES.forEach(function(page, index) {
+            if (page.href === currentPage) {
+                currentIndex = index;
+            }
+        });
+
+        if (currentIndex === -1) return;
+
+        var prev = currentIndex > 0 ? TAMBOUI_PAGES[currentIndex - 1] : null;
+        var next = currentIndex < TAMBOUI_PAGES.length - 1 ? TAMBOUI_PAGES[currentIndex + 1] : null;
+
+        if (!prev && !next) return;
+
+        var nav = document.createElement('nav');
+        nav.className = 'prev-next-nav';
+
+        if (prev) {
+            nav.innerHTML += '<a href="' + prev.href + '" class="prev"><span class="label">Previous</span><span class="title">' + prev.title + '</span></a>';
+        } else {
+            nav.innerHTML += '<span class="prev placeholder"></span>';
+        }
+
+        if (next) {
+            nav.innerHTML += '<a href="' + next.href + '" class="next"><span class="label">Next</span><span class="title">' + next.title + '</span></a>';
+        } else {
+            nav.innerHTML += '<span class="next placeholder"></span>';
+        }
+
+        // Insert before footer
+        footer.parentNode.insertBefore(nav, footer);
+    }
+
+    // ===== Initialize =====
+    document.addEventListener('DOMContentLoaded', function() {
+        createThemeToggle();
+        createTopNavigation();
+        createPrevNextNavigation();
+    });
+})();
+</script>

--- a/docs/src/docs/asciidoc/docinfo.html
+++ b/docs/src/docs/asciidoc/docinfo.html
@@ -1,0 +1,11 @@
+<!-- Theme toggle script - runs early to prevent flash -->
+<script>
+(function() {
+    var theme = localStorage.getItem('tamboui-theme');
+    if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+    } else if (theme === 'light') {
+        document.documentElement.setAttribute('data-theme', 'light');
+    }
+})();
+</script>

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -1,0 +1,293 @@
+= Getting Started
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+This guide will help you get up and running with {project-name} quickly.
+
+== Requirements
+
+* Java 8 or later (Java 17+ highly recommended)
+
+== Installation
+
+=== Maven
+
+Add the snapshot repository and dependencies to your `pom.xml`:
+
+[source,xml,subs="+attributes"]
+----
+<repository>
+    <id>ossrh-snapshots</id>
+    <url>{maven-repo}</url>
+    <releases>
+        <enabled>false</enabled>
+    </releases>
+    <snapshots>
+        <enabled>true</enabled>
+    </snapshots>
+</repository>
+
+<dependencies>
+    <!-- For Toolkit DSL (recommended) -->
+    <dependency>
+        <groupId>{maven-group}</groupId>
+        <artifactId>{toolkit-module}</artifactId>
+        <version>{project-version}</version>
+    </dependency>
+
+    <!-- JLine backend (required) -->
+    <dependency>
+        <groupId>{maven-group}</groupId>
+        <artifactId>{jline-module}</artifactId>
+        <version>{project-version}</version>
+    </dependency>
+</dependencies>
+----
+
+=== Gradle (Kotlin DSL)
+
+[source,kotlin,subs="+attributes"]
+----
+repositories {
+    maven {
+        url = uri("{maven-repo}")
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+}
+
+dependencies {
+    // For Toolkit DSL (recommended)
+    implementation("{maven-group}:{toolkit-module}:{project-version}")
+
+    // JLine backend (required)
+    implementation("{maven-group}:{jline-module}:{project-version}")
+}
+----
+
+=== JBang
+
+For quick experimentation, use JBang with inline dependencies:
+
+[source,java,subs="+attributes"]
+----
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS {maven-group}:{toolkit-module}:LATEST
+//DEPS {maven-group}:{jline-module}:LATEST
+//REPOS https://central.sonatype.com/repository/maven-snapshots/
+
+// Your code here...
+----
+
+== Hello World Examples
+
+{project-name} offers four API levels. Choose based on your needs:
+
+[cols="1,2,1",options="header"]
+|===
+|API Level |Best For |Complexity
+
+|link:api-levels.html#toolkit-dsl[Toolkit DSL]
+|Most applications - declarative, component-based UI
+|Low
+
+|link:api-levels.html#tuirunner[TuiRunner]
+|Custom event handling, animations
+|Medium
+
+|link:api-levels.html#immediate-mode[Immediate Mode]
+|Maximum control, custom rendering
+|High
+
+|link:api-levels.html#inline-display-mode[Inline Display]
+|CLI progress bars, build output, status lines
+|Low
+|===
+
+=== Using Toolkit DSL (Recommended)
+
+The simplest way to build a TUI application:
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.*;
+import dev.tamboui.toolkit.app.ToolkitApp;
+import dev.tamboui.toolkit.element.Element;
+
+public class HelloDsl extends ToolkitApp {
+
+    @Override
+    protected Element render() {
+        return panel("Hello",
+            text("Welcome to TamboUI DSL!").bold().cyan(),
+            spacer(),
+            text("Press 'q' to quit").dim()
+        ).rounded();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new HelloDsl().run();
+    }
+}
+----
+
+=== Using TuiRunner
+
+For more control over the event loop:
+
+[source,java]
+----
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.Keys;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.text.Text;
+
+public class HelloTuiRunner {
+    public static void main(String[] args) throws Exception {
+        try (var tui = TuiRunner.create()) {
+            tui.run(
+                (event, runner) -> {
+                    if (event.isQuit()) {
+                        runner.quit();
+                        return false;
+                    }
+                    return false;
+                },
+                frame -> {
+                    var paragraph = Paragraph.builder()
+                        .text(Text.from("Hello, TamboUI! Press 'q' to quit."))
+                        .build();
+                    frame.renderWidget(paragraph, frame.area());
+                }
+            );
+        }
+    }
+}
+----
+
+=== Using Immediate Mode
+
+For maximum control over the terminal:
+
+[source,java]
+----
+import dev.tamboui.terminal.Backend;
+import dev.tamboui.terminal.BackendFactory;
+import dev.tamboui.terminal.Terminal;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.text.Text;
+
+public class HelloImmediate {
+    public static void main(String[] args) throws Exception {
+        try (var backend = BackendFactory.create()) {
+            backend.enableRawMode();
+            backend.enterAlternateScreen();
+
+            var terminal = new Terminal<>(backend);
+            terminal.draw(frame -> {
+                var paragraph = Paragraph.builder()
+                    .text(Text.from("Hello, Immediate Mode!"))
+                    .build();
+                frame.renderWidget(paragraph, frame.area());
+            });
+
+            // Wait for user input
+            Thread.sleep(2000);
+        }
+    }
+}
+----
+
+=== Using Inline Display
+
+For CLI tools that show progress while preserving terminal history:
+
+[source,java]
+----
+import dev.tamboui.inline.InlineDisplay;
+import dev.tamboui.widgets.gauge.Gauge;
+
+public class HelloInline {
+    public static void main(String[] args) throws Exception {
+        try (var display = InlineDisplay.create(2)) {
+            for (int i = 0; i <= 100; i += 5) {
+                int progress = i;
+                display.render((area, buffer) -> {
+                    var gauge = Gauge.builder()
+                        .ratio(progress / 100.0)
+                        .label("Progress: " + progress + "%")
+                        .build();
+                    gauge.render(area, buffer);
+                });
+                Thread.sleep(50);
+            }
+            display.println("Done!");
+        }
+    }
+}
+----
+
+== Running the Demos
+
+The {project-name} repository includes many demo applications showcasing different features.
+
+=== Using JBang
+
+If you have JBang installed:
+
+[source,bash]
+----
+# List available demos
+jbang alias list .
+
+# Run a specific demo
+jbang sparkline-demo
+----
+
+=== Using the run-demo.sh Script
+
+[source,bash]
+----
+# Show interactive demo selector
+./run-demo.sh
+
+# Run a specific demo on JVM
+./run-demo.sh sparkline-demo
+
+# Run as native executable (requires GraalVM)
+./run-demo.sh sparkline-demo --native
+----
+
+=== Manual Build and Run
+
+[source,bash]
+----
+# Build and install the demo
+./gradlew :demos:sparkline-demo:installDist
+
+# Run it
+./demos/sparkline-demo/build/install/sparkline-demo/bin/sparkline-demo
+----
+
+=== Compiling to Native Image
+
+With GraalVM installed:
+
+[source,bash]
+----
+./gradlew :demos:sparkline-demo:nativeCompile
+./demos/sparkline-demo/build/native/nativeCompile/sparkline-demo
+----
+
+== Next Steps
+
+* Learn about link:core-concepts.html[Core Concepts] to understand the architecture
+* Explore the link:widgets.html[Widgets Reference] to see what's available
+* Read about link:api-levels.html[API Levels] for detailed documentation
+* Follow the link:mvc-architecture.html[Application Structure] guide for building maintainable apps

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1,0 +1,131 @@
+= TamboUI Documentation
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+== Introduction
+
+{project-name} is a Java library for building terminal user interfaces.
+The design follows Rust's {ratatui-url}[ratatui] closely - same rendering model, similar widget APIs, familiar layout system.
+If you know ratatui, you'll pick this up quickly.
+
+[NOTE]
+====
+{project-name} is still experimental and under active development. APIs may change.
+Feedback, issues, and contributions are welcome!
+====
+
+=== Key Features
+
+* *Immediate-mode rendering* - Redraw the entire UI each frame for simple state management
+* *Intermediate buffer system* - Widgets render to a buffer, enabling diff-based terminal updates
+* *Constraint-based layout* - Flexible layout system with percentage, fixed, ratio, and proportional sizing
+* *JLine 3 backend* - Cross-platform terminal support including Windows via Jansi
+* *High-level TUI framework* - TuiRunner eliminates boilerplate with built-in event handling
+* *Declarative Toolkit DSL* - Fluent API for building UIs with components and focus management
+* *PicoCLI integration* - Optional module for CLI argument parsing
+* *GraalVM native image support* - Compile to native executables for instant startup
+
+=== Module Overview
+
+[cols="1,3",options="header"]
+|===
+|Module |Description
+
+|`{core-module}`
+|Core types: Buffer, Cell, Rect, Style, Layout, Text primitives
+
+|`{widgets-module}`
+|All widget implementations (Block, Paragraph, List, Table, Chart, etc.)
+
+|`{jline-module}`
+|JLine 3 terminal backend for cross-platform support
+
+|`{tui-module}`
+|High-level TUI framework with TuiRunner, event handling, bindings, and key helpers
+
+|`{toolkit-module}`
+|Fluent DSL for declarative UI construction with components and focus management
+
+|`{css-module}`
+|CSS-based styling with TCSS format, selectors, and theme switching
+
+|`{annotations-module}`
+|Annotation definitions (`@OnAction`) for action handling
+
+|`{processor-module}`
+|Annotation processor for compile-time action handler generation
+
+|`tamboui-image`
+|Image rendering with Kitty, iTerm, Sixel, and braille protocols
+
+|`tamboui-picocli`
+|Optional PicoCLI integration for CLI argument parsing
+|===
+
+== Documentation Sections
+
+=== link:getting-started.html[Getting Started]
+Installation, hello world examples, and running demos.
+
+=== link:core-concepts.html[Core Concepts]
+Understanding the rendering model, buffer system, layout, and styling.
+
+=== link:widgets.html[Widgets Reference]
+Comprehensive guide to all available widgets with examples.
+
+=== link:api-levels.html[API Levels]
+Detailed documentation for immediate mode, TuiRunner, Toolkit DSL, and inline display.
+
+=== link:styling.html[CSS Styling]
+External stylesheets with TCSS format, selectors, and runtime theme switching.
+
+=== link:bindings.html[Bindings and Actions]
+Key and mouse bindings, action handlers, and the `@OnAction` annotation.
+
+=== link:mvc-architecture.html[Application Structure]
+Architecture patterns for building maintainable TUI applications.
+
+=== link:developer-guide.html[Developer Guide]
+Creating custom widgets and components.
+
+== Quick Example
+
+Here's a minimal example using the Toolkit DSL:
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.*;
+import dev.tamboui.toolkit.app.ToolkitApp;
+import dev.tamboui.toolkit.element.Element;
+
+public class HelloTamboUI extends ToolkitApp {
+
+    @Override
+    protected Element render() {
+        return panel("Hello",
+            text("Welcome to TamboUI!").bold().cyan(),
+            spacer(),
+            text("Press 'q' to quit").dim()
+        ).rounded();
+    }
+
+    public static void main(String[] args) throws Exception {
+        new HelloTamboUI().run();
+    }
+}
+----
+
+== Resources
+
+* {github-url}[GitHub Repository]
+* {github-url}/issues[Issue Tracker]
+* https://tamboui.zulipchat.com[Zulip Chat]
+
+== License
+
+{project-name} is released under the MIT License.

--- a/docs/src/docs/asciidoc/mvc-architecture.adoc
+++ b/docs/src/docs/asciidoc/mvc-architecture.adoc
@@ -1,0 +1,612 @@
+= Application Structure
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+This guide explains how to build maintainable terminal applications using the Model-View-Controller (MVC) pattern with {project-name}.
+
+== Architecture Overview
+
+The recommended architecture separates concerns into three layers:
+
+[source]
+----
+┌─────────────┐     reads      ┌─────────────┐
+│  Controller │ ◄──────────────│    View     │
+│   (State)   │                │  (Element)  │
+└─────────────┘                └─────────────┘
+       ▲                              │
+       │         dispatches           │
+       └──────────────────────────────┘
+                 events
+----
+
+* **Controller**: Holds all application state and provides methods to modify it
+* **View**: A pure function that reads state from the controller and returns an `Element`
+* **Events**: Dispatched to the controller, which updates state
+
+== The Controller
+
+The controller is a plain Java class that encapsulates your application state:
+
+[source,java]
+----
+import dev.tamboui.widgets.input.TextInputState;
+
+public class TodoController {
+    private final List<TodoItem> items = new ArrayList<>();
+    private final TextInputState inputState = new TextInputState();
+    private int selectedIndex = 0;
+    private boolean inputMode = false;
+
+    public record TodoItem(String text, boolean done) {}
+
+    // Queries (read state)
+    public List<TodoItem> items() { return List.copyOf(items); }
+    public int selectedIndex() { return selectedIndex; }
+    public TextInputState inputState() { return inputState; }
+    public boolean isInputMode() { return inputMode; }
+
+    // Commands (modify state)
+    public void moveUp() {
+        if (selectedIndex > 0) selectedIndex--;
+    }
+
+    public void moveDown() {
+        if (selectedIndex < items.size() - 1) {
+            selectedIndex++;
+        }
+    }
+
+    public void toggleSelected() {
+        if (!items.isEmpty()) {
+            var item = items.get(selectedIndex);
+            items.set(selectedIndex, new TodoItem(item.text(), !item.done()));
+        }
+    }
+
+    public void deleteSelected() {
+        if (!items.isEmpty()) {
+            items.remove(selectedIndex);
+            if (selectedIndex >= items.size() && selectedIndex > 0) {
+                selectedIndex--;
+            }
+        }
+    }
+
+    public void startInput() { inputMode = true; }
+    public void cancelInput() { inputMode = false; inputState.clear(); }
+
+    public void submitInput() {
+        if (inputState.length() > 0) {
+            items.add(new TodoItem(inputState.text(), false));
+            selectedIndex = items.size() - 1;
+        }
+        inputMode = false;
+        inputState.clear();
+    }
+}
+----
+
+=== Controller Design Principles
+
+* **Queries** are pure read-only methods that return state
+* **Commands** modify state and have no return value
+* Return defensive copies of collections (`List.copyOf()`)
+* Keep state private, expose through methods
+
+== The View
+
+The view is a pure function that transforms controller state into UI elements:
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.*;
+
+public class TodoView {
+    private final TodoController controller;
+
+    public TodoView(TodoController controller) {
+        this.controller = controller;
+    }
+
+    public Element render() {
+        return panel("Todo List",
+            renderList(),
+            spacer(),
+            renderInput(),
+            renderHelp()
+        ).rounded().id("main").focusable();
+    }
+
+    private Element renderList() {
+        var items = controller.items();
+        if (items.isEmpty()) {
+            return text("No items. Press 'a' to add one.").dim().italic();
+        }
+
+        var elements = new Element[items.size()];
+        for (int i = 0; i < items.size(); i++) {
+            elements[i] = renderItem(i, items.get(i));
+        }
+        return column(elements);
+    }
+
+    private Element renderItem(int index, TodoController.TodoItem item) {
+        var checkbox = item.done() ? "[x]" : "[ ]";
+        var element = text(checkbox + " " + item.text());
+
+        if (index == controller.selectedIndex()) {
+            element = element.reversed();
+        }
+        if (item.done()) {
+            element = element.dim().crossedOut();
+        }
+        return element;
+    }
+
+    private Element renderInput() {
+        if (!controller.isInputMode()) {
+            return text("");
+        }
+        return row(
+            text("New: ").cyan(),
+            textInput(controller.inputState()).fill()
+        );
+    }
+
+    private Element renderHelp() {
+        if (controller.isInputMode()) {
+            return text("[Enter] Save  [Esc] Cancel").dim();
+        }
+        return text("[a] Add  [Space] Toggle  [d] Delete  [j/k] Navigate  [q] Quit").dim();
+    }
+}
+----
+
+=== View Design Principles
+
+* Views are **pure functions**: `Controller → Element`
+* No side effects in render methods
+* All state comes from the controller
+* Conditional rendering based on controller state
+
+== Event Handling
+
+=== Using Lambda Handlers
+
+For simple applications, attach handlers directly:
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.handleTextInputKey;
+
+public class TodoApp {
+    public static void main(String[] args) throws Exception {
+        var controller = new TodoController();
+        var view = new TodoView(controller);
+
+        try (var runner = ToolkitRunner.create()) {
+            runner.run(() ->
+                view.render()
+                    .onKeyEvent(event -> handleEvent(event, controller))
+            );
+        }
+    }
+
+    private static EventResult handleEvent(KeyEvent event, TodoController ctrl) {
+        if (ctrl.isInputMode()) {
+            return handleInputMode(event, ctrl);
+        }
+        return handleNormalMode(event, ctrl);
+    }
+
+    private static EventResult handleInputMode(KeyEvent event, TodoController ctrl) {
+        if (event.isCancel()) {
+            ctrl.cancelInput();
+            return EventResult.HANDLED;
+        }
+        if (event.isSelect()) {
+            ctrl.submitInput();
+            return EventResult.HANDLED;
+        }
+        if (handleTextInputKey(ctrl.inputState(), event)) {
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    }
+
+    private static EventResult handleNormalMode(KeyEvent event, TodoController ctrl) {
+        if (event.isChar('a')) { ctrl.startInput(); return EventResult.HANDLED; }
+        if (event.isUp()) { ctrl.moveUp(); return EventResult.HANDLED; }
+        if (event.isDown()) { ctrl.moveDown(); return EventResult.HANDLED; }
+        if (event.isSelect()) { ctrl.toggleSelected(); return EventResult.HANDLED; }
+        if (event.isChar('d')) { ctrl.deleteSelected(); return EventResult.HANDLED; }
+        return EventResult.UNHANDLED;
+    }
+}
+----
+
+=== Separate Key Handler Class
+
+For complex applications, extract event handling:
+
+[source,java]
+----
+public class TodoKeyHandler {
+    private final TodoController controller;
+
+    public TodoKeyHandler(TodoController controller) {
+        this.controller = controller;
+    }
+
+    public EventResult handle(KeyEvent event) {
+        if (controller.isInputMode()) {
+            return handleInputMode(event);
+        }
+        return handleNormalMode(event);
+    }
+
+    private EventResult handleInputMode(KeyEvent event) {
+        if (event.isCancel()) {
+            controller.cancelInput();
+            return EventResult.HANDLED;
+        }
+        if (event.isConfirm()) {
+            controller.submitInput();
+            return EventResult.HANDLED;
+        }
+        // ... handle text input
+        return EventResult.UNHANDLED;
+    }
+
+    private EventResult handleNormalMode(KeyEvent event) {
+        if (event.isChar('a')) {
+            controller.startInput();
+            return EventResult.HANDLED;
+        }
+        // ... more handlers
+        return EventResult.UNHANDLED;
+    }
+}
+----
+
+=== Event Result
+
+Return values control event propagation:
+
+* `EventResult.HANDLED` - Event was processed, stop propagation
+* `EventResult.UNHANDLED` - Event was not processed, continue routing
+
+== Focus Management
+
+=== Making Elements Focusable
+
+Both `id()` AND `focusable()` are required:
+
+[source,java]
+----
+panel("Panel A")
+    .id("panel-a")          // Unique identifier (REQUIRED)
+    .focusable()            // Enable focus (REQUIRED)
+    .borderColor(Color.GRAY)
+    .focusedBorderColor(Color.CYAN)  // Visual feedback
+----
+
+=== Focus Navigation
+
+[cols="1,2",options="header"]
+|===
+|Key |Action
+
+|Tab
+|Focus next element
+
+|Shift+Tab
+|Focus previous element
+
+|Mouse click
+|Focus clicked element
+
+|ESC
+|Clear focus (if no element handles it)
+|===
+
+=== Multi-Panel Applications
+
+[source,java]
+----
+column(
+    panel("Settings")
+        .id("settings")
+        .focusable()
+        .onKeyEvent(event -> handleSettingsKey(event, controller)),
+
+    panel("Actions")
+        .id("actions")
+        .focusable()
+        .onKeyEvent(event -> handleActionsKey(event, controller))
+)
+----
+
+== Dialogs and Overlays
+
+=== The Dialog Element
+
+[source,java]
+----
+var inputDialog = dialog("New Directory",
+    text("Enter name:"),
+    textInput(inputState),
+    text("[Enter] Confirm  [Esc] Cancel").dim()
+).rounded()
+ .borderColor(Color.CYAN)
+ .width(50)
+ .onConfirm(() -> createDirectory(inputState.text()))
+ .onCancel(() -> dismissDialog());
+----
+
+=== Implementing Custom Overlay
+
+For custom dialogs, implement `Element` directly:
+
+[source,java]
+----
+public class MyView implements Element {
+    private final MyController controller;
+
+    @Override
+    public void render(Frame frame, Rect area, RenderContext context) {
+        // 1. Render main UI
+        var ui = column(header(), content(), footer());
+        ui.render(frame, area, context);
+
+        // 2. Render dialog on top (if present)
+        if (controller.hasDialog()) {
+            renderDialog(frame, area, context);
+        }
+    }
+
+    private void renderDialog(Frame frame, Rect area, RenderContext context) {
+        int dialogWidth = 50;
+        int dialogHeight = 6;
+        int x = (area.width() - dialogWidth) / 2;
+        int y = (area.height() - dialogHeight) / 2;
+        var dialogArea = new Rect(area.x() + x, area.y() + y, dialogWidth, dialogHeight);
+
+        // Clear area first
+        frame.renderWidget(Clear.INSTANCE, dialogArea);
+
+        // Render dialog panel
+        var dialog = panel("Confirm",
+            text(controller.dialogMessage()),
+            text("[y] Yes  [n] No  [Esc] Cancel").dim()
+        ).rounded().borderColor(Color.YELLOW);
+
+        dialog.render(frame, dialogArea, context);
+    }
+
+    @Override
+    public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
+        // ESC should dismiss dialog, not clear focus
+        if (event.isCancel() && controller.hasDialog()) {
+            controller.dismissDialog();
+            return EventResult.HANDLED;
+        }
+        // ... other handling
+        return EventResult.UNHANDLED;
+    }
+}
+----
+
+== Complete Example
+
+[source,java]
+----
+import dev.tamboui.toolkit.app.ToolkitRunner;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.style.Color;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+public class TodoApp {
+
+    // ═══════════════════════════════════════════════════════════════
+    // CONTROLLER
+    // ═══════════════════════════════════════════════════════════════
+
+    static class Controller {
+        public record Item(String text, boolean done) {}
+
+        private final List<Item> items = new ArrayList<>();
+        private final StringBuilder input = new StringBuilder();
+        private int cursor = 0;
+        private boolean editing = false;
+
+        public List<Item> items() { return List.copyOf(items); }
+        public int cursor() { return cursor; }
+        public String input() { return input.toString(); }
+        public boolean isEditing() { return editing; }
+        public boolean isEmpty() { return items.isEmpty(); }
+
+        public void cursorUp() { if (cursor > 0) cursor--; }
+        public void cursorDown() { if (cursor < items.size() - 1) cursor++; }
+
+        public void toggle() {
+            if (!items.isEmpty()) {
+                var item = items.get(cursor);
+                items.set(cursor, new Item(item.text(), !item.done()));
+            }
+        }
+
+        public void delete() {
+            if (!items.isEmpty()) {
+                items.remove(cursor);
+                if (cursor >= items.size() && cursor > 0) cursor--;
+            }
+        }
+
+        public void startEditing() { editing = true; }
+        public void cancelEditing() { editing = false; input.setLength(0); }
+        public void typeChar(char c) { input.append(c); }
+        public void backspace() {
+            if (input.length() > 0) input.setLength(input.length() - 1);
+        }
+
+        public void submit() {
+            if (input.length() > 0) {
+                items.add(new Item(input.toString(), false));
+                cursor = items.size() - 1;
+            }
+            editing = false;
+            input.setLength(0);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // VIEW
+    // ═══════════════════════════════════════════════════════════════
+
+    static class View {
+        private final Controller ctrl;
+
+        View(Controller ctrl) { this.ctrl = ctrl; }
+
+        Element render() {
+            return panel("Todo List",
+                ctrl.isEmpty() ? emptyState() : itemList(),
+                spacer(),
+                inputArea(),
+                helpBar()
+            ).rounded().borderColor(Color.DARK_GRAY)
+             .focusedBorderColor(Color.CYAN)
+             .id("main").focusable();
+        }
+
+        private Element emptyState() {
+            return text("No items yet. Press 'a' to add one.").dim().italic();
+        }
+
+        private Element itemList() {
+            var items = ctrl.items();
+            var elements = new Element[items.size()];
+            for (int i = 0; i < items.size(); i++) {
+                elements[i] = itemRow(i, items.get(i));
+            }
+            return column(elements);
+        }
+
+        private Element itemRow(int index, Controller.Item item) {
+            var prefix = item.done() ? "[x] " : "[ ] ";
+            var elem = text(prefix + item.text());
+
+            if (index == ctrl.cursor()) elem = elem.reversed();
+            if (item.done()) elem = elem.dim().crossedOut();
+
+            return elem;
+        }
+
+        private Element inputArea() {
+            if (!ctrl.isEditing()) return text("");
+            return row(
+                text("New: ").cyan(),
+                text(ctrl.input() + "_").bold()
+            );
+        }
+
+        private Element helpBar() {
+            var help = ctrl.isEditing()
+                ? "[Enter] Save  [Esc] Cancel"
+                : "[a] Add  [Space] Toggle  [d] Delete  [j/k] Move  [q] Quit";
+            return text(help).dim();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // EVENT HANDLER
+    // ═══════════════════════════════════════════════════════════════
+
+    static EventResult handleKey(KeyEvent event, Controller ctrl) {
+        if (ctrl.isEditing()) {
+            if (event.isCancel()) { ctrl.cancelEditing(); return EventResult.HANDLED; }
+            if (event.isSelect()) { ctrl.submit(); return EventResult.HANDLED; }
+            if (event.code() == KeyCode.CHAR && event.character() >= 32) {
+                ctrl.typeChar(event.character());
+                return EventResult.HANDLED;
+            }
+            if (event.code() == KeyCode.BACKSPACE) {
+                ctrl.backspace();
+                return EventResult.HANDLED;
+            }
+            return EventResult.UNHANDLED;
+        }
+
+        if (event.isChar('a')) { ctrl.startEditing(); return EventResult.HANDLED; }
+        if (event.isUp()) { ctrl.cursorUp(); return EventResult.HANDLED; }
+        if (event.isDown()) { ctrl.cursorDown(); return EventResult.HANDLED; }
+        if (event.isSelect()) { ctrl.toggle(); return EventResult.HANDLED; }
+        if (event.isChar('d')) { ctrl.delete(); return EventResult.HANDLED; }
+        return EventResult.UNHANDLED;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // MAIN
+    // ═══════════════════════════════════════════════════════════════
+
+    public static void main(String[] args) throws Exception {
+        var controller = new Controller();
+        var view = new View(controller);
+
+        // Add sample data
+        controller.items.add(new Controller.Item("Learn TamboUI", false));
+        controller.items.add(new Controller.Item("Build awesome apps", false));
+
+        try (var runner = ToolkitRunner.create()) {
+            runner.run(() ->
+                view.render()
+                    .onKeyEvent(e -> handleKey(e, controller))
+            );
+        }
+    }
+}
+----
+
+== Benefits of This Architecture
+
+[cols="1,3",options="header"]
+|===
+|Benefit |Description
+
+|Testable
+|Controller can be unit tested without any UI
+
+|Reusable
+|Same controller can power different views
+
+|Predictable
+|State changes only through controller methods
+
+|Debuggable
+|Easy to log/inspect state transitions
+
+|Maintainable
+|Clear separation of concerns
+|===
+
+== Next Steps
+
+* Explore the link:widgets.html[Widgets Reference] for available components
+* Learn about link:bindings.html[Bindings and Actions] for handling user input
+* Read the link:developer-guide.html[Developer Guide] for creating custom widgets
+* See the link:api-levels.html[API Levels] for alternative approaches

--- a/docs/src/docs/asciidoc/styling.adoc
+++ b/docs/src/docs/asciidoc/styling.adoc
@@ -1,0 +1,418 @@
+= CSS Styling
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+{project-name} supports CSS-based styling as an alternative to programmatic style configuration.
+Instead of chaining `.bold().cyan().onBlue()` calls, you can define styles in external `.tcss` files and apply them via selectors.
+
+== Why Use CSS?
+
+Programmatic styling works well for simple cases:
+
+[source,java]
+----
+text("Hello").bold().cyan()
+panel("Title", content).rounded().borderColor(Color.BLUE)
+----
+
+But as applications grow, CSS offers advantages:
+
+* **Separation of concerns** - styling lives outside your code
+* **Theming** - switch between light/dark themes at runtime
+* **Designer-friendly** - non-developers can adjust colors and spacing
+* **Consistency** - define styles once, apply everywhere via classes
+
+== The StyleEngine
+
+`StyleEngine` manages stylesheets and resolves styles for elements:
+
+[source,java]
+----
+StyleEngine engine = StyleEngine.create();
+
+// Add inline CSS
+engine.addStylesheet("Panel { border-type: rounded; }");
+
+// Load named themes from classpath
+engine.loadStylesheet("dark", "/themes/dark.tcss");
+engine.loadStylesheet("light", "/themes/light.tcss");
+
+// Switch themes at runtime
+engine.setActiveStylesheet("dark");
+----
+
+== TCSS Format
+
+{project-name} uses `.tcss` (Textual CSS) files - a CSS dialect designed for terminal UIs.
+
+=== Variables
+
+Define reusable values:
+
+[source,css]
+----
+$bg-primary: black;
+$fg-primary: white;
+$accent: cyan;
+$border-color: dark-gray;
+
+Panel {
+    background: $bg-primary;
+    color: $fg-primary;
+    border-color: $border-color;
+}
+
+Panel:focus {
+    border-color: $accent;
+}
+----
+
+=== Selectors
+
+Type selectors match element types:
+
+[source,css]
+----
+Panel {
+    border-type: rounded;
+}
+
+Text {
+    color: white;
+}
+----
+
+Class selectors match CSS classes:
+
+[source,css]
+----
+.primary {
+    color: cyan;
+    text-style: bold;
+}
+
+.danger {
+    color: red;
+}
+----
+
+ID selectors match specific elements:
+
+[source,css]
+----
+#sidebar {
+    width: 30;
+    background: dark-gray;
+}
+
+#main-content {
+    padding: 1;
+}
+----
+
+Pseudo-class selectors match element state:
+
+[source,css]
+----
+Panel:focus {
+    border-color: cyan;
+    border-type: double;
+}
+
+Button:hover {
+    text-style: bold;
+}
+
+ListContainer-item:selected {
+    background: blue;
+}
+
+ListContainer-item:nth-child(even) {
+    background: #1a1a1a;
+}
+----
+
+Supported pseudo-classes: `:focus`, `:hover`, `:disabled`, `:active`, `:selected`, `:first-child`, `:last-child`, `:nth-child(even)`, `:nth-child(odd)`.
+
+Compound selectors combine multiple conditions:
+
+[source,css]
+----
+Panel.primary#main {
+    border-color: cyan;
+}
+----
+
+Descendant and child combinators:
+
+[source,css]
+----
+/* Any Button inside a Panel */
+Panel Button {
+    color: white;
+}
+
+/* Direct child only */
+Panel > Button {
+    text-style: bold;
+}
+----
+
+=== Nesting
+
+Use `&` for nested rules:
+
+[source,css]
+----
+Panel {
+    border-type: rounded;
+    border-color: gray;
+
+    &:focus {
+        border-color: cyan;
+        border-type: double;
+    }
+
+    &.primary {
+        border-color: blue;
+    }
+}
+----
+
+=== Properties
+
+[cols="1,2,2",options="header"]
+|===
+|Property |Values |Example
+
+|`color`
+|Named colors, hex, rgb
+|`color: cyan;` `color: #ff5500;`
+
+|`background`
+|Named colors, hex, rgb
+|`background: black;`
+
+|`text-style`
+|bold, dim, italic, underlined, reversed
+|`text-style: bold;`
+
+|`border-type`
+|plain, rounded, double, thick
+|`border-type: rounded;`
+
+|`border-color`
+|Named colors, hex, rgb
+|`border-color: cyan;`
+
+|`padding`
+|Single value or top right bottom left
+|`padding: 1;` `padding: 1 2 1 2;`
+
+|`text-align`
+|left, center, right
+|`text-align: center;`
+
+|`width`
+|Integer (columns)
+|`width: 40;`
+|===
+
+Named colors: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, `dark-gray`, and their bright variants.
+
+=== Importance
+
+Override specificity with `!important`:
+
+[source,css]
+----
+.error {
+    color: red !important;
+}
+----
+
+== Applying Styles
+
+=== With Toolkit DSL
+
+Elements automatically participate in CSS styling when you set IDs and classes:
+
+[source,java]
+----
+panel("Settings",
+    text("Username").cssClass("label"),
+    textInput(usernameState).id("username-input"),
+    text("Password").cssClass("label"),
+    textInput(passwordState).id("password-input").cssClass("secret")
+)
+.id("settings-panel")
+.cssClass("primary")
+----
+
+=== With ToolkitRunner
+
+Pass the StyleEngine when creating the runner:
+
+[source,java]
+----
+StyleEngine engine = StyleEngine.create();
+engine.loadStylesheet("dark", "/themes/dark.tcss");
+engine.setActiveStylesheet("dark");
+
+try (var runner = ToolkitRunner.builder()
+        .styleEngine(engine)
+        .build()) {
+    runner.run(() -> myApp());
+}
+----
+
+=== Implementing Styleable
+
+For custom widgets outside the Toolkit, implement the `Styleable` interface:
+
+[source,java]
+----
+public class MyWidget implements Widget, Styleable {
+    private String id;
+    private Set<String> classes = new HashSet<>();
+
+    @Override
+    public String styleType() {
+        return "MyWidget";  // Used for type selectors
+    }
+
+    @Override
+    public Optional<String> cssId() {
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public Set<String> cssClasses() {
+        return classes;
+    }
+
+    @Override
+    public Optional<Styleable> cssParent() {
+        return Optional.empty();  // Or return parent for descendant selectors
+    }
+}
+----
+
+Then resolve and apply styles:
+
+[source,java]
+----
+CssStyleResolver resolved = engine.resolve(widget);
+
+Style style = Style.EMPTY;
+if (resolved.foreground() != null) {
+    style = style.fg(resolved.foreground());
+}
+if (resolved.background() != null) {
+    style = style.bg(resolved.background());
+}
+style = style.addModifiers(resolved.modifiers());
+----
+
+== Theme Switching
+
+Switch themes at runtime:
+
+[source,java]
+----
+@OnAction("toggleTheme")
+void onToggleTheme(Event event) {
+    String current = engine.getActiveStylesheet();
+    String next = "dark".equals(current) ? "light" : "dark";
+    engine.setActiveStylesheet(next);
+}
+----
+
+Listen for style changes:
+
+[source,java]
+----
+engine.addChangeListener(() -> {
+    // Styles changed, trigger redraw
+    requestRedraw();
+});
+----
+
+== Example Theme Files
+
+.dark.tcss
+[source,css]
+----
+$bg-primary: black;
+$fg-primary: white;
+$accent: cyan;
+$border-color: dark-gray;
+
+* {
+    color: $fg-primary;
+    background: $bg-primary;
+}
+
+Panel {
+    border-type: rounded;
+    border-color: $border-color;
+}
+
+Panel:focus {
+    border-color: $accent;
+    border-type: double;
+}
+
+.primary {
+    color: $accent;
+    text-style: bold;
+}
+
+.danger {
+    color: red;
+}
+
+.muted {
+    color: gray;
+}
+----
+
+.light.tcss
+[source,css]
+----
+$bg-primary: white;
+$fg-primary: black;
+$accent: blue;
+$border-color: gray;
+
+* {
+    color: $fg-primary;
+    background: $bg-primary;
+}
+
+Panel {
+    border-type: rounded;
+    border-color: $border-color;
+}
+
+Panel:focus {
+    border-color: $accent;
+    border-type: double;
+}
+
+.primary {
+    color: $accent;
+    text-style: bold;
+}
+----
+
+== Next Steps
+
+* link:api-levels.html[API Levels] - understanding the different abstraction layers
+* link:widgets.html[Widgets Reference] - available components to style
+* link:developer-guide.html[Developer Guide] - creating custom styleable widgets

--- a/docs/src/docs/asciidoc/widgets.adoc
+++ b/docs/src/docs/asciidoc/widgets.adoc
@@ -1,0 +1,535 @@
+= Widgets Reference
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+{project-name} provides a comprehensive set of widgets for building terminal UIs.
+
+== Widget Overview
+
+[cols="1,1,2",options="header"]
+|===
+|Widget |Type |Description
+
+|<<block,Block>>
+|Stateless
+|Container with borders, titles, and padding
+
+|<<paragraph,Paragraph>>
+|Stateless
+|Multi-line text with wrapping and alignment
+
+|<<listwidget,ListWidget>>
+|Stateful
+|Scrollable list with selection
+
+|<<table,Table>>
+|Stateful
+|Grid with rows, columns, and selection
+
+|<<tabs,Tabs>>
+|Stateful
+|Tab bar with selection
+
+|<<gauge,Gauge>>
+|Stateless
+|Progress bar with percentage
+
+|<<linegauge,LineGauge>>
+|Stateless
+|Horizontal line progress indicator
+
+|<<sparkline,Sparkline>>
+|Stateless
+|Mini line chart for data series
+
+|<<barchart,BarChart>>
+|Stateless
+|Vertical bar chart
+
+|<<chart,Chart>>
+|Stateless
+|Line and scatter plots with axes
+
+|<<canvas,Canvas>>
+|Stateless
+|Drawing surface with shapes
+
+|<<calendar,Calendar>>
+|Stateless
+|Monthly calendar with date styling
+
+|<<scrollbar,Scrollbar>>
+|Stateful
+|Visual scroll position indicator
+
+|<<textinput,TextInput>>
+|Stateful
+|Single-line text input
+
+|<<clear,Clear>>
+|Stateless
+|Clears an area (for widget layering)
+|===
+
+== Container Widgets
+
+=== Block
+
+A `Block` is the most fundamental container widget. It can have borders, titles, and padding.
+
+[source,java]
+----
+Block block = Block.builder()
+    .title("My Title")
+    .borders(Borders.ALL)
+    .borderType(BorderType.ROUNDED)
+    .borderStyle(Style.EMPTY.fg(Color.CYAN))
+    .padding(new Padding(1, 2, 1, 2))  // top, right, bottom, left
+    .build();
+
+// Render the block
+block.render(area, buffer);
+
+// Get the inner area (after borders and padding)
+Rect inner = block.inner(area);
+----
+
+Border types:
+
+* `BorderType.PLAIN` - Simple lines (`─`, `│`)
+* `BorderType.ROUNDED` - Rounded corners (`╭`, `╮`, `╰`, `╯`)
+* `BorderType.DOUBLE` - Double lines (`═`, `║`)
+* `BorderType.THICK` - Thick lines (`━`, `┃`)
+
+=== Clear
+
+Clears an area by filling it with spaces. Useful before rendering overlays:
+
+[source,java]
+----
+Clear.INSTANCE.render(dialogArea, buffer);
+// Then render your dialog on top
+----
+
+== Text Widgets
+
+=== Paragraph
+
+Displays multi-line text with wrapping and alignment:
+
+[source,java]
+----
+Paragraph paragraph = Paragraph.builder()
+    .text(Text.from("This is a paragraph of text that can wrap across multiple lines."))
+    .wrap(Wrap.WORD)
+    .alignment(Alignment.LEFT)
+    .block(Block.builder()
+        .title("Description")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+paragraph.render(area, buffer);
+----
+
+Wrap modes:
+
+* `Wrap.NONE` - No wrapping, text is clipped
+* `Wrap.CHARACTER` - Wrap at any character
+* `Wrap.WORD` - Wrap at word boundaries
+
+== Selection Widgets
+
+=== ListWidget
+
+A scrollable list with selection:
+
+[source,java]
+----
+// Create items
+List<ListItem> items = List.of(
+    ListItem.from("First item"),
+    ListItem.from("Second item"),
+    ListItem.styled("Styled item", Style.EMPTY.bold())
+);
+
+// Create state
+ListState state = new ListState();
+state.select(0);  // Select first item
+
+// Build and render
+ListWidget list = ListWidget.builder()
+    .items(items)
+    .highlightStyle(Style.EMPTY.reversed())
+    .highlightSymbol(">> ")
+    .block(Block.builder()
+        .title("Select an Item")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+list.render(area, buffer, state);
+----
+
+State methods:
+
+* `state.select(index)` - Select specific index
+* `state.selectNext(totalItems)` - Move selection down
+* `state.selectPrevious()` - Move selection up
+* `state.selectFirst()` - Jump to first item
+* `state.selectLast(totalItems)` - Jump to last item
+
+=== Table
+
+A data table with rows and columns:
+
+[source,java]
+----
+// Create table
+Table table = Table.builder()
+    .header(Row.from("Name", "Age", "City"))
+    .rows(
+        Row.from("Alice", "30", "NYC"),
+        Row.from("Bob", "25", "LA"),
+        Row.from("Charlie", "35", "Chicago")
+    )
+    .widths(
+        Constraint.percentage(40),
+        Constraint.length(10),
+        Constraint.fill()
+    )
+    .highlightStyle(Style.EMPTY.bg(Color.DARK_GRAY))
+    .block(Block.builder()
+        .title("Users")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+// Create and use state
+TableState state = new TableState();
+state.select(0);
+table.render(area, buffer, state);
+----
+
+=== Tabs
+
+A tab bar for navigation:
+
+[source,java]
+----
+Tabs tabs = Tabs.builder()
+    .titles("Home", "Settings", "About")
+    .highlightStyle(Style.EMPTY.bold().fg(Color.CYAN))
+    .divider(" | ")
+    .block(Block.builder()
+        .borders(Borders.BOTTOM)
+        .build())
+    .build();
+
+TabsState state = new TabsState();
+state.select(0);
+tabs.render(area, buffer, state);
+----
+
+== Data Visualization
+
+=== Gauge
+
+A progress bar showing completion percentage:
+
+[source,java]
+----
+Gauge gauge = Gauge.builder()
+    .ratio(0.75)  // 75% complete
+    .label("Loading...")
+    .gaugeStyle(Style.EMPTY.fg(Color.GREEN))
+    .block(Block.builder()
+        .title("Progress")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+gauge.render(area, buffer);
+----
+
+=== LineGauge
+
+A compact single-line progress indicator:
+
+[source,java]
+----
+LineGauge lineGauge = LineGauge.builder()
+    .ratio(0.5)
+    .label("50%")
+    .lineSet(LineSet.THICK)
+    .filledStyle(Style.EMPTY.fg(Color.CYAN))
+    .unfilledStyle(Style.EMPTY.fg(Color.DARK_GRAY))
+    .build();
+
+lineGauge.render(area, buffer);
+----
+
+=== Sparkline
+
+A mini chart showing data trends:
+
+[source,java]
+----
+int[] data = {1, 4, 2, 8, 5, 7, 3, 6};
+
+Sparkline sparkline = Sparkline.builder()
+    .data(data)
+    .barStyle(Style.EMPTY.fg(Color.CYAN))
+    .block(Block.builder()
+        .title("CPU Usage")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+sparkline.render(area, buffer);
+----
+
+=== BarChart
+
+Vertical bar chart for comparing values:
+
+[source,java]
+----
+BarChart barChart = BarChart.builder()
+    .bars(
+        Bar.builder().value(80).label("Mon").build(),
+        Bar.builder().value(95).label("Tue").build(),
+        Bar.builder().value(60).label("Wed").build(),
+        Bar.builder().value(75).label("Thu").build(),
+        Bar.builder().value(90).label("Fri").build()
+    )
+    .barWidth(5)
+    .barGap(1)
+    .barStyle(Style.EMPTY.fg(Color.GREEN))
+    .labelStyle(Style.EMPTY.dim())
+    .block(Block.builder()
+        .title("Weekly Sales")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+barChart.render(area, buffer);
+----
+
+=== Chart
+
+Line and scatter plots with axes:
+
+[source,java]
+----
+// Create datasets
+Dataset dataset1 = Dataset.builder()
+    .name("Series A")
+    .data(List.of(
+        new Point(0, 0),
+        new Point(1, 2),
+        new Point(2, 1),
+        new Point(3, 4),
+        new Point(4, 3)
+    ))
+    .marker(Marker.BRAILLE)
+    .graphStyle(Style.EMPTY.fg(Color.CYAN))
+    .build();
+
+// Build chart
+Chart chart = Chart.builder()
+    .datasets(dataset1)
+    .xAxis(Axis.builder()
+        .title("X Axis")
+        .bounds(0, 5)
+        .build())
+    .yAxis(Axis.builder()
+        .title("Y Axis")
+        .bounds(0, 5)
+        .build())
+    .block(Block.builder()
+        .title("Line Chart")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+chart.render(area, buffer);
+----
+
+Marker types:
+
+* `Marker.DOT` - Single dots
+* `Marker.BRAILLE` - Braille patterns for higher resolution
+* `Marker.BLOCK` - Block characters
+
+=== Canvas
+
+A drawing surface for custom graphics:
+
+[source,java]
+----
+Canvas canvas = Canvas.builder()
+    .xBounds(-10, 10)
+    .yBounds(-10, 10)
+    .marker(Marker.BRAILLE)
+    .paint(ctx -> {
+        // Draw shapes
+        ctx.draw(new Circle(0, 0, 5, Color.RED));
+        ctx.draw(new Line(-5, -5, 5, 5, Color.GREEN));
+        ctx.draw(new Rectangle(-3, -3, 6, 6, Color.BLUE));
+    })
+    .block(Block.builder()
+        .title("Drawing")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+canvas.render(area, buffer);
+----
+
+Available shapes:
+
+* `Circle` - Circle with center and radius
+* `Line` - Line between two points
+* `Rectangle` - Rectangle with position and size
+* `Points` - Collection of individual points
+
+=== Calendar
+
+A monthly calendar widget:
+
+[source,java]
+----
+Calendar calendar = Calendar.builder()
+    .date(LocalDate.now())
+    .showSurroundingMonths(true)
+    .dateStyle(date -> {
+        if (date.equals(LocalDate.now())) {
+            return Style.EMPTY.bold().fg(Color.CYAN);
+        }
+        return Style.EMPTY;
+    })
+    .block(Block.builder()
+        .title("Calendar")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+calendar.render(area, buffer);
+----
+
+== Input Widgets
+
+=== TextInput
+
+A single-line text input field:
+
+[source,java]
+----
+// Create state
+TextInputState state = new TextInputState();
+
+// Or with initial value
+TextInputState state = new TextInputState("initial text");
+
+// Build widget
+TextInput textInput = TextInput.builder()
+    .placeholder("Enter your name...")
+    .cursorStyle(Style.EMPTY.reversed())
+    .block(Block.builder()
+        .title("Name")
+        .borders(Borders.ALL)
+        .build())
+    .build();
+
+textInput.render(area, buffer, state);
+
+// Handle key events
+if (event.code() == KeyCode.CHAR) {
+    state.insert(event.character());
+} else if (event.code() == KeyCode.BACKSPACE) {
+    state.deleteBackward();
+} else if (event.code() == KeyCode.DELETE) {
+    state.deleteForward();
+} else if (event.code() == KeyCode.LEFT) {
+    state.moveCursorLeft();
+} else if (event.code() == KeyCode.RIGHT) {
+    state.moveCursorRight();
+}
+----
+
+State methods:
+
+* `state.text()` - Get current text
+* `state.setText(text)` - Set text
+* `state.insert(char)` - Insert character at cursor
+* `state.deleteBackward()` - Backspace
+* `state.deleteForward()` - Delete
+* `state.moveCursorLeft()` / `moveCursorRight()` - Move cursor
+* `state.clear()` - Clear all text
+
+== Utility Widgets
+
+=== Scrollbar
+
+Visual indicator of scroll position:
+
+[source,java]
+----
+Scrollbar scrollbar = Scrollbar.builder()
+    .orientation(ScrollbarOrientation.VERTICAL)
+    .thumbStyle(Style.EMPTY.fg(Color.CYAN))
+    .trackStyle(Style.EMPTY.fg(Color.DARK_GRAY))
+    .build();
+
+ScrollbarState state = new ScrollbarState();
+state.contentLength(100);
+state.viewportLength(20);
+state.position(scrollPosition);
+
+scrollbar.render(area, buffer, state);
+----
+
+== Using Widgets with Toolkit DSL
+
+The Toolkit DSL provides fluent factories for all widgets:
+
+[source,java]
+----
+import static dev.tamboui.toolkit.Toolkit.*;
+
+// Text
+text("Hello").bold().cyan()
+
+// Panel (Block)
+panel("Title", child1, child2).rounded().borderColor(Color.CYAN)
+
+// List
+list("Item 1", "Item 2", "Item 3").state(listState).highlightColor(Color.YELLOW)
+
+// Table
+table()
+    .header("Name", "Age")
+    .row("Alice", "30")
+    .state(tableState)
+
+// Gauge
+gauge(0.75).label("Loading...").gaugeColor(Color.GREEN)
+
+// Sparkline
+sparkline(1, 4, 2, 8, 5).color(Color.CYAN)
+
+// TextInput
+textInput(inputState).placeholder("Enter name...")
+
+// Layout
+row(left, right).spacing(1)
+column(top, middle, bottom).spacing(1)
+----
+
+See link:api-levels.html[API Levels] for more details on the Toolkit DSL.

--- a/docs/src/theme/highlight/highlight.min.js
+++ b/docs/src/theme/highlight/highlight.min.js
@@ -1,0 +1,1213 @@
+/*!
+  Highlight.js v11.9.0 (git: f47103d4f1)
+  (c) 2006-2023 undefined and other contributors
+  License: BSD-3-Clause
+ */
+var hljs=function(){"use strict";function e(n){
+return n instanceof Map?n.clear=n.delete=n.set=()=>{
+throw Error("map is read-only")}:n instanceof Set&&(n.add=n.clear=n.delete=()=>{
+throw Error("set is read-only")
+}),Object.freeze(n),Object.getOwnPropertyNames(n).forEach((t=>{
+const a=n[t],i=typeof a;"object"!==i&&"function"!==i||Object.isFrozen(a)||e(a)
+})),n}class n{constructor(e){
+void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
+ignoreMatch(){this.isMatchIgnored=!0}}function t(e){
+return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
+}function a(e,...n){const t=Object.create(null);for(const n in e)t[n]=e[n]
+;return n.forEach((e=>{for(const n in e)t[n]=e[n]})),t}const i=e=>!!e.scope
+;class r{constructor(e,n){
+this.buffer="",this.classPrefix=n.classPrefix,e.walk(this)}addText(e){
+this.buffer+=t(e)}openNode(e){if(!i(e))return;const n=((e,{prefix:n})=>{
+if(e.startsWith("language:"))return e.replace("language:","language-")
+;if(e.includes(".")){const t=e.split(".")
+;return[`${n}${t.shift()}`,...t.map(((e,n)=>`${e}${"_".repeat(n+1)}`))].join(" ")
+}return`${n}${e}`})(e.scope,{prefix:this.classPrefix});this.span(n)}
+closeNode(e){i(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
+this.buffer+=`<span class="${e}">`}}const s=(e={})=>{const n={children:[]}
+;return Object.assign(n,e),n};class o{constructor(){
+this.rootNode=s(),this.stack=[this.rootNode]}get top(){
+return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
+this.top.children.push(e)}openNode(e){const n=s({scope:e})
+;this.add(n),this.stack.push(n)}closeNode(){
+if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
+for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
+walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,n){
+return"string"==typeof n?e.addText(n):n.children&&(e.openNode(n),
+n.children.forEach((n=>this._walk(e,n))),e.closeNode(n)),e}static _collapse(e){
+"string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
+o._collapse(e)})))}}class l extends o{constructor(e){super(),this.options=e}
+addText(e){""!==e&&this.add(e)}startScope(e){this.openNode(e)}endScope(){
+this.closeNode()}__addSublanguage(e,n){const t=e.root
+;n&&(t.scope="language:"+n),this.add(t)}toHTML(){
+return new r(this,this.options).value()}finalize(){
+return this.closeAllNodes(),!0}}function c(e){
+return e?"string"==typeof e?e:e.source:null}function d(e){return b("(?=",e,")")}
+function g(e){return b("(?:",e,")*")}function u(e){return b("(?:",e,")?")}
+function b(...e){return e.map((e=>c(e))).join("")}function m(...e){const n=(e=>{
+const n=e[e.length-1]
+;return"object"==typeof n&&n.constructor===Object?(e.splice(e.length-1,1),n):{}
+})(e);return"("+(n.capture?"":"?:")+e.map((e=>c(e))).join("|")+")"}
+function p(e){return RegExp(e.toString()+"|").exec("").length-1}
+const _=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
+;function h(e,{joinWith:n}){let t=0;return e.map((e=>{t+=1;const n=t
+;let a=c(e),i="";for(;a.length>0;){const e=_.exec(a);if(!e){i+=a;break}
+i+=a.substring(0,e.index),
+a=a.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?i+="\\"+(Number(e[1])+n):(i+=e[0],
+"("===e[0]&&t++)}return i})).map((e=>`(${e})`)).join(n)}
+const f="[a-zA-Z]\\w*",E="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",N="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",w="\\b(0b[01]+)",v={
+begin:"\\\\[\\s\\S]",relevance:0},O={scope:"string",begin:"'",end:"'",
+illegal:"\\n",contains:[v]},k={scope:"string",begin:'"',end:'"',illegal:"\\n",
+contains:[v]},x=(e,n,t={})=>{const i=a({scope:"comment",begin:e,end:n,
+contains:[]},t);i.contains.push({scope:"doctag",
+begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
+end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
+;const r=m("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
+;return i.contains.push({begin:b(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i
+},M=x("//","$"),S=x("/\\*","\\*/"),A=x("#","$");var C=Object.freeze({
+__proto__:null,APOS_STRING_MODE:O,BACKSLASH_ESCAPE:v,BINARY_NUMBER_MODE:{
+scope:"number",begin:w,relevance:0},BINARY_NUMBER_RE:w,COMMENT:x,
+C_BLOCK_COMMENT_MODE:S,C_LINE_COMMENT_MODE:M,C_NUMBER_MODE:{scope:"number",
+begin:N,relevance:0},C_NUMBER_RE:N,END_SAME_AS_BEGIN:e=>Object.assign(e,{
+"on:begin":(e,n)=>{n.data._beginMatch=e[1]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}}),HASH_COMMENT_MODE:A,IDENT_RE:f,
+MATCH_NOTHING_RE:/\b\B/,METHOD_GUARD:{begin:"\\.\\s*"+E,relevance:0},
+NUMBER_MODE:{scope:"number",begin:y,relevance:0},NUMBER_RE:y,
+PHRASAL_WORDS_MODE:{
+begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+},QUOTE_STRING_MODE:k,REGEXP_MODE:{scope:"regexp",begin:/\/(?=[^/\n]*\/)/,
+end:/\/[gimuy]*/,contains:[v,{begin:/\[/,end:/\]/,relevance:0,contains:[v]}]},
+RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
+SHEBANG:(e={})=>{const n=/^#![ ]*\//
+;return e.binary&&(e.begin=b(n,/.*\b/,e.binary,/\b.*/)),a({scope:"meta",begin:n,
+end:/$/,relevance:0,"on:begin":(e,n)=>{0!==e.index&&n.ignoreMatch()}},e)},
+TITLE_MODE:{scope:"title",begin:f,relevance:0},UNDERSCORE_IDENT_RE:E,
+UNDERSCORE_TITLE_MODE:{scope:"title",begin:E,relevance:0}});function T(e,n){
+"."===e.input[e.index-1]&&n.ignoreMatch()}function R(e,n){
+void 0!==e.className&&(e.scope=e.className,delete e.className)}function D(e,n){
+n&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
+e.__beforeBegin=T,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
+void 0===e.relevance&&(e.relevance=0))}function I(e,n){
+Array.isArray(e.illegal)&&(e.illegal=m(...e.illegal))}function L(e,n){
+if(e.match){
+if(e.begin||e.end)throw Error("begin & end are not supported with match")
+;e.begin=e.match,delete e.match}}function B(e,n){
+void 0===e.relevance&&(e.relevance=1)}const $=(e,n)=>{if(!e.beforeMatch)return
+;if(e.starts)throw Error("beforeMatch cannot be used with starts")
+;const t=Object.assign({},e);Object.keys(e).forEach((n=>{delete e[n]
+})),e.keywords=t.keywords,e.begin=b(t.beforeMatch,d(t.begin)),e.starts={
+relevance:0,contains:[Object.assign(t,{endsParent:!0})]
+},e.relevance=0,delete t.beforeMatch
+},z=["of","and","for","in","not","or","if","then","parent","list","value"],F="keyword"
+;function U(e,n,t=F){const a=Object.create(null)
+;return"string"==typeof e?i(t,e.split(" ")):Array.isArray(e)?i(t,e):Object.keys(e).forEach((t=>{
+Object.assign(a,U(e[t],n,t))})),a;function i(e,t){
+n&&(t=t.map((e=>e.toLowerCase()))),t.forEach((n=>{const t=n.split("|")
+;a[t[0]]=[e,j(t[0],t[1])]}))}}function j(e,n){
+return n?Number(n):(e=>z.includes(e.toLowerCase()))(e)?0:1}const P={},K=e=>{
+console.error(e)},H=(e,...n)=>{console.log("WARN: "+e,...n)},q=(e,n)=>{
+P[`${e}/${n}`]||(console.log(`Deprecated as of ${e}. ${n}`),P[`${e}/${n}`]=!0)
+},G=Error();function Z(e,n,{key:t}){let a=0;const i=e[t],r={},s={}
+;for(let e=1;e<=n.length;e++)s[e+a]=i[e],r[e+a]=!0,a+=p(n[e-1])
+;e[t]=s,e[t]._emit=r,e[t]._multi=!0}function W(e){(e=>{
+e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
+delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
+_wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
+}),(e=>{if(Array.isArray(e.begin)){
+if(e.skip||e.excludeBegin||e.returnBegin)throw K("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
+G
+;if("object"!=typeof e.beginScope||null===e.beginScope)throw K("beginScope must be object"),
+G;Z(e,e.begin,{key:"beginScope"}),e.begin=h(e.begin,{joinWith:""})}})(e),(e=>{
+if(Array.isArray(e.end)){
+if(e.skip||e.excludeEnd||e.returnEnd)throw K("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
+G
+;if("object"!=typeof e.endScope||null===e.endScope)throw K("endScope must be object"),
+G;Z(e,e.end,{key:"endScope"}),e.end=h(e.end,{joinWith:""})}})(e)}function Q(e){
+function n(n,t){
+return RegExp(c(n),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(t?"g":""))
+}class t{constructor(){
+this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
+addRule(e,n){
+n.position=this.position++,this.matchIndexes[this.matchAt]=n,this.regexes.push([n,e]),
+this.matchAt+=p(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
+;const e=this.regexes.map((e=>e[1]));this.matcherRe=n(h(e,{joinWith:"|"
+}),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
+;const n=this.matcherRe.exec(e);if(!n)return null
+;const t=n.findIndex(((e,n)=>n>0&&void 0!==e)),a=this.matchIndexes[t]
+;return n.splice(0,t),Object.assign(n,a)}}class i{constructor(){
+this.rules=[],this.multiRegexes=[],
+this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
+if(this.multiRegexes[e])return this.multiRegexes[e];const n=new t
+;return this.rules.slice(e).forEach((([e,t])=>n.addRule(e,t))),
+n.compile(),this.multiRegexes[e]=n,n}resumingScanAtSamePosition(){
+return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,n){
+this.rules.push([e,n]),"begin"===n.type&&this.count++}exec(e){
+const n=this.getMatcher(this.regexIndex);n.lastIndex=this.lastIndex
+;let t=n.exec(e)
+;if(this.resumingScanAtSamePosition())if(t&&t.index===this.lastIndex);else{
+const n=this.getMatcher(0);n.lastIndex=this.lastIndex+1,t=n.exec(e)}
+return t&&(this.regexIndex+=t.position+1,
+this.regexIndex===this.count&&this.considerAll()),t}}
+if(e.compilerExtensions||(e.compilerExtensions=[]),
+e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
+;return e.classNameAliases=a(e.classNameAliases||{}),function t(r,s){const o=r
+;if(r.isCompiled)return o
+;[R,L,W,$].forEach((e=>e(r,s))),e.compilerExtensions.forEach((e=>e(r,s))),
+r.__beforeBegin=null,[D,I,B].forEach((e=>e(r,s))),r.isCompiled=!0;let l=null
+;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
+l=r.keywords.$pattern,
+delete r.keywords.$pattern),l=l||/\w+/,r.keywords&&(r.keywords=U(r.keywords,e.case_insensitive)),
+o.keywordPatternRe=n(l,!0),
+s&&(r.begin||(r.begin=/\B|\b/),o.beginRe=n(o.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
+r.end&&(o.endRe=n(o.end)),
+o.terminatorEnd=c(o.end)||"",r.endsWithParent&&s.terminatorEnd&&(o.terminatorEnd+=(r.end?"|":"")+s.terminatorEnd)),
+r.illegal&&(o.illegalRe=n(r.illegal)),
+r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((n=>a(e,{
+variants:null},n)))),e.cachedVariants?e.cachedVariants:X(e)?a(e,{
+starts:e.starts?a(e.starts):null
+}):Object.isFrozen(e)?a(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{t(e,o)
+})),r.starts&&t(r.starts,s),o.matcher=(e=>{const n=new i
+;return e.contains.forEach((e=>n.addRule(e.begin,{rule:e,type:"begin"
+}))),e.terminatorEnd&&n.addRule(e.terminatorEnd,{type:"end"
+}),e.illegal&&n.addRule(e.illegal,{type:"illegal"}),n})(o),o}(e)}function X(e){
+return!!e&&(e.endsWithParent||X(e.starts))}class V extends Error{
+constructor(e,n){super(e),this.name="HTMLInjectionError",this.html=n}}
+const J=t,Y=a,ee=Symbol("nomatch"),ne=t=>{
+const a=Object.create(null),i=Object.create(null),r=[];let s=!0
+;const o="Could not find the language '{}', did you forget to load/include a language module?",c={
+disableAutodetect:!0,name:"Plain text",contains:[]};let p={
+ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
+languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
+cssSelector:"pre code",languages:null,__emitter:l};function _(e){
+return p.noHighlightRe.test(e)}function h(e,n,t){let a="",i=""
+;"object"==typeof n?(a=e,
+t=n.ignoreIllegals,i=n.language):(q("10.7.0","highlight(lang, code, ...args) has been deprecated."),
+q("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
+i=e,a=n),void 0===t&&(t=!0);const r={code:a,language:i};x("before:highlight",r)
+;const s=r.result?r.result:f(r.language,r.code,t)
+;return s.code=r.code,x("after:highlight",s),s}function f(e,t,i,r){
+const l=Object.create(null);function c(){if(!x.keywords)return void S.addText(A)
+;let e=0;x.keywordPatternRe.lastIndex=0;let n=x.keywordPatternRe.exec(A),t=""
+;for(;n;){t+=A.substring(e,n.index)
+;const i=w.case_insensitive?n[0].toLowerCase():n[0],r=(a=i,x.keywords[a]);if(r){
+const[e,a]=r
+;if(S.addText(t),t="",l[i]=(l[i]||0)+1,l[i]<=7&&(C+=a),e.startsWith("_"))t+=n[0];else{
+const t=w.classNameAliases[e]||e;g(n[0],t)}}else t+=n[0]
+;e=x.keywordPatternRe.lastIndex,n=x.keywordPatternRe.exec(A)}var a
+;t+=A.substring(e),S.addText(t)}function d(){null!=x.subLanguage?(()=>{
+if(""===A)return;let e=null;if("string"==typeof x.subLanguage){
+if(!a[x.subLanguage])return void S.addText(A)
+;e=f(x.subLanguage,A,!0,M[x.subLanguage]),M[x.subLanguage]=e._top
+}else e=E(A,x.subLanguage.length?x.subLanguage:null)
+;x.relevance>0&&(C+=e.relevance),S.__addSublanguage(e._emitter,e.language)
+})():c(),A=""}function g(e,n){
+""!==e&&(S.startScope(n),S.addText(e),S.endScope())}function u(e,n){let t=1
+;const a=n.length-1;for(;t<=a;){if(!e._emit[t]){t++;continue}
+const a=w.classNameAliases[e[t]]||e[t],i=n[t];a?g(i,a):(A=i,c(),A=""),t++}}
+function b(e,n){
+return e.scope&&"string"==typeof e.scope&&S.openNode(w.classNameAliases[e.scope]||e.scope),
+e.beginScope&&(e.beginScope._wrap?(g(A,w.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
+A=""):e.beginScope._multi&&(u(e.beginScope,n),A="")),x=Object.create(e,{parent:{
+value:x}}),x}function m(e,t,a){let i=((e,n)=>{const t=e&&e.exec(n)
+;return t&&0===t.index})(e.endRe,a);if(i){if(e["on:end"]){const a=new n(e)
+;e["on:end"](t,a),a.isMatchIgnored&&(i=!1)}if(i){
+for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+if(e.endsWithParent)return m(e.parent,t,a)}function _(e){
+return 0===x.matcher.regexIndex?(A+=e[0],1):(D=!0,0)}function h(e){
+const n=e[0],a=t.substring(e.index),i=m(x,e,a);if(!i)return ee;const r=x
+;x.endScope&&x.endScope._wrap?(d(),
+g(n,x.endScope._wrap)):x.endScope&&x.endScope._multi?(d(),
+u(x.endScope,e)):r.skip?A+=n:(r.returnEnd||r.excludeEnd||(A+=n),
+d(),r.excludeEnd&&(A=n));do{
+x.scope&&S.closeNode(),x.skip||x.subLanguage||(C+=x.relevance),x=x.parent
+}while(x!==i.parent);return i.starts&&b(i.starts,e),r.returnEnd?0:n.length}
+let y={};function N(a,r){const o=r&&r[0];if(A+=a,null==o)return d(),0
+;if("begin"===y.type&&"end"===r.type&&y.index===r.index&&""===o){
+if(A+=t.slice(r.index,r.index+1),!s){const n=Error(`0 width match regex (${e})`)
+;throw n.languageName=e,n.badRule=y.rule,n}return 1}
+if(y=r,"begin"===r.type)return(e=>{
+const t=e[0],a=e.rule,i=new n(a),r=[a.__beforeBegin,a["on:begin"]]
+;for(const n of r)if(n&&(n(e,i),i.isMatchIgnored))return _(t)
+;return a.skip?A+=t:(a.excludeBegin&&(A+=t),
+d(),a.returnBegin||a.excludeBegin||(A=t)),b(a,e),a.returnBegin?0:t.length})(r)
+;if("illegal"===r.type&&!i){
+const e=Error('Illegal lexeme "'+o+'" for mode "'+(x.scope||"<unnamed>")+'"')
+;throw e.mode=x,e}if("end"===r.type){const e=h(r);if(e!==ee)return e}
+if("illegal"===r.type&&""===o)return 1
+;if(R>1e5&&R>3*r.index)throw Error("potential infinite loop, way more iterations than matches")
+;return A+=o,o.length}const w=v(e)
+;if(!w)throw K(o.replace("{}",e)),Error('Unknown language: "'+e+'"')
+;const O=Q(w);let k="",x=r||O;const M={},S=new p.__emitter(p);(()=>{const e=[]
+;for(let n=x;n!==w;n=n.parent)n.scope&&e.unshift(n.scope)
+;e.forEach((e=>S.openNode(e)))})();let A="",C=0,T=0,R=0,D=!1;try{
+if(w.__emitTokens)w.__emitTokens(t,S);else{for(x.matcher.considerAll();;){
+R++,D?D=!1:x.matcher.considerAll(),x.matcher.lastIndex=T
+;const e=x.matcher.exec(t);if(!e)break;const n=N(t.substring(T,e.index),e)
+;T=e.index+n}N(t.substring(T))}return S.finalize(),k=S.toHTML(),{language:e,
+value:k,relevance:C,illegal:!1,_emitter:S,_top:x}}catch(n){
+if(n.message&&n.message.includes("Illegal"))return{language:e,value:J(t),
+illegal:!0,relevance:0,_illegalBy:{message:n.message,index:T,
+context:t.slice(T-100,T+100),mode:n.mode,resultSoFar:k},_emitter:S};if(s)return{
+language:e,value:J(t),illegal:!1,relevance:0,errorRaised:n,_emitter:S,_top:x}
+;throw n}}function E(e,n){n=n||p.languages||Object.keys(a);const t=(e=>{
+const n={value:J(e),illegal:!1,relevance:0,_top:c,_emitter:new p.__emitter(p)}
+;return n._emitter.addText(e),n})(e),i=n.filter(v).filter(k).map((n=>f(n,e,!1)))
+;i.unshift(t);const r=i.sort(((e,n)=>{
+if(e.relevance!==n.relevance)return n.relevance-e.relevance
+;if(e.language&&n.language){if(v(e.language).supersetOf===n.language)return 1
+;if(v(n.language).supersetOf===e.language)return-1}return 0})),[s,o]=r,l=s
+;return l.secondBest=o,l}function y(e){let n=null;const t=(e=>{
+let n=e.className+" ";n+=e.parentNode?e.parentNode.className:""
+;const t=p.languageDetectRe.exec(n);if(t){const n=v(t[1])
+;return n||(H(o.replace("{}",t[1])),
+H("Falling back to no-highlight mode for this block.",e)),n?t[1]:"no-highlight"}
+return n.split(/\s+/).find((e=>_(e)||v(e)))})(e);if(_(t))return
+;if(x("before:highlightElement",{el:e,language:t
+}),e.dataset.highlighted)return void console.log("Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",e)
+;if(e.children.length>0&&(p.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
+console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
+console.warn("The element with unescaped HTML:"),
+console.warn(e)),p.throwUnescapedHTML))throw new V("One of your code blocks includes unescaped HTML.",e.innerHTML)
+;n=e;const a=n.textContent,r=t?h(a,{language:t,ignoreIllegals:!0}):E(a)
+;e.innerHTML=r.value,e.dataset.highlighted="yes",((e,n,t)=>{const a=n&&i[n]||t
+;e.classList.add("hljs"),e.classList.add("language-"+a)
+})(e,t,r.language),e.result={language:r.language,re:r.relevance,
+relevance:r.relevance},r.secondBest&&(e.secondBest={
+language:r.secondBest.language,relevance:r.secondBest.relevance
+}),x("after:highlightElement",{el:e,result:r,text:a})}let N=!1;function w(){
+"loading"!==document.readyState?document.querySelectorAll(p.cssSelector).forEach(y):N=!0
+}function v(e){return e=(e||"").toLowerCase(),a[e]||a[i[e]]}
+function O(e,{languageName:n}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+i[e.toLowerCase()]=n}))}function k(e){const n=v(e)
+;return n&&!n.disableAutodetect}function x(e,n){const t=e;r.forEach((e=>{
+e[t]&&e[t](n)}))}
+"undefined"!=typeof window&&window.addEventListener&&window.addEventListener("DOMContentLoaded",(()=>{
+N&&w()}),!1),Object.assign(t,{highlight:h,highlightAuto:E,highlightAll:w,
+highlightElement:y,
+highlightBlock:e=>(q("10.7.0","highlightBlock will be removed entirely in v12.0"),
+q("10.7.0","Please use highlightElement now."),y(e)),configure:e=>{p=Y(p,e)},
+initHighlighting:()=>{
+w(),q("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
+initHighlightingOnLoad:()=>{
+w(),q("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
+},registerLanguage:(e,n)=>{let i=null;try{i=n(t)}catch(n){
+if(K("Language definition for '{}' could not be registered.".replace("{}",e)),
+!s)throw n;K(n),i=c}
+i.name||(i.name=e),a[e]=i,i.rawDefinition=n.bind(null,t),i.aliases&&O(i.aliases,{
+languageName:e})},unregisterLanguage:e=>{delete a[e]
+;for(const n of Object.keys(i))i[n]===e&&delete i[n]},
+listLanguages:()=>Object.keys(a),getLanguage:v,registerAliases:O,
+autoDetection:k,inherit:Y,addPlugin:e=>{(e=>{
+e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=n=>{
+e["before:highlightBlock"](Object.assign({block:n.el},n))
+}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=n=>{
+e["after:highlightBlock"](Object.assign({block:n.el},n))})})(e),r.push(e)},
+removePlugin:e=>{const n=r.indexOf(e);-1!==n&&r.splice(n,1)}}),t.debugMode=()=>{
+s=!1},t.safeMode=()=>{s=!0},t.versionString="11.9.0",t.regex={concat:b,
+lookahead:d,either:m,optional:u,anyNumberOfTimes:g}
+;for(const n in C)"object"==typeof C[n]&&e(C[n]);return Object.assign(t,C),t
+},te=ne({});te.newInstance=()=>ne({});var ae=te;const ie=e=>({IMPORTANT:{
+scope:"meta",begin:"!important"},BLOCK_COMMENT:e.C_BLOCK_COMMENT_MODE,HEXCOLOR:{
+scope:"number",begin:/#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/},
+FUNCTION_DISPATCH:{className:"built_in",begin:/[\w-]+(?=\()/},
+ATTRIBUTE_SELECTOR_MODE:{scope:"selector-attr",begin:/\[/,end:/\]/,illegal:"$",
+contains:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},CSS_NUMBER_MODE:{
+scope:"number",
+begin:e.NUMBER_RE+"(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+relevance:0},CSS_VARIABLE:{className:"attr",begin:/--[A-Za-z_][A-Za-z0-9_-]*/}
+}),re=["a","abbr","address","article","aside","audio","b","blockquote","body","button","canvas","caption","cite","code","dd","del","details","dfn","div","dl","dt","em","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","html","i","iframe","img","input","ins","kbd","label","legend","li","main","mark","menu","nav","object","ol","p","q","quote","samp","section","span","strong","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","ul","var","video"],se=["any-hover","any-pointer","aspect-ratio","color","color-gamut","color-index","device-aspect-ratio","device-height","device-width","display-mode","forced-colors","grid","height","hover","inverted-colors","monochrome","orientation","overflow-block","overflow-inline","pointer","prefers-color-scheme","prefers-contrast","prefers-reduced-motion","prefers-reduced-transparency","resolution","scan","scripting","update","width","min-width","max-width","min-height","max-height"],oe=["active","any-link","blank","checked","current","default","defined","dir","disabled","drop","empty","enabled","first","first-child","first-of-type","fullscreen","future","focus","focus-visible","focus-within","has","host","host-context","hover","indeterminate","in-range","invalid","is","lang","last-child","last-of-type","left","link","local-link","not","nth-child","nth-col","nth-last-child","nth-last-col","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","past","placeholder-shown","read-only","read-write","required","right","root","scope","target","target-within","user-invalid","valid","visited","where"],le=["after","backdrop","before","cue","cue-region","first-letter","first-line","grammar-error","marker","part","placeholder","selection","slotted","spelling-error"],ce=["align-content","align-items","align-self","all","animation","animation-delay","animation-direction","animation-duration","animation-fill-mode","animation-iteration-count","animation-name","animation-play-state","animation-timing-function","backface-visibility","background","background-attachment","background-blend-mode","background-clip","background-color","background-image","background-origin","background-position","background-repeat","background-size","block-size","border","border-block","border-block-color","border-block-end","border-block-end-color","border-block-end-style","border-block-end-width","border-block-start","border-block-start-color","border-block-start-style","border-block-start-width","border-block-style","border-block-width","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-style","border-bottom-width","border-collapse","border-color","border-image","border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width","border-inline","border-inline-color","border-inline-end","border-inline-end-color","border-inline-end-style","border-inline-end-width","border-inline-start","border-inline-start-color","border-inline-start-style","border-inline-start-width","border-inline-style","border-inline-width","border-left","border-left-color","border-left-style","border-left-width","border-radius","border-right","border-right-color","border-right-style","border-right-width","border-spacing","border-style","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-style","border-top-width","border-width","bottom","box-decoration-break","box-shadow","box-sizing","break-after","break-before","break-inside","caption-side","caret-color","clear","clip","clip-path","clip-rule","color","column-count","column-fill","column-gap","column-rule","column-rule-color","column-rule-style","column-rule-width","column-span","column-width","columns","contain","content","content-visibility","counter-increment","counter-reset","cue","cue-after","cue-before","cursor","direction","display","empty-cells","filter","flex","flex-basis","flex-direction","flex-flow","flex-grow","flex-shrink","flex-wrap","float","flow","font","font-display","font-family","font-feature-settings","font-kerning","font-language-override","font-size","font-size-adjust","font-smoothing","font-stretch","font-style","font-synthesis","font-variant","font-variant-caps","font-variant-east-asian","font-variant-ligatures","font-variant-numeric","font-variant-position","font-variation-settings","font-weight","gap","glyph-orientation-vertical","grid","grid-area","grid-auto-columns","grid-auto-flow","grid-auto-rows","grid-column","grid-column-end","grid-column-start","grid-gap","grid-row","grid-row-end","grid-row-start","grid-template","grid-template-areas","grid-template-columns","grid-template-rows","hanging-punctuation","height","hyphens","icon","image-orientation","image-rendering","image-resolution","ime-mode","inline-size","isolation","justify-content","left","letter-spacing","line-break","line-height","list-style","list-style-image","list-style-position","list-style-type","margin","margin-block","margin-block-end","margin-block-start","margin-bottom","margin-inline","margin-inline-end","margin-inline-start","margin-left","margin-right","margin-top","marks","mask","mask-border","mask-border-mode","mask-border-outset","mask-border-repeat","mask-border-slice","mask-border-source","mask-border-width","mask-clip","mask-composite","mask-image","mask-mode","mask-origin","mask-position","mask-repeat","mask-size","mask-type","max-block-size","max-height","max-inline-size","max-width","min-block-size","min-height","min-inline-size","min-width","mix-blend-mode","nav-down","nav-index","nav-left","nav-right","nav-up","none","normal","object-fit","object-position","opacity","order","orphans","outline","outline-color","outline-offset","outline-style","outline-width","overflow","overflow-wrap","overflow-x","overflow-y","padding","padding-block","padding-block-end","padding-block-start","padding-bottom","padding-inline","padding-inline-end","padding-inline-start","padding-left","padding-right","padding-top","page-break-after","page-break-before","page-break-inside","pause","pause-after","pause-before","perspective","perspective-origin","pointer-events","position","quotes","resize","rest","rest-after","rest-before","right","row-gap","scroll-margin","scroll-margin-block","scroll-margin-block-end","scroll-margin-block-start","scroll-margin-bottom","scroll-margin-inline","scroll-margin-inline-end","scroll-margin-inline-start","scroll-margin-left","scroll-margin-right","scroll-margin-top","scroll-padding","scroll-padding-block","scroll-padding-block-end","scroll-padding-block-start","scroll-padding-bottom","scroll-padding-inline","scroll-padding-inline-end","scroll-padding-inline-start","scroll-padding-left","scroll-padding-right","scroll-padding-top","scroll-snap-align","scroll-snap-stop","scroll-snap-type","scrollbar-color","scrollbar-gutter","scrollbar-width","shape-image-threshold","shape-margin","shape-outside","speak","speak-as","src","tab-size","table-layout","text-align","text-align-all","text-align-last","text-combine-upright","text-decoration","text-decoration-color","text-decoration-line","text-decoration-style","text-emphasis","text-emphasis-color","text-emphasis-position","text-emphasis-style","text-indent","text-justify","text-orientation","text-overflow","text-rendering","text-shadow","text-transform","text-underline-position","top","transform","transform-box","transform-origin","transform-style","transition","transition-delay","transition-duration","transition-property","transition-timing-function","unicode-bidi","vertical-align","visibility","voice-balance","voice-duration","voice-family","voice-pitch","voice-range","voice-rate","voice-stress","voice-volume","white-space","widows","width","will-change","word-break","word-spacing","word-wrap","writing-mode","z-index"].reverse(),de=oe.concat(le)
+;var ge="[0-9](_*[0-9])*",ue=`\\.(${ge})`,be="[0-9a-fA-F](_*[0-9a-fA-F])*",me={
+className:"number",variants:[{
+begin:`(\\b(${ge})((${ue})|\\.)?|(${ue}))[eE][+-]?(${ge})[fFdD]?\\b`},{
+begin:`\\b(${ge})((${ue})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{
+begin:`(${ue})[fFdD]?\\b`},{begin:`\\b(${ge})[fFdD]\\b`},{
+begin:`\\b0[xX]((${be})\\.?|(${be})?\\.(${be}))[pP][+-]?(${ge})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${be})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};function pe(e,n,t){return-1===t?"":e.replace(n,(a=>pe(e,n,t-1)))}
+const _e="[A-Za-z$_][0-9A-Za-z$_]*",he=["as","in","of","if","for","while","finally","var","new","function","do","return","void","else","break","catch","instanceof","with","throw","case","default","try","switch","continue","typeof","delete","let","yield","const","class","debugger","async","await","static","import","from","export","extends"],fe=["true","false","null","undefined","NaN","Infinity"],Ee=["Object","Function","Boolean","Symbol","Math","Date","Number","BigInt","String","RegExp","Array","Float32Array","Float64Array","Int8Array","Uint8Array","Uint8ClampedArray","Int16Array","Int32Array","Uint16Array","Uint32Array","BigInt64Array","BigUint64Array","Set","Map","WeakSet","WeakMap","ArrayBuffer","SharedArrayBuffer","Atomics","DataView","JSON","Promise","Generator","GeneratorFunction","AsyncFunction","Reflect","Proxy","Intl","WebAssembly"],ye=["Error","EvalError","InternalError","RangeError","ReferenceError","SyntaxError","TypeError","URIError"],Ne=["setInterval","setTimeout","clearInterval","clearTimeout","require","exports","eval","isFinite","isNaN","parseFloat","parseInt","decodeURI","decodeURIComponent","encodeURI","encodeURIComponent","escape","unescape"],we=["arguments","this","super","console","window","document","localStorage","sessionStorage","module","global"],ve=[].concat(Ne,Ee,ye)
+;function Oe(e){const n=e.regex,t=_e,a={begin:/<[A-Za-z0-9\\._:-]+/,
+end:/\/[A-Za-z0-9\\._:-]+>|\/>/,isTrulyOpeningTag:(e,n)=>{
+const t=e[0].length+e.index,a=e.input[t]
+;if("<"===a||","===a)return void n.ignoreMatch();let i
+;">"===a&&(((e,{after:n})=>{const t="</"+e[0].slice(1)
+;return-1!==e.input.indexOf(t,n)})(e,{after:t})||n.ignoreMatch())
+;const r=e.input.substring(t)
+;((i=r.match(/^\s*=/))||(i=r.match(/^\s+extends\s+/))&&0===i.index)&&n.ignoreMatch()
+}},i={$pattern:_e,keyword:he,literal:fe,built_in:ve,"variable.language":we
+},r="[0-9](_?[0-9])*",s=`\\.(${r})`,o="0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",l={
+className:"number",variants:[{
+begin:`(\\b(${o})((${s})|\\.)?|(${s}))[eE][+-]?(${r})\\b`},{
+begin:`\\b(${o})\\b((${s})\\b|\\.)?|(${s})\\b`},{
+begin:"\\b(0|[1-9](_?[0-9])*)n\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b"},{
+begin:"\\b0[bB][0-1](_?[0-1])*n?\\b"},{begin:"\\b0[oO][0-7](_?[0-7])*n?\\b"},{
+begin:"\\b0[0-7]+n?\\b"}],relevance:0},c={className:"subst",begin:"\\$\\{",
+end:"\\}",keywords:i,contains:[]},d={begin:"html`",end:"",starts:{end:"`",
+returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"xml"}},g={
+begin:"css`",end:"",starts:{end:"`",returnEnd:!1,
+contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"css"}},u={begin:"gql`",end:"",
+starts:{end:"`",returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],
+subLanguage:"graphql"}},b={className:"string",begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE,c]},m={className:"comment",
+variants:[e.COMMENT(/\/\*\*(?!\/)/,"\\*/",{relevance:0,contains:[{
+begin:"(?=@[A-Za-z]+)",relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"},{className:"type",begin:"\\{",end:"\\}",excludeEnd:!0,
+excludeBegin:!0,relevance:0},{className:"variable",begin:t+"(?=\\s*(-)|$)",
+endsParent:!0,relevance:0},{begin:/(?=[^\n])\s/,relevance:0}]}]
+}),e.C_BLOCK_COMMENT_MODE,e.C_LINE_COMMENT_MODE]
+},p=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,{match:/\$\d+/},l]
+;c.contains=p.concat({begin:/\{/,end:/\}/,keywords:i,contains:["self"].concat(p)
+});const _=[].concat(m,c.contains),h=_.concat([{begin:/\(/,end:/\)/,keywords:i,
+contains:["self"].concat(_)}]),f={className:"params",begin:/\(/,end:/\)/,
+excludeBegin:!0,excludeEnd:!0,keywords:i,contains:h},E={variants:[{
+match:[/class/,/\s+/,t,/\s+/,/extends/,/\s+/,n.concat(t,"(",n.concat(/\./,t),")*")],
+scope:{1:"keyword",3:"title.class",5:"keyword",7:"title.class.inherited"}},{
+match:[/class/,/\s+/,t],scope:{1:"keyword",3:"title.class"}}]},y={relevance:0,
+match:n.either(/\bJSON/,/\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,/\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,/\b[A-Z]{2,}[a-z]+([A-Z][a-z]+|\d)*([A-Z][a-z]*)*/),
+className:"title.class",keywords:{_:[...Ee,...ye]}},N={variants:[{
+match:[/function/,/\s+/,t,/(?=\s*\()/]},{match:[/function/,/\s*(?=\()/]}],
+className:{1:"keyword",3:"title.function"},label:"func.def",contains:[f],
+illegal:/%/},w={
+match:n.concat(/\b/,(v=[...Ne,"super","import"],n.concat("(?!",v.join("|"),")")),t,n.lookahead(/\(/)),
+className:"title.function",relevance:0};var v;const O={
+begin:n.concat(/\./,n.lookahead(n.concat(t,/(?![0-9A-Za-z$_(])/))),end:t,
+excludeBegin:!0,keywords:"prototype",className:"property",relevance:0},k={
+match:[/get|set/,/\s+/,t,/(?=\()/],className:{1:"keyword",3:"title.function"},
+contains:[{begin:/\(\)/},f]
+},x="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+e.UNDERSCORE_IDENT_RE+")\\s*=>",M={
+match:[/const|var|let/,/\s+/,t,/\s*/,/=\s*/,/(async\s*)?/,n.lookahead(x)],
+keywords:"async",className:{1:"keyword",3:"title.function"},contains:[f]}
+;return{name:"JavaScript",aliases:["js","jsx","mjs","cjs"],keywords:i,exports:{
+PARAMS_CONTAINS:h,CLASS_REFERENCE:y},illegal:/#(?![$_A-z])/,
+contains:[e.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
+label:"use_strict",className:"meta",relevance:10,
+begin:/^\s*['"]use (strict|asm)['"]/
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,m,{match:/\$\d+/},l,y,{
+className:"attr",begin:t+n.lookahead(":"),relevance:0},M,{
+begin:"("+e.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
+keywords:"return throw case",relevance:0,contains:[m,e.REGEXP_MODE,{
+className:"function",begin:x,returnBegin:!0,end:"\\s*=>",contains:[{
+className:"params",variants:[{begin:e.UNDERSCORE_IDENT_RE,relevance:0},{
+className:null,begin:/\(\s*\)/,skip:!0},{begin:/\(/,end:/\)/,excludeBegin:!0,
+excludeEnd:!0,keywords:i,contains:h}]}]},{begin:/,/,relevance:0},{match:/\s+/,
+relevance:0},{variants:[{begin:"<>",end:"</>"},{
+match:/<[A-Za-z0-9\\._:-]+\s*\/>/},{begin:a.begin,
+"on:begin":a.isTrulyOpeningTag,end:a.end}],subLanguage:"xml",contains:[{
+begin:a.begin,end:a.end,skip:!0,contains:["self"]}]}]},N,{
+beginKeywords:"while if switch catch for"},{
+begin:"\\b(?!function)"+e.UNDERSCORE_IDENT_RE+"\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
+returnBegin:!0,label:"func.def",contains:[f,e.inherit(e.TITLE_MODE,{begin:t,
+className:"title.function"})]},{match:/\.\.\./,relevance:0},O,{match:"\\$"+t,
+relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
+contains:[f]},w,{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},E,k,{match:/\$[(.]/}]}}
+const ke=e=>b(/\b/,e,/\w$/.test(e)?/\b/:/\B/),xe=["Protocol","Type"].map(ke),Me=["init","self"].map(ke),Se=["Any","Self"],Ae=["actor","any","associatedtype","async","await",/as\?/,/as!/,"as","borrowing","break","case","catch","class","consume","consuming","continue","convenience","copy","default","defer","deinit","didSet","distributed","do","dynamic","each","else","enum","extension","fallthrough",/fileprivate\(set\)/,"fileprivate","final","for","func","get","guard","if","import","indirect","infix",/init\?/,/init!/,"inout",/internal\(set\)/,"internal","in","is","isolated","nonisolated","lazy","let","macro","mutating","nonmutating",/open\(set\)/,"open","operator","optional","override","postfix","precedencegroup","prefix",/private\(set\)/,"private","protocol",/public\(set\)/,"public","repeat","required","rethrows","return","set","some","static","struct","subscript","super","switch","throws","throw",/try\?/,/try!/,"try","typealias",/unowned\(safe\)/,/unowned\(unsafe\)/,"unowned","var","weak","where","while","willSet"],Ce=["false","nil","true"],Te=["assignment","associativity","higherThan","left","lowerThan","none","right"],Re=["#colorLiteral","#column","#dsohandle","#else","#elseif","#endif","#error","#file","#fileID","#fileLiteral","#filePath","#function","#if","#imageLiteral","#keyPath","#line","#selector","#sourceLocation","#warning"],De=["abs","all","any","assert","assertionFailure","debugPrint","dump","fatalError","getVaList","isKnownUniquelyReferenced","max","min","numericCast","pointwiseMax","pointwiseMin","precondition","preconditionFailure","print","readLine","repeatElement","sequence","stride","swap","swift_unboxFromSwiftValueWithType","transcode","type","unsafeBitCast","unsafeDowncast","withExtendedLifetime","withUnsafeMutablePointer","withUnsafePointer","withVaList","withoutActuallyEscaping","zip"],Ie=m(/[/=\-+!*%<>&|^~?]/,/[\u00A1-\u00A7]/,/[\u00A9\u00AB]/,/[\u00AC\u00AE]/,/[\u00B0\u00B1]/,/[\u00B6\u00BB\u00BF\u00D7\u00F7]/,/[\u2016-\u2017]/,/[\u2020-\u2027]/,/[\u2030-\u203E]/,/[\u2041-\u2053]/,/[\u2055-\u205E]/,/[\u2190-\u23FF]/,/[\u2500-\u2775]/,/[\u2794-\u2BFF]/,/[\u2E00-\u2E7F]/,/[\u3001-\u3003]/,/[\u3008-\u3020]/,/[\u3030]/),Le=m(Ie,/[\u0300-\u036F]/,/[\u1DC0-\u1DFF]/,/[\u20D0-\u20FF]/,/[\uFE00-\uFE0F]/,/[\uFE20-\uFE2F]/),Be=b(Ie,Le,"*"),$e=m(/[a-zA-Z_]/,/[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,/[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,/[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,/[\u1E00-\u1FFF]/,/[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,/[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,/[\u2C00-\u2DFF\u2E80-\u2FFF]/,/[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,/[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,/[\uFE47-\uFEFE\uFF00-\uFFFD]/),ze=m($e,/\d/,/[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),Fe=b($e,ze,"*"),Ue=b(/[A-Z]/,ze,"*"),je=["attached","autoclosure",b(/convention\(/,m("swift","block","c"),/\)/),"discardableResult","dynamicCallable","dynamicMemberLookup","escaping","freestanding","frozen","GKInspectable","IBAction","IBDesignable","IBInspectable","IBOutlet","IBSegueAction","inlinable","main","nonobjc","NSApplicationMain","NSCopying","NSManaged",b(/objc\(/,Fe,/\)/),"objc","objcMembers","propertyWrapper","requires_stored_property_inits","resultBuilder","Sendable","testable","UIApplicationMain","unchecked","unknown","usableFromInline","warn_unqualified_access"],Pe=["iOS","iOSApplicationExtension","macOS","macOSApplicationExtension","macCatalyst","macCatalystApplicationExtension","watchOS","watchOSApplicationExtension","tvOS","tvOSApplicationExtension","swift"]
+;var Ke=Object.freeze({__proto__:null,grmr_bash:e=>{const n=e.regex,t={},a={
+begin:/\$\{/,end:/\}/,contains:["self",{begin:/:-/,contains:[t]}]}
+;Object.assign(t,{className:"variable",variants:[{
+begin:n.concat(/\$[\w\d#@][\w\d_]*/,"(?![\\w\\d])(?![$])")},a]});const i={
+className:"subst",begin:/\$\(/,end:/\)/,contains:[e.BACKSLASH_ESCAPE]},r={
+begin:/<<-?\s*(?=\w+)/,starts:{contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,
+end:/(\w+)/,className:"string"})]}},s={className:"string",begin:/"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,t,i]};i.contains.push(s);const o={begin:/\$?\(\(/,
+end:/\)\)/,contains:[{begin:/\d+#[0-9a-f]+/,className:"number"},e.NUMBER_MODE,t]
+},l=e.SHEBANG({binary:"(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",relevance:10
+}),c={className:"function",begin:/\w[\w\d_]*\s*\(\s*\)\s*\{/,returnBegin:!0,
+contains:[e.inherit(e.TITLE_MODE,{begin:/\w[\w\d_]*/})],relevance:0};return{
+name:"Bash",aliases:["sh"],keywords:{$pattern:/\b[a-z][a-z0-9._-]+\b/,
+keyword:["if","then","else","elif","fi","for","while","until","in","do","done","case","esac","function","select"],
+literal:["true","false"],
+built_in:["break","cd","continue","eval","exec","exit","export","getopts","hash","pwd","readonly","return","shift","test","times","trap","umask","unset","alias","bind","builtin","caller","command","declare","echo","enable","help","let","local","logout","mapfile","printf","read","readarray","source","type","typeset","ulimit","unalias","set","shopt","autoload","bg","bindkey","bye","cap","chdir","clone","comparguments","compcall","compctl","compdescribe","compfiles","compgroups","compquote","comptags","comptry","compvalues","dirs","disable","disown","echotc","echoti","emulate","fc","fg","float","functions","getcap","getln","history","integer","jobs","kill","limit","log","noglob","popd","print","pushd","pushln","rehash","sched","setcap","setopt","stat","suspend","ttyctl","unfunction","unhash","unlimit","unsetopt","vared","wait","whence","where","which","zcompile","zformat","zftp","zle","zmodload","zparseopts","zprof","zpty","zregexparse","zsocket","zstyle","ztcp","chcon","chgrp","chown","chmod","cp","dd","df","dir","dircolors","ln","ls","mkdir","mkfifo","mknod","mktemp","mv","realpath","rm","rmdir","shred","sync","touch","truncate","vdir","b2sum","base32","base64","cat","cksum","comm","csplit","cut","expand","fmt","fold","head","join","md5sum","nl","numfmt","od","paste","ptx","pr","sha1sum","sha224sum","sha256sum","sha384sum","sha512sum","shuf","sort","split","sum","tac","tail","tr","tsort","unexpand","uniq","wc","arch","basename","chroot","date","dirname","du","echo","env","expr","factor","groups","hostid","id","link","logname","nice","nohup","nproc","pathchk","pinky","printenv","printf","pwd","readlink","runcon","seq","sleep","stat","stdbuf","stty","tee","test","timeout","tty","uname","unlink","uptime","users","who","whoami","yes"]
+},contains:[l,e.SHEBANG(),c,o,e.HASH_COMMENT_MODE,r,{match:/(\/[a-z._-]+)+/},s,{
+match:/\\"/},{className:"string",begin:/'/,end:/'/},{match:/\\'/},t]}},
+grmr_c:e=>{const n=e.regex,t=e.COMMENT("//","$",{contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",variants:[{begin:"\\b[a-z\\d_]*_t\\b"},{
+match:/\batomic_[a-z]{3,6}\b/}]},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)"
+},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+keyword:["asm","auto","break","case","continue","default","do","else","enum","extern","for","fortran","goto","if","inline","register","restrict","return","sizeof","struct","switch","typedef","union","volatile","while","_Alignas","_Alignof","_Atomic","_Generic","_Noreturn","_Static_assert","_Thread_local","alignas","alignof","noreturn","static_assert","thread_local","_Pragma"],
+type:["float","double","signed","unsigned","int","short","long","char","void","_Bool","_Complex","_Imaginary","_Decimal32","_Decimal64","_Decimal128","const","static","complex","bool","imaginary"],
+literal:"true false NULL",
+built_in:"std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp fscanf future isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan vfprintf vprintf vsprintf endl initializer_list unique_ptr"
+},b=[c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],m={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:b.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:b.concat(["self"]),relevance:0}]),relevance:0},p={
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[e.inherit(d,{className:"title.function"})],
+relevance:0},{relevance:0,match:/,/},{className:"params",begin:/\(/,end:/\)/,
+keywords:u,relevance:0,contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,
+end:/\)/,keywords:u,relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]
+}]},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C",aliases:["h"],keywords:u,
+disableAutodetect:!0,illegal:"</",contains:[].concat(m,p,b,[c,{
+begin:e.IDENT_RE+"::",keywords:u},{className:"class",
+beginKeywords:"enum class struct union",end:/[{;:<>=]/,contains:[{
+beginKeywords:"final class struct"},e.TITLE_MODE]}]),exports:{preprocessor:c,
+strings:o,keywords:u}}},grmr_cpp:e=>{const n=e.regex,t=e.COMMENT("//","$",{
+contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="(?!struct)("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",begin:"\\b[a-z\\d_]*_t\\b"},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)"
+},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+type:["bool","char","char16_t","char32_t","char8_t","double","float","int","long","short","void","wchar_t","unsigned","signed","const","static"],
+keyword:["alignas","alignof","and","and_eq","asm","atomic_cancel","atomic_commit","atomic_noexcept","auto","bitand","bitor","break","case","catch","class","co_await","co_return","co_yield","compl","concept","const_cast|10","consteval","constexpr","constinit","continue","decltype","default","delete","do","dynamic_cast|10","else","enum","explicit","export","extern","false","final","for","friend","goto","if","import","inline","module","mutable","namespace","new","noexcept","not","not_eq","nullptr","operator","or","or_eq","override","private","protected","public","reflexpr","register","reinterpret_cast|10","requires","return","sizeof","static_assert","static_cast|10","struct","switch","synchronized","template","this","thread_local","throw","transaction_safe","transaction_safe_dynamic","true","try","typedef","typeid","typename","union","using","virtual","volatile","while","xor","xor_eq"],
+literal:["NULL","false","nullopt","nullptr","true"],built_in:["_Pragma"],
+_type_hints:["any","auto_ptr","barrier","binary_semaphore","bitset","complex","condition_variable","condition_variable_any","counting_semaphore","deque","false_type","future","imaginary","initializer_list","istringstream","jthread","latch","lock_guard","multimap","multiset","mutex","optional","ostringstream","packaged_task","pair","promise","priority_queue","queue","recursive_mutex","recursive_timed_mutex","scoped_lock","set","shared_future","shared_lock","shared_mutex","shared_timed_mutex","shared_ptr","stack","string_view","stringstream","timed_mutex","thread","true_type","tuple","unique_lock","unique_ptr","unordered_map","unordered_multimap","unordered_multiset","unordered_set","variant","vector","weak_ptr","wstring","wstring_view"]
+},b={className:"function.dispatch",relevance:0,keywords:{
+_hint:["abort","abs","acos","apply","as_const","asin","atan","atan2","calloc","ceil","cerr","cin","clog","cos","cosh","cout","declval","endl","exchange","exit","exp","fabs","floor","fmod","forward","fprintf","fputs","free","frexp","fscanf","future","invoke","isalnum","isalpha","iscntrl","isdigit","isgraph","islower","isprint","ispunct","isspace","isupper","isxdigit","labs","launder","ldexp","log","log10","make_pair","make_shared","make_shared_for_overwrite","make_tuple","make_unique","malloc","memchr","memcmp","memcpy","memset","modf","move","pow","printf","putchar","puts","realloc","scanf","sin","sinh","snprintf","sprintf","sqrt","sscanf","std","stderr","stdin","stdout","strcat","strchr","strcmp","strcpy","strcspn","strlen","strncat","strncmp","strncpy","strpbrk","strrchr","strspn","strstr","swap","tan","tanh","terminate","to_underlying","tolower","toupper","vfprintf","visit","vprintf","vsprintf"]
+},
+begin:n.concat(/\b/,/(?!decltype)/,/(?!if)/,/(?!for)/,/(?!switch)/,/(?!while)/,e.IDENT_RE,n.lookahead(/(<[^<>]+>|)\s*\(/))
+},m=[b,c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],p={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:m.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:m.concat(["self"]),relevance:0}]),relevance:0},_={className:"function",
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[d],relevance:0},{begin:/::/,relevance:0},{
+begin:/:/,endsWithParent:!0,contains:[o,l]},{relevance:0,match:/,/},{
+className:"params",begin:/\(/,end:/\)/,keywords:u,relevance:0,
+contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,end:/\)/,keywords:u,
+relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]}]
+},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C++",
+aliases:["cc","c++","h++","hpp","hh","hxx","cxx"],keywords:u,illegal:"</",
+classNameAliases:{"function.dispatch":"built_in"},
+contains:[].concat(p,_,b,m,[c,{
+begin:"\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function)\\s*<(?!<)",
+end:">",keywords:u,contains:["self",s]},{begin:e.IDENT_RE+"::",keywords:u},{
+match:[/\b(?:enum(?:\s+(?:class|struct))?|class|struct|union)/,/\s+/,/\w+/],
+className:{1:"keyword",3:"title.class"}}])}},grmr_csharp:e=>{const n={
+keyword:["abstract","as","base","break","case","catch","class","const","continue","do","else","event","explicit","extern","finally","fixed","for","foreach","goto","if","implicit","in","interface","internal","is","lock","namespace","new","operator","out","override","params","private","protected","public","readonly","record","ref","return","scoped","sealed","sizeof","stackalloc","static","struct","switch","this","throw","try","typeof","unchecked","unsafe","using","virtual","void","volatile","while"].concat(["add","alias","and","ascending","async","await","by","descending","equals","from","get","global","group","init","into","join","let","nameof","not","notnull","on","or","orderby","partial","remove","select","set","unmanaged","value|0","var","when","where","with","yield"]),
+built_in:["bool","byte","char","decimal","delegate","double","dynamic","enum","float","int","long","nint","nuint","object","sbyte","short","string","ulong","uint","ushort"],
+literal:["default","false","null","true"]},t=e.inherit(e.TITLE_MODE,{
+begin:"[a-zA-Z](\\.?\\w)*"}),a={className:"number",variants:[{
+begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)"},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},i={className:"string",begin:'@"',end:'"',contains:[{begin:'""'}]
+},r=e.inherit(i,{illegal:/\n/}),s={className:"subst",begin:/\{/,end:/\}/,
+keywords:n},o=e.inherit(s,{illegal:/\n/}),l={className:"string",begin:/\$"/,
+end:'"',illegal:/\n/,contains:[{begin:/\{\{/},{begin:/\}\}/
+},e.BACKSLASH_ESCAPE,o]},c={className:"string",begin:/\$@"/,end:'"',contains:[{
+begin:/\{\{/},{begin:/\}\}/},{begin:'""'},s]},d=e.inherit(c,{illegal:/\n/,
+contains:[{begin:/\{\{/},{begin:/\}\}/},{begin:'""'},o]})
+;s.contains=[c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.C_BLOCK_COMMENT_MODE],
+o.contains=[d,l,r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.inherit(e.C_BLOCK_COMMENT_MODE,{
+illegal:/\n/})];const g={variants:[c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},u={begin:"<",end:">",contains:[{beginKeywords:"in out"},t]
+},b=e.IDENT_RE+"(<"+e.IDENT_RE+"(\\s*,\\s*"+e.IDENT_RE+")*>)?(\\[\\])?",m={
+begin:"@"+e.IDENT_RE,relevance:0};return{name:"C#",aliases:["cs","c#"],
+keywords:n,illegal:/::/,contains:[e.COMMENT("///","$",{returnBegin:!0,
+contains:[{className:"doctag",variants:[{begin:"///",relevance:0},{
+begin:"\x3c!--|--\x3e"},{begin:"</?",end:">"}]}]
+}),e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"meta",begin:"#",
+end:"$",keywords:{
+keyword:"if else elif endif define undef warning error line region endregion pragma checksum"
+}},g,a,{beginKeywords:"class interface",relevance:0,end:/[{;=]/,
+illegal:/[^\s:,]/,contains:[{beginKeywords:"where class"
+},t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{beginKeywords:"namespace",
+relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"record",relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"meta",
+begin:"^\\s*\\[(?=[\\w])",excludeBegin:!0,end:"\\]",excludeEnd:!0,contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+beginKeywords:"new return throw await else",relevance:0},{className:"function",
+begin:"("+b+"\\s+)+"+e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+end:/\s*[{;=]/,excludeEnd:!0,keywords:n,contains:[{
+beginKeywords:"public private protected static internal protected abstract async extern override unsafe virtual new sealed partial",
+relevance:0},{begin:e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+contains:[e.TITLE_MODE,u],relevance:0},{match:/\(\)/},{className:"params",
+begin:/\(/,end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:n,relevance:0,
+contains:[g,a,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},m]}},grmr_css:e=>{
+const n=e.regex,t=ie(e),a=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE];return{
+name:"CSS",case_insensitive:!0,illegal:/[=|'\$]/,keywords:{
+keyframePosition:"from to"},classNameAliases:{keyframePosition:"selector-tag"},
+contains:[t.BLOCK_COMMENT,{begin:/-(webkit|moz|ms|o)-(?=[a-z])/
+},t.CSS_NUMBER_MODE,{className:"selector-id",begin:/#[A-Za-z0-9_-]+/,relevance:0
+},{className:"selector-class",begin:"\\.[a-zA-Z-][a-zA-Z0-9_-]*",relevance:0
+},t.ATTRIBUTE_SELECTOR_MODE,{className:"selector-pseudo",variants:[{
+begin:":("+oe.join("|")+")"},{begin:":(:)?("+le.join("|")+")"}]
+},t.CSS_VARIABLE,{className:"attribute",begin:"\\b("+ce.join("|")+")\\b"},{
+begin:/:/,end:/[;}{]/,
+contains:[t.BLOCK_COMMENT,t.HEXCOLOR,t.IMPORTANT,t.CSS_NUMBER_MODE,...a,{
+begin:/(url|data-uri)\(/,end:/\)/,relevance:0,keywords:{built_in:"url data-uri"
+},contains:[...a,{className:"string",begin:/[^)]/,endsWithParent:!0,
+excludeEnd:!0}]},t.FUNCTION_DISPATCH]},{begin:n.lookahead(/@/),end:"[{;]",
+relevance:0,illegal:/:/,contains:[{className:"keyword",begin:/@-?\w[\w]*(-\w+)*/
+},{begin:/\s/,endsWithParent:!0,excludeEnd:!0,relevance:0,keywords:{
+$pattern:/[a-z-]+/,keyword:"and or not only",attribute:se.join(" ")},contains:[{
+begin:/[a-z-]+(?=:)/,className:"attribute"},...a,t.CSS_NUMBER_MODE]}]},{
+className:"selector-tag",begin:"\\b("+re.join("|")+")\\b"}]}},grmr_diff:e=>{
+const n=e.regex;return{name:"Diff",aliases:["patch"],contains:[{
+className:"meta",relevance:10,
+match:n.either(/^@@ +-\d+,\d+ +\+\d+,\d+ +@@/,/^\*\*\* +\d+,\d+ +\*\*\*\*$/,/^--- +\d+,\d+ +----$/)
+},{className:"comment",variants:[{
+begin:n.either(/Index: /,/^index/,/={3,}/,/^-{3}/,/^\*{3} /,/^\+{3}/,/^diff --git/),
+end:/$/},{match:/^\*{15}$/}]},{className:"addition",begin:/^\+/,end:/$/},{
+className:"deletion",begin:/^-/,end:/$/},{className:"addition",begin:/^!/,
+end:/$/}]}},grmr_go:e=>{const n={
+keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var"],
+type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune"],
+literal:["true","false","iota","nil"],
+built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"]
+};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",
+variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{
+className:"number",variants:[{begin:e.C_NUMBER_RE+"[i]",relevance:1
+},e.C_NUMBER_MODE]},{begin:/:=/},{className:"function",beginKeywords:"func",
+end:"\\s*(\\{|$)",excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",
+begin:/\(/,end:/\)/,endsParent:!0,keywords:n,illegal:/["']/}]}]}},
+grmr_graphql:e=>{const n=e.regex;return{name:"GraphQL",aliases:["gql"],
+case_insensitive:!0,disableAutodetect:!1,keywords:{
+keyword:["query","mutation","subscription","type","input","schema","directive","interface","union","scalar","fragment","enum","on"],
+literal:["true","false","null"]},
+contains:[e.HASH_COMMENT_MODE,e.QUOTE_STRING_MODE,e.NUMBER_MODE,{
+scope:"punctuation",match:/[.]{3}/,relevance:0},{scope:"punctuation",
+begin:/[\!\(\)\:\=\[\]\{\|\}]{1}/,relevance:0},{scope:"variable",begin:/\$/,
+end:/\W/,excludeEnd:!0,relevance:0},{scope:"meta",match:/@\w+/,excludeEnd:!0},{
+scope:"symbol",begin:n.concat(/[_A-Za-z][_0-9A-Za-z]*/,n.lookahead(/\s*:/)),
+relevance:0}],illegal:[/[;<']/,/BEGIN/]}},grmr_ini:e=>{const n=e.regex,t={
+className:"number",relevance:0,variants:[{begin:/([+-]+)?[\d]+_[\d_]+/},{
+begin:e.NUMBER_RE}]},a=e.COMMENT();a.variants=[{begin:/;/,end:/$/},{begin:/#/,
+end:/$/}];const i={className:"variable",variants:[{begin:/\$[\w\d"][\w\d_]*/},{
+begin:/\$\{(.*?)\}/}]},r={className:"literal",
+begin:/\bon|off|true|false|yes|no\b/},s={className:"string",
+contains:[e.BACKSLASH_ESCAPE],variants:[{begin:"'''",end:"'''",relevance:10},{
+begin:'"""',end:'"""',relevance:10},{begin:'"',end:'"'},{begin:"'",end:"'"}]
+},o={begin:/\[/,end:/\]/,contains:[a,r,i,s,t,"self"],relevance:0
+},l=n.either(/[A-Za-z0-9_-]+/,/"(\\"|[^"])*"/,/'[^']*'/);return{
+name:"TOML, also INI",aliases:["toml"],case_insensitive:!0,illegal:/\S/,
+contains:[a,{className:"section",begin:/\[+/,end:/\]+/},{
+begin:n.concat(l,"(\\s*\\.\\s*",l,")*",n.lookahead(/\s*=\s*[^#\s]/)),
+className:"attr",starts:{end:/$/,contains:[a,o,r,i,s,t]}}]}},grmr_java:e=>{
+const n=e.regex,t="[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",a=t+pe("(?:<"+t+"~~~(?:\\s*,\\s*"+t+"~~~)*>)?",/~~~/g,2),i={
+keyword:["synchronized","abstract","private","var","static","if","const ","for","while","strictfp","finally","protected","import","native","final","void","enum","else","break","transient","catch","instanceof","volatile","case","assert","package","default","public","try","switch","continue","throws","protected","public","private","module","requires","exports","do","sealed","yield","permits"],
+literal:["false","true","null"],
+type:["char","boolean","long","float","int","byte","short","double"],
+built_in:["super","this"]},r={className:"meta",begin:"@"+t,contains:[{
+begin:/\(/,end:/\)/,contains:["self"]}]},s={className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,contains:[e.C_BLOCK_COMMENT_MODE],endsParent:!0}
+;return{name:"Java",aliases:["jsp"],keywords:i,illegal:/<\/|#/,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{begin:/\w+@/,
+relevance:0},{className:"doctag",begin:"@[A-Za-z]+"}]}),{
+begin:/import java\.[a-z]+\./,keywords:"import",relevance:2
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{begin:/"""/,end:/"""/,
+className:"string",contains:[e.BACKSLASH_ESCAPE]
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{
+match:[/\b(?:class|interface|enum|extends|implements|new)/,/\s+/,t],className:{
+1:"keyword",3:"title.class"}},{match:/non-sealed/,scope:"keyword"},{
+begin:[n.concat(/(?!else)/,t),/\s+/,t,/\s+/,/=(?!=)/],className:{1:"type",
+3:"variable",5:"operator"}},{begin:[/record/,/\s+/,t],className:{1:"keyword",
+3:"title.class"},contains:[s,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"new throw return else",relevance:0},{
+begin:["(?:"+a+"\\s+)",e.UNDERSCORE_IDENT_RE,/\s*(?=\()/],className:{
+2:"title.function"},keywords:i,contains:[{className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,
+contains:[r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,me,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},me,r]}},grmr_javascript:Oe,
+grmr_json:e=>{const n=["true","false","null"],t={scope:"literal",
+beginKeywords:n.join(" ")};return{name:"JSON",keywords:{literal:n},contains:[{
+className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,relevance:1.01},{
+match:/[{}[\],:]/,className:"punctuation",relevance:0
+},e.QUOTE_STRING_MODE,t,e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE],
+illegal:"\\S"}},grmr_kotlin:e=>{const n={
+keyword:"abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual",
+built_in:"Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
+literal:"true false null"},t={className:"symbol",begin:e.UNDERSCORE_IDENT_RE+"@"
+},a={className:"subst",begin:/\$\{/,end:/\}/,contains:[e.C_NUMBER_MODE]},i={
+className:"variable",begin:"\\$"+e.UNDERSCORE_IDENT_RE},r={className:"string",
+variants:[{begin:'"""',end:'"""(?=[^"])',contains:[i,a]},{begin:"'",end:"'",
+illegal:/\n/,contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"',illegal:/\n/,
+contains:[e.BACKSLASH_ESCAPE,i,a]}]};a.contains.push(r);const s={
+className:"meta",
+begin:"@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*"+e.UNDERSCORE_IDENT_RE+")?"
+},o={className:"meta",begin:"@"+e.UNDERSCORE_IDENT_RE,contains:[{begin:/\(/,
+end:/\)/,contains:[e.inherit(r,{className:"string"}),"self"]}]
+},l=me,c=e.COMMENT("/\\*","\\*/",{contains:[e.C_BLOCK_COMMENT_MODE]}),d={
+variants:[{className:"type",begin:e.UNDERSCORE_IDENT_RE},{begin:/\(/,end:/\)/,
+contains:[]}]},g=d;return g.variants[1].contains=[d],d.variants[1].contains=[g],
+{name:"Kotlin",aliases:["kt","kts"],keywords:n,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"}]}),e.C_LINE_COMMENT_MODE,c,{className:"keyword",
+begin:/\b(break|continue|return|this)\b/,starts:{contains:[{className:"symbol",
+begin:/@\w+/}]}},t,s,o,{className:"function",beginKeywords:"fun",end:"[(]|$",
+returnBegin:!0,excludeEnd:!0,keywords:n,relevance:5,contains:[{
+begin:e.UNDERSCORE_IDENT_RE+"\\s*\\(",returnBegin:!0,relevance:0,
+contains:[e.UNDERSCORE_TITLE_MODE]},{className:"type",begin:/</,end:/>/,
+keywords:"reified",relevance:0},{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,relevance:0,contains:[{begin:/:/,end:/[=,\/]/,
+endsWithParent:!0,contains:[d,e.C_LINE_COMMENT_MODE,c],relevance:0
+},e.C_LINE_COMMENT_MODE,c,s,o,r,e.C_NUMBER_MODE]},c]},{
+begin:[/class|interface|trait/,/\s+/,e.UNDERSCORE_IDENT_RE],beginScope:{
+3:"title.class"},keywords:"class interface trait",end:/[:\{(]|$/,excludeEnd:!0,
+illegal:"extends implements",contains:[{
+beginKeywords:"public protected internal private constructor"
+},e.UNDERSCORE_TITLE_MODE,{className:"type",begin:/</,end:/>/,excludeBegin:!0,
+excludeEnd:!0,relevance:0},{className:"type",begin:/[,:]\s*/,end:/[<\(,){\s]|$/,
+excludeBegin:!0,returnEnd:!0},s,o]},r,{className:"meta",begin:"^#!/usr/bin/env",
+end:"$",illegal:"\n"},l]}},grmr_less:e=>{
+const n=ie(e),t=de,a="[\\w-]+",i="("+a+"|@\\{"+a+"\\})",r=[],s=[],o=e=>({
+className:"string",begin:"~?"+e+".*?"+e}),l=(e,n,t)=>({className:e,begin:n,
+relevance:t}),c={$pattern:/[a-z-]+/,keyword:"and or not only",
+attribute:se.join(" ")},d={begin:"\\(",end:"\\)",contains:s,keywords:c,
+relevance:0}
+;s.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,o("'"),o('"'),n.CSS_NUMBER_MODE,{
+begin:"(url|data-uri)\\(",starts:{className:"string",end:"[\\)\\n]",
+excludeEnd:!0}
+},n.HEXCOLOR,d,l("variable","@@?"+a,10),l("variable","@\\{"+a+"\\}"),l("built_in","~?`[^`]*?`"),{
+className:"attribute",begin:a+"\\s*:",end:":",returnBegin:!0,excludeEnd:!0
+},n.IMPORTANT,{beginKeywords:"and not"},n.FUNCTION_DISPATCH);const g=s.concat({
+begin:/\{/,end:/\}/,contains:r}),u={beginKeywords:"when",endsWithParent:!0,
+contains:[{beginKeywords:"and not"}].concat(s)},b={begin:i+"\\s*:",
+returnBegin:!0,end:/[;}]/,relevance:0,contains:[{begin:/-(webkit|moz|ms|o)-/
+},n.CSS_VARIABLE,{className:"attribute",begin:"\\b("+ce.join("|")+")\\b",
+end:/(?=:)/,starts:{endsWithParent:!0,illegal:"[<=$]",relevance:0,contains:s}}]
+},m={className:"keyword",
+begin:"@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b",
+starts:{end:"[;{}]",keywords:c,returnEnd:!0,contains:s,relevance:0}},p={
+className:"variable",variants:[{begin:"@"+a+"\\s*:",relevance:15},{begin:"@"+a
+}],starts:{end:"[;}]",returnEnd:!0,contains:g}},_={variants:[{
+begin:"[\\.#:&\\[>]",end:"[;{}]"},{begin:i,end:/\{/}],returnBegin:!0,
+returnEnd:!0,illegal:"[<='$\"]",relevance:0,
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,u,l("keyword","all\\b"),l("variable","@\\{"+a+"\\}"),{
+begin:"\\b("+re.join("|")+")\\b",className:"selector-tag"
+},n.CSS_NUMBER_MODE,l("selector-tag",i,0),l("selector-id","#"+i),l("selector-class","\\."+i,0),l("selector-tag","&",0),n.ATTRIBUTE_SELECTOR_MODE,{
+className:"selector-pseudo",begin:":("+oe.join("|")+")"},{
+className:"selector-pseudo",begin:":(:)?("+le.join("|")+")"},{begin:/\(/,
+end:/\)/,relevance:0,contains:g},{begin:"!important"},n.FUNCTION_DISPATCH]},h={
+begin:a+":(:)?"+`(${t.join("|")})`,returnBegin:!0,contains:[_]}
+;return r.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,m,p,h,b,_,u,n.FUNCTION_DISPATCH),
+{name:"Less",case_insensitive:!0,illegal:"[=>'/<($\"]",contains:r}},
+grmr_lua:e=>{const n="\\[=*\\[",t="\\]=*\\]",a={begin:n,end:t,contains:["self"]
+},i=[e.COMMENT("--(?!"+n+")","$"),e.COMMENT("--"+n,t,{contains:[a],relevance:10
+})];return{name:"Lua",keywords:{$pattern:e.UNDERSCORE_IDENT_RE,
+literal:"true false nil",
+keyword:"and break do else elseif end for goto if in local not or repeat return then until while",
+built_in:"_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove"
+},contains:i.concat([{className:"function",beginKeywords:"function",end:"\\)",
+contains:[e.inherit(e.TITLE_MODE,{
+begin:"([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*"}),{className:"params",
+begin:"\\(",endsWithParent:!0,contains:i}].concat(i)
+},e.C_NUMBER_MODE,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{className:"string",
+begin:n,end:t,contains:[a],relevance:5}])}},grmr_makefile:e=>{const n={
+className:"variable",variants:[{begin:"\\$\\("+e.UNDERSCORE_IDENT_RE+"\\)",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\$[@%<?\^\+\*]/}]},t={className:"string",
+begin:/"/,end:/"/,contains:[e.BACKSLASH_ESCAPE,n]},a={className:"variable",
+begin:/\$\([\w-]+\s/,end:/\)/,keywords:{
+built_in:"subst patsubst strip findstring filter filter-out sort word wordlist firstword lastword dir notdir suffix basename addsuffix addprefix join wildcard realpath abspath error warning shell origin flavor foreach if or and call eval file value"
+},contains:[n]},i={begin:"^"+e.UNDERSCORE_IDENT_RE+"\\s*(?=[:+?]?=)"},r={
+className:"section",begin:/^[^\s]+:/,end:/$/,contains:[n]};return{
+name:"Makefile",aliases:["mk","mak","make"],keywords:{$pattern:/[\w-]+/,
+keyword:"define endef undefine ifdef ifndef ifeq ifneq else endif include -include sinclude override export unexport private vpath"
+},contains:[e.HASH_COMMENT_MODE,n,t,a,i,{className:"meta",begin:/^\.PHONY:/,
+end:/$/,keywords:{$pattern:/[\.\w]+/,keyword:".PHONY"}},r]}},grmr_markdown:e=>{
+const n={begin:/<\/?[A-Za-z_]/,end:">",subLanguage:"xml",relevance:0},t={
+variants:[{begin:/\[.+?\]\[.*?\]/,relevance:0},{
+begin:/\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/,
+relevance:2},{
+begin:e.regex.concat(/\[.+?\]\(/,/[A-Za-z][A-Za-z0-9+.-]*/,/:\/\/.*?\)/),
+relevance:2},{begin:/\[.+?\]\([./?&#].*?\)/,relevance:1},{
+begin:/\[.*?\]\(.*?\)/,relevance:0}],returnBegin:!0,contains:[{match:/\[(?=\])/
+},{className:"string",relevance:0,begin:"\\[",end:"\\]",excludeBegin:!0,
+returnEnd:!0},{className:"link",relevance:0,begin:"\\]\\(",end:"\\)",
+excludeBegin:!0,excludeEnd:!0},{className:"symbol",relevance:0,begin:"\\]\\[",
+end:"\\]",excludeBegin:!0,excludeEnd:!0}]},a={className:"strong",contains:[],
+variants:[{begin:/_{2}(?!\s)/,end:/_{2}/},{begin:/\*{2}(?!\s)/,end:/\*{2}/}]
+},i={className:"emphasis",contains:[],variants:[{begin:/\*(?![*\s])/,end:/\*/},{
+begin:/_(?![_\s])/,end:/_/,relevance:0}]},r=e.inherit(a,{contains:[]
+}),s=e.inherit(i,{contains:[]});a.contains.push(s),i.contains.push(r)
+;let o=[n,t];return[a,i,r,s].forEach((e=>{e.contains=e.contains.concat(o)
+})),o=o.concat(a,i),{name:"Markdown",aliases:["md","mkdown","mkd"],contains:[{
+className:"section",variants:[{begin:"^#{1,6}",end:"$",contains:o},{
+begin:"(?=^.+?\\n[=-]{2,}$)",contains:[{begin:"^[=-]*$"},{begin:"^",end:"\\n",
+contains:o}]}]},n,{className:"bullet",begin:"^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
+end:"\\s+",excludeEnd:!0},a,i,{className:"quote",begin:"^>\\s+",contains:o,
+end:"$"},{className:"code",variants:[{begin:"(`{3,})[^`](.|\\n)*?\\1`*[ ]*"},{
+begin:"(~{3,})[^~](.|\\n)*?\\1~*[ ]*"},{begin:"```",end:"```+[ ]*$"},{
+begin:"~~~",end:"~~~+[ ]*$"},{begin:"`.+?`"},{begin:"(?=^( {4}|\\t))",
+contains:[{begin:"^( {4}|\\t)",end:"(\\n)$"}],relevance:0}]},{
+begin:"^[-\\*]{3,}",end:"$"},t,{begin:/^\[[^\n]+\]:/,returnBegin:!0,contains:[{
+className:"symbol",begin:/\[/,end:/\]/,excludeBegin:!0,excludeEnd:!0},{
+className:"link",begin:/:\s*/,end:/$/,excludeBegin:!0}]}]}},grmr_objectivec:e=>{
+const n=/[a-zA-Z@][a-zA-Z0-9_]*/,t={$pattern:n,
+keyword:["@interface","@class","@protocol","@implementation"]};return{
+name:"Objective-C",aliases:["mm","objc","obj-c","obj-c++","objective-c++"],
+keywords:{"variable.language":["this","super"],$pattern:n,
+keyword:["while","export","sizeof","typedef","const","struct","for","union","volatile","static","mutable","if","do","return","goto","enum","else","break","extern","asm","case","default","register","explicit","typename","switch","continue","inline","readonly","assign","readwrite","self","@synchronized","id","typeof","nonatomic","IBOutlet","IBAction","strong","weak","copy","in","out","inout","bycopy","byref","oneway","__strong","__weak","__block","__autoreleasing","@private","@protected","@public","@try","@property","@end","@throw","@catch","@finally","@autoreleasepool","@synthesize","@dynamic","@selector","@optional","@required","@encode","@package","@import","@defs","@compatibility_alias","__bridge","__bridge_transfer","__bridge_retained","__bridge_retain","__covariant","__contravariant","__kindof","_Nonnull","_Nullable","_Null_unspecified","__FUNCTION__","__PRETTY_FUNCTION__","__attribute__","getter","setter","retain","unsafe_unretained","nonnull","nullable","null_unspecified","null_resettable","class","instancetype","NS_DESIGNATED_INITIALIZER","NS_UNAVAILABLE","NS_REQUIRES_SUPER","NS_RETURNS_INNER_POINTER","NS_INLINE","NS_AVAILABLE","NS_DEPRECATED","NS_ENUM","NS_OPTIONS","NS_SWIFT_UNAVAILABLE","NS_ASSUME_NONNULL_BEGIN","NS_ASSUME_NONNULL_END","NS_REFINED_FOR_SWIFT","NS_SWIFT_NAME","NS_SWIFT_NOTHROW","NS_DURING","NS_HANDLER","NS_ENDHANDLER","NS_VALUERETURN","NS_VOIDRETURN"],
+literal:["false","true","FALSE","TRUE","nil","YES","NO","NULL"],
+built_in:["dispatch_once_t","dispatch_queue_t","dispatch_sync","dispatch_async","dispatch_once"],
+type:["int","float","char","unsigned","signed","short","long","double","wchar_t","unichar","void","bool","BOOL","id|0","_Bool"]
+},illegal:"</",contains:[{className:"built_in",
+begin:"\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,e.C_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{
+className:"string",variants:[{begin:'@"',end:'"',illegal:"\\n",
+contains:[e.BACKSLASH_ESCAPE]}]},{className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,
+keywords:{
+keyword:"if else elif endif define undef warning error line pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(e.QUOTE_STRING_MODE,{
+className:"string"}),{className:"string",begin:/<.*?>/,end:/$/,illegal:"\\n"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"class",
+begin:"("+t.keyword.join("|")+")\\b",end:/(\{|$)/,excludeEnd:!0,keywords:t,
+contains:[e.UNDERSCORE_TITLE_MODE]},{begin:"\\."+e.UNDERSCORE_IDENT_RE,
+relevance:0}]}},grmr_perl:e=>{const n=e.regex,t=/[dualxmsipngr]{0,12}/,a={
+$pattern:/[\w.]+/,
+keyword:"abs accept alarm and atan2 bind binmode bless break caller chdir chmod chomp chop chown chr chroot close closedir connect continue cos crypt dbmclose dbmopen defined delete die do dump each else elsif endgrent endhostent endnetent endprotoent endpwent endservent eof eval exec exists exit exp fcntl fileno flock for foreach fork format formline getc getgrent getgrgid getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr getnetbyname getnetent getpeername getpgrp getpriority getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid getservbyname getservbyport getservent getsockname getsockopt given glob gmtime goto grep gt hex if index int ioctl join keys kill last lc lcfirst length link listen local localtime log lstat lt ma map mkdir msgctl msgget msgrcv msgsnd my ne next no not oct open opendir or ord our pack package pipe pop pos print printf prototype push q|0 qq quotemeta qw qx rand read readdir readline readlink readpipe recv redo ref rename require reset return reverse rewinddir rindex rmdir say scalar seek seekdir select semctl semget semop send setgrent sethostent setnetent setpgrp setpriority setprotoent setpwent setservent setsockopt shift shmctl shmget shmread shmwrite shutdown sin sleep socket socketpair sort splice split sprintf sqrt srand stat state study sub substr symlink syscall sysopen sysread sysseek system syswrite tell telldir tie tied time times tr truncate uc ucfirst umask undef unless unlink unpack unshift untie until use utime values vec wait waitpid wantarray warn when while write x|0 xor y|0"
+},i={className:"subst",begin:"[$@]\\{",end:"\\}",keywords:a},r={begin:/->\{/,
+end:/\}/},s={variants:[{begin:/\$\d/},{
+begin:n.concat(/[$%@](\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,"(?![A-Za-z])(?![@$%])")
+},{begin:/[$%@][^\s\w{]/,relevance:0}]
+},o=[e.BACKSLASH_ESCAPE,i,s],l=[/!/,/\//,/\|/,/\?/,/'/,/"/,/#/],c=(e,a,i="\\1")=>{
+const r="\\1"===i?i:n.concat(i,a)
+;return n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,r,/(?:\\.|[^\\\/])*?/,i,t)
+},d=(e,a,i)=>n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,i,t),g=[s,e.HASH_COMMENT_MODE,e.COMMENT(/^=\w/,/=cut/,{
+endsWithParent:!0}),r,{className:"string",contains:o,variants:[{
+begin:"q[qwxr]?\\s*\\(",end:"\\)",relevance:5},{begin:"q[qwxr]?\\s*\\[",
+end:"\\]",relevance:5},{begin:"q[qwxr]?\\s*\\{",end:"\\}",relevance:5},{
+begin:"q[qwxr]?\\s*\\|",end:"\\|",relevance:5},{begin:"q[qwxr]?\\s*<",end:">",
+relevance:5},{begin:"qw\\s+q",end:"q",relevance:5},{begin:"'",end:"'",
+contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"'},{begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\{\w+\}/,relevance:0},{
+begin:"-?\\w+\\s*=>",relevance:0}]},{className:"number",
+begin:"(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?)|[0_]\\b",
+relevance:0},{
+begin:"(\\/\\/|"+e.RE_STARTERS_RE+"|\\b(split|return|print|reverse|grep)\\b)\\s*",
+keywords:"split return print reverse grep",relevance:0,
+contains:[e.HASH_COMMENT_MODE,{className:"regexp",variants:[{
+begin:c("s|tr|y",n.either(...l,{capture:!0}))},{begin:c("s|tr|y","\\(","\\)")},{
+begin:c("s|tr|y","\\[","\\]")},{begin:c("s|tr|y","\\{","\\}")}],relevance:2},{
+className:"regexp",variants:[{begin:/(m|qr)\/\//,relevance:0},{
+begin:d("(?:m|qr)?",/\//,/\//)},{begin:d("m|qr",n.either(...l,{capture:!0
+}),/\1/)},{begin:d("m|qr",/\(/,/\)/)},{begin:d("m|qr",/\[/,/\]/)},{
+begin:d("m|qr",/\{/,/\}/)}]}]},{className:"function",beginKeywords:"sub",
+end:"(\\s*\\(.*?\\))?[;{]",excludeEnd:!0,relevance:5,contains:[e.TITLE_MODE]},{
+begin:"-\\w\\b",relevance:0},{begin:"^__DATA__$",end:"^__END__$",
+subLanguage:"mojolicious",contains:[{begin:"^@@.*",end:"$",className:"comment"}]
+}];return i.contains=g,r.contains=g,{name:"Perl",aliases:["pl","pm"],keywords:a,
+contains:g}},grmr_php:e=>{
+const n=e.regex,t=/(?![A-Za-z0-9])(?![$])/,a=n.concat(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,t),i=n.concat(/(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,t),r={
+scope:"variable",match:"\\$+"+a},s={scope:"subst",variants:[{begin:/\$\w+/},{
+begin:/\{\$/,end:/\}/}]},o=e.inherit(e.APOS_STRING_MODE,{illegal:null
+}),l="[ \t\n]",c={scope:"string",variants:[e.inherit(e.QUOTE_STRING_MODE,{
+illegal:null,contains:e.QUOTE_STRING_MODE.contains.concat(s)}),o,{
+begin:/<<<[ \t]*(?:(\w+)|"(\w+)")\n/,end:/[ \t]*(\w+)\b/,
+contains:e.QUOTE_STRING_MODE.contains.concat(s),"on:begin":(e,n)=>{
+n.data._beginMatch=e[1]||e[2]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}},e.END_SAME_AS_BEGIN({
+begin:/<<<[ \t]*'(\w+)'\n/,end:/[ \t]*(\w+)\b/})]},d={scope:"number",variants:[{
+begin:"\\b0[bB][01]+(?:_[01]+)*\\b"},{begin:"\\b0[oO][0-7]+(?:_[0-7]+)*\\b"},{
+begin:"\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b"},{
+begin:"(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?"
+}],relevance:0
+},g=["false","null","true"],u=["__CLASS__","__DIR__","__FILE__","__FUNCTION__","__COMPILER_HALT_OFFSET__","__LINE__","__METHOD__","__NAMESPACE__","__TRAIT__","die","echo","exit","include","include_once","print","require","require_once","array","abstract","and","as","binary","bool","boolean","break","callable","case","catch","class","clone","const","continue","declare","default","do","double","else","elseif","empty","enddeclare","endfor","endforeach","endif","endswitch","endwhile","enum","eval","extends","final","finally","float","for","foreach","from","global","goto","if","implements","instanceof","insteadof","int","integer","interface","isset","iterable","list","match|0","mixed","new","never","object","or","private","protected","public","readonly","real","return","string","switch","throw","trait","try","unset","use","var","void","while","xor","yield"],b=["Error|0","AppendIterator","ArgumentCountError","ArithmeticError","ArrayIterator","ArrayObject","AssertionError","BadFunctionCallException","BadMethodCallException","CachingIterator","CallbackFilterIterator","CompileError","Countable","DirectoryIterator","DivisionByZeroError","DomainException","EmptyIterator","ErrorException","Exception","FilesystemIterator","FilterIterator","GlobIterator","InfiniteIterator","InvalidArgumentException","IteratorIterator","LengthException","LimitIterator","LogicException","MultipleIterator","NoRewindIterator","OutOfBoundsException","OutOfRangeException","OuterIterator","OverflowException","ParentIterator","ParseError","RangeException","RecursiveArrayIterator","RecursiveCachingIterator","RecursiveCallbackFilterIterator","RecursiveDirectoryIterator","RecursiveFilterIterator","RecursiveIterator","RecursiveIteratorIterator","RecursiveRegexIterator","RecursiveTreeIterator","RegexIterator","RuntimeException","SeekableIterator","SplDoublyLinkedList","SplFileInfo","SplFileObject","SplFixedArray","SplHeap","SplMaxHeap","SplMinHeap","SplObjectStorage","SplObserver","SplPriorityQueue","SplQueue","SplStack","SplSubject","SplTempFileObject","TypeError","UnderflowException","UnexpectedValueException","UnhandledMatchError","ArrayAccess","BackedEnum","Closure","Fiber","Generator","Iterator","IteratorAggregate","Serializable","Stringable","Throwable","Traversable","UnitEnum","WeakReference","WeakMap","Directory","__PHP_Incomplete_Class","parent","php_user_filter","self","static","stdClass"],m={
+keyword:u,literal:(e=>{const n=[];return e.forEach((e=>{
+n.push(e),e.toLowerCase()===e?n.push(e.toUpperCase()):n.push(e.toLowerCase())
+})),n})(g),built_in:b},p=e=>e.map((e=>e.replace(/\|\d+$/,""))),_={variants:[{
+match:[/new/,n.concat(l,"+"),n.concat("(?!",p(b).join("\\b|"),"\\b)"),i],scope:{
+1:"keyword",4:"title.class"}}]},h=n.concat(a,"\\b(?!\\()"),f={variants:[{
+match:[n.concat(/::/,n.lookahead(/(?!class\b)/)),h],scope:{2:"variable.constant"
+}},{match:[/::/,/class/],scope:{2:"variable.language"}},{
+match:[i,n.concat(/::/,n.lookahead(/(?!class\b)/)),h],scope:{1:"title.class",
+3:"variable.constant"}},{match:[i,n.concat("::",n.lookahead(/(?!class\b)/))],
+scope:{1:"title.class"}},{match:[i,/::/,/class/],scope:{1:"title.class",
+3:"variable.language"}}]},E={scope:"attr",
+match:n.concat(a,n.lookahead(":"),n.lookahead(/(?!::)/))},y={relevance:0,
+begin:/\(/,end:/\)/,keywords:m,contains:[E,r,f,e.C_BLOCK_COMMENT_MODE,c,d,_]
+},N={relevance:0,
+match:[/\b/,n.concat("(?!fn\\b|function\\b|",p(u).join("\\b|"),"|",p(b).join("\\b|"),"\\b)"),a,n.concat(l,"*"),n.lookahead(/(?=\()/)],
+scope:{3:"title.function.invoke"},contains:[y]};y.contains.push(N)
+;const w=[E,f,e.C_BLOCK_COMMENT_MODE,c,d,_];return{case_insensitive:!1,
+keywords:m,contains:[{begin:n.concat(/#\[\s*/,i),beginScope:"meta",end:/]/,
+endScope:"meta",keywords:{literal:g,keyword:["new","array"]},contains:[{
+begin:/\[/,end:/]/,keywords:{literal:g,keyword:["new","array"]},
+contains:["self",...w]},...w,{scope:"meta",match:i}]
+},e.HASH_COMMENT_MODE,e.COMMENT("//","$"),e.COMMENT("/\\*","\\*/",{contains:[{
+scope:"doctag",match:"@[A-Za-z]+"}]}),{match:/__halt_compiler\(\);/,
+keywords:"__halt_compiler",starts:{scope:"comment",end:e.MATCH_NOTHING_RE,
+contains:[{match:/\?>/,scope:"meta",endsParent:!0}]}},{scope:"meta",variants:[{
+begin:/<\?php/,relevance:10},{begin:/<\?=/},{begin:/<\?/,relevance:.1},{
+begin:/\?>/}]},{scope:"variable.language",match:/\$this\b/},r,N,f,{
+match:[/const/,/\s/,a],scope:{1:"keyword",3:"variable.constant"}},_,{
+scope:"function",relevance:0,beginKeywords:"fn function",end:/[;{]/,
+excludeEnd:!0,illegal:"[$%\\[]",contains:[{beginKeywords:"use"
+},e.UNDERSCORE_TITLE_MODE,{begin:"=>",endsParent:!0},{scope:"params",
+begin:"\\(",end:"\\)",excludeBegin:!0,excludeEnd:!0,keywords:m,
+contains:["self",r,f,e.C_BLOCK_COMMENT_MODE,c,d]}]},{scope:"class",variants:[{
+beginKeywords:"enum",illegal:/[($"]/},{beginKeywords:"class interface trait",
+illegal:/[:($"]/}],relevance:0,end:/\{/,excludeEnd:!0,contains:[{
+beginKeywords:"extends implements"},e.UNDERSCORE_TITLE_MODE]},{
+beginKeywords:"namespace",relevance:0,end:";",illegal:/[.']/,
+contains:[e.inherit(e.UNDERSCORE_TITLE_MODE,{scope:"title.class"})]},{
+beginKeywords:"use",relevance:0,end:";",contains:[{
+match:/\b(as|const|function)\b/,scope:"keyword"},e.UNDERSCORE_TITLE_MODE]},c,d]}
+},grmr_php_template:e=>({name:"PHP template",subLanguage:"xml",contains:[{
+begin:/<\?(php|=)?/,end:/\?>/,subLanguage:"php",contains:[{begin:"/\\*",
+end:"\\*/",skip:!0},{begin:'b"',end:'"',skip:!0},{begin:"b'",end:"'",skip:!0
+},e.inherit(e.APOS_STRING_MODE,{illegal:null,className:null,contains:null,
+skip:!0}),e.inherit(e.QUOTE_STRING_MODE,{illegal:null,className:null,
+contains:null,skip:!0})]}]}),grmr_plaintext:e=>({name:"Plain text",
+aliases:["text","txt"],disableAutodetect:!0}),grmr_python:e=>{
+const n=e.regex,t=/[\p{XID_Start}_]\p{XID_Continue}*/u,a=["and","as","assert","async","await","break","case","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","match","nonlocal|10","not","or","pass","raise","return","try","while","with","yield"],i={
+$pattern:/[A-Za-z]\w+|__\w+__/,keyword:a,
+built_in:["__import__","abs","all","any","ascii","bin","bool","breakpoint","bytearray","bytes","callable","chr","classmethod","compile","complex","delattr","dict","dir","divmod","enumerate","eval","exec","filter","float","format","frozenset","getattr","globals","hasattr","hash","help","hex","id","input","int","isinstance","issubclass","iter","len","list","locals","map","max","memoryview","min","next","object","oct","open","ord","pow","print","property","range","repr","reversed","round","set","setattr","slice","sorted","staticmethod","str","sum","super","tuple","type","vars","zip"],
+literal:["__debug__","Ellipsis","False","None","NotImplemented","True"],
+type:["Any","Callable","Coroutine","Dict","List","Literal","Generic","Optional","Sequence","Set","Tuple","Type","Union"]
+},r={className:"meta",begin:/^(>>>|\.\.\.) /},s={className:"subst",begin:/\{/,
+end:/\}/,keywords:i,illegal:/#/},o={begin:/\{\{/,relevance:0},l={
+className:"string",contains:[e.BACKSLASH_ESCAPE],variants:[{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,end:/"""/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([fF][rR]|[rR][fF]|[fF])'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"""/,
+end:/"""/,contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([uU]|[rR])'/,end:/'/,
+relevance:10},{begin:/([uU]|[rR])"/,end:/"/,relevance:10},{
+begin:/([bB]|[bB][rR]|[rR][bB])'/,end:/'/},{begin:/([bB]|[bB][rR]|[rR][bB])"/,
+end:/"/},{begin:/([fF][rR]|[rR][fF]|[fF])'/,end:/'/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},c="[0-9](_?[0-9])*",d=`(\\b(${c}))?\\.(${c})|\\b(${c})\\.`,g="\\b|"+a.join("|"),u={
+className:"number",relevance:0,variants:[{
+begin:`(\\b(${c})|(${d}))[eE][+-]?(${c})[jJ]?(?=${g})`},{begin:`(${d})[jJ]?`},{
+begin:`\\b([1-9](_?[0-9])*|0+(_?0)*)[lLjJ]?(?=${g})`},{
+begin:`\\b0[bB](_?[01])+[lL]?(?=${g})`},{begin:`\\b0[oO](_?[0-7])+[lL]?(?=${g})`
+},{begin:`\\b0[xX](_?[0-9a-fA-F])+[lL]?(?=${g})`},{begin:`\\b(${c})[jJ](?=${g})`
+}]},b={className:"comment",begin:n.lookahead(/# type:/),end:/$/,keywords:i,
+contains:[{begin:/# type:/},{begin:/#/,end:/\b\B/,endsWithParent:!0}]},m={
+className:"params",variants:[{className:"",begin:/\(\s*\)/,skip:!0},{begin:/\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:i,
+contains:["self",r,u,l,e.HASH_COMMENT_MODE]}]};return s.contains=[l,u,r],{
+name:"Python",aliases:["py","gyp","ipython"],unicodeRegex:!0,keywords:i,
+illegal:/(<\/|\?)|=>/,contains:[r,u,{begin:/\bself\b/},{beginKeywords:"if",
+relevance:0},l,b,e.HASH_COMMENT_MODE,{match:[/\bdef/,/\s+/,t],scope:{
+1:"keyword",3:"title.function"},contains:[m]},{variants:[{
+match:[/\bclass/,/\s+/,t,/\s*/,/\(\s*/,t,/\s*\)/]},{match:[/\bclass/,/\s+/,t]}],
+scope:{1:"keyword",3:"title.class",6:"title.class.inherited"}},{
+className:"meta",begin:/^[\t ]*@/,end:/(?=#)|$/,contains:[u,m,l]}]}},
+grmr_python_repl:e=>({aliases:["pycon"],contains:[{className:"meta.prompt",
+starts:{end:/ |$/,starts:{end:"$",subLanguage:"python"}},variants:[{
+begin:/^>>>(?=[ ]|$)/},{begin:/^\.\.\.(?=[ ]|$)/}]}]}),grmr_r:e=>{
+const n=e.regex,t=/(?:(?:[a-zA-Z]|\.[._a-zA-Z])[._a-zA-Z0-9]*)|\.(?!\d)/,a=n.either(/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/,/0[xX][0-9a-fA-F]+(?:[pP][+-]?\d+)?[Li]?/,/(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?[Li]?/),i=/[=!<>:]=|\|\||&&|:::?|<-|<<-|->>|->|\|>|[-+*\/?!$&|:<=>@^~]|\*\*/,r=n.either(/[()]/,/[{}]/,/\[\[/,/[[\]]/,/\\/,/,/)
+;return{name:"R",keywords:{$pattern:t,
+keyword:"function if in break next repeat else for while",
+literal:"NULL NA TRUE FALSE Inf NaN NA_integer_|10 NA_real_|10 NA_character_|10 NA_complex_|10",
+built_in:"LETTERS letters month.abb month.name pi T F abs acos acosh all any anyNA Arg as.call as.character as.complex as.double as.environment as.integer as.logical as.null.default as.numeric as.raw asin asinh atan atanh attr attributes baseenv browser c call ceiling class Conj cos cosh cospi cummax cummin cumprod cumsum digamma dim dimnames emptyenv exp expression floor forceAndCall gamma gc.time globalenv Im interactive invisible is.array is.atomic is.call is.character is.complex is.double is.environment is.expression is.finite is.function is.infinite is.integer is.language is.list is.logical is.matrix is.na is.name is.nan is.null is.numeric is.object is.pairlist is.raw is.recursive is.single is.symbol lazyLoadDBfetch length lgamma list log max min missing Mod names nargs nzchar oldClass on.exit pos.to.env proc.time prod quote range Re rep retracemem return round seq_along seq_len seq.int sign signif sin sinh sinpi sqrt standardGeneric substitute sum switch tan tanh tanpi tracemem trigamma trunc unclass untracemem UseMethod xtfrm"
+},contains:[e.COMMENT(/#'/,/$/,{contains:[{scope:"doctag",match:/@examples/,
+starts:{end:n.lookahead(n.either(/\n^#'\s*(?=@[a-zA-Z]+)/,/\n^(?!#')/)),
+endsParent:!0}},{scope:"doctag",begin:"@param",end:/$/,contains:[{
+scope:"variable",variants:[{match:t},{match:/`(?:\\.|[^`\\])+`/}],endsParent:!0
+}]},{scope:"doctag",match:/@[a-zA-Z]+/},{scope:"keyword",match:/\\[a-zA-Z]+/}]
+}),e.HASH_COMMENT_MODE,{scope:"string",contains:[e.BACKSLASH_ESCAPE],
+variants:[e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\(/,end:/\)(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\{/,end:/\}(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\[/,end:/\](-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\(/,end:/\)(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\{/,end:/\}(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\[/,end:/\](-*)'/}),{begin:'"',end:'"',
+relevance:0},{begin:"'",end:"'",relevance:0}]},{relevance:0,variants:[{scope:{
+1:"operator",2:"number"},match:[i,a]},{scope:{1:"operator",2:"number"},
+match:[/%[^%]*%/,a]},{scope:{1:"punctuation",2:"number"},match:[r,a]},{scope:{
+2:"number"},match:[/[^a-zA-Z0-9._]|^/,a]}]},{scope:{3:"operator"},
+match:[t,/\s+/,/<-/,/\s+/]},{scope:"operator",relevance:0,variants:[{match:i},{
+match:/%[^%]*%/}]},{scope:"punctuation",relevance:0,match:r},{begin:"`",end:"`",
+contains:[{begin:/\\./}]}]}},grmr_ruby:e=>{
+const n=e.regex,t="([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)",a=n.either(/\b([A-Z]+[a-z0-9]+)+/,/\b([A-Z]+[a-z0-9]+)+[A-Z]+/),i=n.concat(a,/(::\w+)*/),r={
+"variable.constant":["__FILE__","__LINE__","__ENCODING__"],
+"variable.language":["self","super"],
+keyword:["alias","and","begin","BEGIN","break","case","class","defined","do","else","elsif","end","END","ensure","for","if","in","module","next","not","or","redo","require","rescue","retry","return","then","undef","unless","until","when","while","yield","include","extend","prepend","public","private","protected","raise","throw"],
+built_in:["proc","lambda","attr_accessor","attr_reader","attr_writer","define_method","private_constant","module_function"],
+literal:["true","false","nil"]},s={className:"doctag",begin:"@[A-Za-z]+"},o={
+begin:"#<",end:">"},l=[e.COMMENT("#","$",{contains:[s]
+}),e.COMMENT("^=begin","^=end",{contains:[s],relevance:10
+}),e.COMMENT("^__END__",e.MATCH_NOTHING_RE)],c={className:"subst",begin:/#\{/,
+end:/\}/,keywords:r},d={className:"string",contains:[e.BACKSLASH_ESCAPE,c],
+variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/},{begin:/`/,end:/`/},{
+begin:/%[qQwWx]?\(/,end:/\)/},{begin:/%[qQwWx]?\[/,end:/\]/},{
+begin:/%[qQwWx]?\{/,end:/\}/},{begin:/%[qQwWx]?</,end:/>/},{begin:/%[qQwWx]?\//,
+end:/\//},{begin:/%[qQwWx]?%/,end:/%/},{begin:/%[qQwWx]?-/,end:/-/},{
+begin:/%[qQwWx]?\|/,end:/\|/},{begin:/\B\?(\\\d{1,3})/},{
+begin:/\B\?(\\x[A-Fa-f0-9]{1,2})/},{begin:/\B\?(\\u\{?[A-Fa-f0-9]{1,6}\}?)/},{
+begin:/\B\?(\\M-\\C-|\\M-\\c|\\c\\M-|\\M-|\\C-\\M-)[\x20-\x7e]/},{
+begin:/\B\?\\(c|C-)[\x20-\x7e]/},{begin:/\B\?\\?\S/},{
+begin:n.concat(/<<[-~]?'?/,n.lookahead(/(\w+)(?=\W)[^\n]*\n(?:[^\n]*\n)*?\s*\1\b/)),
+contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,end:/(\w+)/,
+contains:[e.BACKSLASH_ESCAPE,c]})]}]},g="[0-9](_?[0-9])*",u={className:"number",
+relevance:0,variants:[{
+begin:`\\b([1-9](_?[0-9])*|0)(\\.(${g}))?([eE][+-]?(${g})|r)?i?\\b`},{
+begin:"\\b0[dD][0-9](_?[0-9])*r?i?\\b"},{begin:"\\b0[bB][0-1](_?[0-1])*r?i?\\b"
+},{begin:"\\b0[oO][0-7](_?[0-7])*r?i?\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*r?i?\\b"},{
+begin:"\\b0(_?[0-7])+r?i?\\b"}]},b={variants:[{match:/\(\)/},{
+className:"params",begin:/\(/,end:/(?=\))/,excludeBegin:!0,endsParent:!0,
+keywords:r}]},m=[d,{variants:[{match:[/class\s+/,i,/\s+<\s+/,i]},{
+match:[/\b(class|module)\s+/,i]}],scope:{2:"title.class",
+4:"title.class.inherited"},keywords:r},{match:[/(include|extend)\s+/,i],scope:{
+2:"title.class"},keywords:r},{relevance:0,match:[i,/\.new[. (]/],scope:{
+1:"title.class"}},{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},{relevance:0,match:a,scope:"title.class"},{
+match:[/def/,/\s+/,t],scope:{1:"keyword",3:"title.function"},contains:[b]},{
+begin:e.IDENT_RE+"::"},{className:"symbol",
+begin:e.UNDERSCORE_IDENT_RE+"(!|\\?)?:",relevance:0},{className:"symbol",
+begin:":(?!\\s)",contains:[d,{begin:t}],relevance:0},u,{className:"variable",
+begin:"(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])(?![A-Za-z])(?![@$?'])"},{
+className:"params",begin:/\|/,end:/\|/,excludeBegin:!0,excludeEnd:!0,
+relevance:0,keywords:r},{begin:"("+e.RE_STARTERS_RE+"|unless)\\s*",
+keywords:"unless",contains:[{className:"regexp",contains:[e.BACKSLASH_ESCAPE,c],
+illegal:/\n/,variants:[{begin:"/",end:"/[a-z]*"},{begin:/%r\{/,end:/\}[a-z]*/},{
+begin:"%r\\(",end:"\\)[a-z]*"},{begin:"%r!",end:"![a-z]*"},{begin:"%r\\[",
+end:"\\][a-z]*"}]}].concat(o,l),relevance:0}].concat(o,l)
+;c.contains=m,b.contains=m;const p=[{begin:/^\s*=>/,starts:{end:"$",contains:m}
+},{className:"meta.prompt",
+begin:"^([>?]>|[\\w#]+\\(\\w+\\):\\d+:\\d+[>*]|(\\w+-)?\\d+\\.\\d+\\.\\d+(p\\d+)?[^\\d][^>]+>)(?=[ ])",
+starts:{end:"$",keywords:r,contains:m}}];return l.unshift(o),{name:"Ruby",
+aliases:["rb","gemspec","podspec","thor","irb"],keywords:r,illegal:/\/\*/,
+contains:[e.SHEBANG({binary:"ruby"})].concat(p).concat(l).concat(m)}},
+grmr_rust:e=>{const n=e.regex,t={className:"title.function.invoke",relevance:0,
+begin:n.concat(/\b/,/(?!let|for|while|if|else|match\b)/,e.IDENT_RE,n.lookahead(/\s*\(/))
+},a="([ui](8|16|32|64|128|size)|f(32|64))?",i=["drop ","Copy","Send","Sized","Sync","Drop","Fn","FnMut","FnOnce","ToOwned","Clone","Debug","PartialEq","PartialOrd","Eq","Ord","AsRef","AsMut","Into","From","Default","Iterator","Extend","IntoIterator","DoubleEndedIterator","ExactSizeIterator","SliceConcatExt","ToString","assert!","assert_eq!","bitflags!","bytes!","cfg!","col!","concat!","concat_idents!","debug_assert!","debug_assert_eq!","env!","eprintln!","panic!","file!","format!","format_args!","include_bytes!","include_str!","line!","local_data_key!","module_path!","option_env!","print!","println!","select!","stringify!","try!","unimplemented!","unreachable!","vec!","write!","writeln!","macro_rules!","assert_ne!","debug_assert_ne!"],r=["i8","i16","i32","i64","i128","isize","u8","u16","u32","u64","u128","usize","f32","f64","str","char","bool","Box","Option","Result","String","Vec"]
+;return{name:"Rust",aliases:["rs"],keywords:{$pattern:e.IDENT_RE+"!?",type:r,
+keyword:["abstract","as","async","await","become","box","break","const","continue","crate","do","dyn","else","enum","extern","false","final","fn","for","if","impl","in","let","loop","macro","match","mod","move","mut","override","priv","pub","ref","return","self","Self","static","struct","super","trait","true","try","type","typeof","unsafe","unsized","use","virtual","where","while","yield"],
+literal:["true","false","Some","None","Ok","Err"],built_in:i},illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.COMMENT("/\\*","\\*/",{contains:["self"]
+}),e.inherit(e.QUOTE_STRING_MODE,{begin:/b?"/,illegal:null}),{
+className:"string",variants:[{begin:/b?r(#*)"(.|\n)*?"\1(?!#)/},{
+begin:/b?'\\?(x\w{2}|u\w{4}|U\w{8}|.)'/}]},{className:"symbol",
+begin:/'[a-zA-Z_][a-zA-Z0-9_]*/},{className:"number",variants:[{
+begin:"\\b0b([01_]+)"+a},{begin:"\\b0o([0-7_]+)"+a},{
+begin:"\\b0x([A-Fa-f0-9_]+)"+a},{
+begin:"\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)"+a}],relevance:0},{
+begin:[/fn/,/\s+/,e.UNDERSCORE_IDENT_RE],className:{1:"keyword",
+3:"title.function"}},{className:"meta",begin:"#!?\\[",end:"\\]",contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+begin:[/let/,/\s+/,/(?:mut\s+)?/,e.UNDERSCORE_IDENT_RE],className:{1:"keyword",
+3:"keyword",4:"variable"}},{
+begin:[/for/,/\s+/,e.UNDERSCORE_IDENT_RE,/\s+/,/in/],className:{1:"keyword",
+3:"variable",5:"keyword"}},{begin:[/type/,/\s+/,e.UNDERSCORE_IDENT_RE],
+className:{1:"keyword",3:"title.class"}},{
+begin:[/(?:trait|enum|struct|union|impl|for)/,/\s+/,e.UNDERSCORE_IDENT_RE],
+className:{1:"keyword",3:"title.class"}},{begin:e.IDENT_RE+"::",keywords:{
+keyword:"Self",built_in:i,type:r}},{className:"punctuation",begin:"->"},t]}},
+grmr_scss:e=>{const n=ie(e),t=le,a=oe,i="@[a-z-]+",r={className:"variable",
+begin:"(\\$[a-zA-Z-][a-zA-Z0-9_-]*)\\b",relevance:0};return{name:"SCSS",
+case_insensitive:!0,illegal:"[=/|']",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,n.CSS_NUMBER_MODE,{
+className:"selector-id",begin:"#[A-Za-z0-9_-]+",relevance:0},{
+className:"selector-class",begin:"\\.[A-Za-z0-9_-]+",relevance:0
+},n.ATTRIBUTE_SELECTOR_MODE,{className:"selector-tag",
+begin:"\\b("+re.join("|")+")\\b",relevance:0},{className:"selector-pseudo",
+begin:":("+a.join("|")+")"},{className:"selector-pseudo",
+begin:":(:)?("+t.join("|")+")"},r,{begin:/\(/,end:/\)/,
+contains:[n.CSS_NUMBER_MODE]},n.CSS_VARIABLE,{className:"attribute",
+begin:"\\b("+ce.join("|")+")\\b"},{
+begin:"\\b(whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|underline|transparent|top|thin|thick|text|text-top|text-bottom|tb-rl|table-header-group|table-footer-group|sw-resize|super|strict|static|square|solid|small-caps|separate|se-resize|scroll|s-resize|rtl|row-resize|ridge|right|repeat|repeat-y|repeat-x|relative|progress|pointer|overline|outside|outset|oblique|nowrap|not-allowed|normal|none|nw-resize|no-repeat|no-drop|newspaper|ne-resize|n-resize|move|middle|medium|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|list-item|line|line-through|line-edge|lighter|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline|inline-block|inherit|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|horizontal|hidden|help|hand|groove|fixed|ellipsis|e-resize|double|dotted|distribute|distribute-space|distribute-letter|distribute-all-lines|disc|disabled|default|decimal|dashed|crosshair|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|bolder|bold|block|bidi-override|below|baseline|auto|always|all-scroll|absolute|table|table-cell)\\b"
+},{begin:/:/,end:/[;}{]/,relevance:0,
+contains:[n.BLOCK_COMMENT,r,n.HEXCOLOR,n.CSS_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.IMPORTANT,n.FUNCTION_DISPATCH]
+},{begin:"@(page|font-face)",keywords:{$pattern:i,keyword:"@page @font-face"}},{
+begin:"@",end:"[{;]",returnBegin:!0,keywords:{$pattern:/[a-z-]+/,
+keyword:"and or not only",attribute:se.join(" ")},contains:[{begin:i,
+className:"keyword"},{begin:/[a-z-]+(?=:)/,className:"attribute"
+},r,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.HEXCOLOR,n.CSS_NUMBER_MODE]
+},n.FUNCTION_DISPATCH]}},grmr_shell:e=>({name:"Shell Session",
+aliases:["console","shellsession"],contains:[{className:"meta.prompt",
+begin:/^\s{0,3}[/~\w\d[\]()@-]*[>%$#][ ]?/,starts:{end:/[^\\](?=\s*$)/,
+subLanguage:"bash"}}]}),grmr_sql:e=>{
+const n=e.regex,t=e.COMMENT("--","$"),a=["true","false","unknown"],i=["bigint","binary","blob","boolean","char","character","clob","date","dec","decfloat","decimal","float","int","integer","interval","nchar","nclob","national","numeric","real","row","smallint","time","timestamp","varchar","varying","varbinary"],r=["abs","acos","array_agg","asin","atan","avg","cast","ceil","ceiling","coalesce","corr","cos","cosh","count","covar_pop","covar_samp","cume_dist","dense_rank","deref","element","exp","extract","first_value","floor","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","last_value","lead","listagg","ln","log","log10","lower","max","min","mod","nth_value","ntile","nullif","percent_rank","percentile_cont","percentile_disc","position","position_regex","power","rank","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","row_number","sin","sinh","sqrt","stddev_pop","stddev_samp","substring","substring_regex","sum","tan","tanh","translate","translate_regex","treat","trim","trim_array","unnest","upper","value_of","var_pop","var_samp","width_bucket"],s=["create table","insert into","primary key","foreign key","not null","alter table","add constraint","grouping sets","on overflow","character set","respect nulls","ignore nulls","nulls first","nulls last","depth first","breadth first"],o=r,l=["abs","acos","all","allocate","alter","and","any","are","array","array_agg","array_max_cardinality","as","asensitive","asin","asymmetric","at","atan","atomic","authorization","avg","begin","begin_frame","begin_partition","between","bigint","binary","blob","boolean","both","by","call","called","cardinality","cascaded","case","cast","ceil","ceiling","char","char_length","character","character_length","check","classifier","clob","close","coalesce","collate","collect","column","commit","condition","connect","constraint","contains","convert","copy","corr","corresponding","cos","cosh","count","covar_pop","covar_samp","create","cross","cube","cume_dist","current","current_catalog","current_date","current_default_transform_group","current_path","current_role","current_row","current_schema","current_time","current_timestamp","current_path","current_role","current_transform_group_for_type","current_user","cursor","cycle","date","day","deallocate","dec","decimal","decfloat","declare","default","define","delete","dense_rank","deref","describe","deterministic","disconnect","distinct","double","drop","dynamic","each","element","else","empty","end","end_frame","end_partition","end-exec","equals","escape","every","except","exec","execute","exists","exp","external","extract","false","fetch","filter","first_value","float","floor","for","foreign","frame_row","free","from","full","function","fusion","get","global","grant","group","grouping","groups","having","hold","hour","identity","in","indicator","initial","inner","inout","insensitive","insert","int","integer","intersect","intersection","interval","into","is","join","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","language","large","last_value","lateral","lead","leading","left","like","like_regex","listagg","ln","local","localtime","localtimestamp","log","log10","lower","match","match_number","match_recognize","matches","max","member","merge","method","min","minute","mod","modifies","module","month","multiset","national","natural","nchar","nclob","new","no","none","normalize","not","nth_value","ntile","null","nullif","numeric","octet_length","occurrences_regex","of","offset","old","omit","on","one","only","open","or","order","out","outer","over","overlaps","overlay","parameter","partition","pattern","per","percent","percent_rank","percentile_cont","percentile_disc","period","portion","position","position_regex","power","precedes","precision","prepare","primary","procedure","ptf","range","rank","reads","real","recursive","ref","references","referencing","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","release","result","return","returns","revoke","right","rollback","rollup","row","row_number","rows","running","savepoint","scope","scroll","search","second","seek","select","sensitive","session_user","set","show","similar","sin","sinh","skip","smallint","some","specific","specifictype","sql","sqlexception","sqlstate","sqlwarning","sqrt","start","static","stddev_pop","stddev_samp","submultiset","subset","substring","substring_regex","succeeds","sum","symmetric","system","system_time","system_user","table","tablesample","tan","tanh","then","time","timestamp","timezone_hour","timezone_minute","to","trailing","translate","translate_regex","translation","treat","trigger","trim","trim_array","true","truncate","uescape","union","unique","unknown","unnest","update","upper","user","using","value","values","value_of","var_pop","var_samp","varbinary","varchar","varying","versioning","when","whenever","where","width_bucket","window","with","within","without","year","add","asc","collation","desc","final","first","last","view"].filter((e=>!r.includes(e))),c={
+begin:n.concat(/\b/,n.either(...o),/\s*\(/),relevance:0,keywords:{built_in:o}}
+;return{name:"SQL",case_insensitive:!0,illegal:/[{}]|<\//,keywords:{
+$pattern:/\b[\w\.]+/,keyword:((e,{exceptions:n,when:t}={})=>{const a=t
+;return n=n||[],e.map((e=>e.match(/\|\d+$/)||n.includes(e)?e:a(e)?e+"|0":e))
+})(l,{when:e=>e.length<3}),literal:a,type:i,
+built_in:["current_catalog","current_date","current_default_transform_group","current_path","current_role","current_schema","current_transform_group_for_type","current_user","session_user","system_time","system_user","current_time","localtime","current_timestamp","localtimestamp"]
+},contains:[{begin:n.either(...s),relevance:0,keywords:{$pattern:/[\w\.]+/,
+keyword:l.concat(s),literal:a,type:i}},{className:"type",
+begin:n.either("double precision","large object","with timezone","without timezone")
+},c,{className:"variable",begin:/@[a-z0-9][a-z0-9_]*/},{className:"string",
+variants:[{begin:/'/,end:/'/,contains:[{begin:/''/}]}]},{begin:/"/,end:/"/,
+contains:[{begin:/""/}]},e.C_NUMBER_MODE,e.C_BLOCK_COMMENT_MODE,t,{
+className:"operator",begin:/[-+*/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?/,
+relevance:0}]}},grmr_swift:e=>{const n={match:/\s+/,relevance:0
+},t=e.COMMENT("/\\*","\\*/",{contains:["self"]}),a=[e.C_LINE_COMMENT_MODE,t],i={
+match:[/\./,m(...xe,...Me)],className:{2:"keyword"}},r={match:b(/\./,m(...Ae)),
+relevance:0},s=Ae.filter((e=>"string"==typeof e)).concat(["_|0"]),o={variants:[{
+className:"keyword",
+match:m(...Ae.filter((e=>"string"!=typeof e)).concat(Se).map(ke),...Me)}]},l={
+$pattern:m(/\b\w+/,/#\w+/),keyword:s.concat(Re),literal:Ce},c=[i,r,o],g=[{
+match:b(/\./,m(...De)),relevance:0},{className:"built_in",
+match:b(/\b/,m(...De),/(?=\()/)}],u={match:/->/,relevance:0},p=[u,{
+className:"operator",relevance:0,variants:[{match:Be},{match:`\\.(\\.|${Le})+`}]
+}],_="([0-9]_*)+",h="([0-9a-fA-F]_*)+",f={className:"number",relevance:0,
+variants:[{match:`\\b(${_})(\\.(${_}))?([eE][+-]?(${_}))?\\b`},{
+match:`\\b0x(${h})(\\.(${h}))?([pP][+-]?(${_}))?\\b`},{match:/\b0o([0-7]_*)+\b/
+},{match:/\b0b([01]_*)+\b/}]},E=(e="")=>({className:"subst",variants:[{
+match:b(/\\/,e,/[0\\tnr"']/)},{match:b(/\\/,e,/u\{[0-9a-fA-F]{1,8}\}/)}]
+}),y=(e="")=>({className:"subst",match:b(/\\/,e,/[\t ]*(?:[\r\n]|\r\n)/)
+}),N=(e="")=>({className:"subst",label:"interpol",begin:b(/\\/,e,/\(/),end:/\)/
+}),w=(e="")=>({begin:b(e,/"""/),end:b(/"""/,e),contains:[E(e),y(e),N(e)]
+}),v=(e="")=>({begin:b(e,/"/),end:b(/"/,e),contains:[E(e),N(e)]}),O={
+className:"string",
+variants:[w(),w("#"),w("##"),w("###"),v(),v("#"),v("##"),v("###")]
+},k=[e.BACKSLASH_ESCAPE,{begin:/\[/,end:/\]/,relevance:0,
+contains:[e.BACKSLASH_ESCAPE]}],x={begin:/\/[^\s](?=[^/\n]*\/)/,end:/\//,
+contains:k},M=e=>{const n=b(e,/\//),t=b(/\//,e);return{begin:n,end:t,
+contains:[...k,{scope:"comment",begin:`#(?!.*${t})`,end:/$/}]}},S={
+scope:"regexp",variants:[M("###"),M("##"),M("#"),x]},A={match:b(/`/,Fe,/`/)
+},C=[A,{className:"variable",match:/\$\d+/},{className:"variable",
+match:`\\$${ze}+`}],T=[{match:/(@|#(un)?)available/,scope:"keyword",starts:{
+contains:[{begin:/\(/,end:/\)/,keywords:Pe,contains:[...p,f,O]}]}},{
+scope:"keyword",match:b(/@/,m(...je))},{scope:"meta",match:b(/@/,Fe)}],R={
+match:d(/\b[A-Z]/),relevance:0,contains:[{className:"type",
+match:b(/(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)/,ze,"+")
+},{className:"type",match:Ue,relevance:0},{match:/[?!]+/,relevance:0},{
+match:/\.\.\./,relevance:0},{match:b(/\s+&\s+/,d(Ue)),relevance:0}]},D={
+begin:/</,end:/>/,keywords:l,contains:[...a,...c,...T,u,R]};R.contains.push(D)
+;const I={begin:/\(/,end:/\)/,relevance:0,keywords:l,contains:["self",{
+match:b(Fe,/\s*:/),keywords:"_|0",relevance:0
+},...a,S,...c,...g,...p,f,O,...C,...T,R]},L={begin:/</,end:/>/,
+keywords:"repeat each",contains:[...a,R]},B={begin:/\(/,end:/\)/,keywords:l,
+contains:[{begin:m(d(b(Fe,/\s*:/)),d(b(Fe,/\s+/,Fe,/\s*:/))),end:/:/,
+relevance:0,contains:[{className:"keyword",match:/\b_\b/},{className:"params",
+match:Fe}]},...a,...c,...p,f,O,...T,R,I],endsParent:!0,illegal:/["']/},$={
+match:[/(func|macro)/,/\s+/,m(A.match,Fe,Be)],className:{1:"keyword",
+3:"title.function"},contains:[L,B,n],illegal:[/\[/,/%/]},z={
+match:[/\b(?:subscript|init[?!]?)/,/\s*(?=[<(])/],className:{1:"keyword"},
+contains:[L,B,n],illegal:/\[|%/},F={match:[/operator/,/\s+/,Be],className:{
+1:"keyword",3:"title"}},U={begin:[/precedencegroup/,/\s+/,Ue],className:{
+1:"keyword",3:"title"},contains:[R],keywords:[...Te,...Ce],end:/}/}
+;for(const e of O.variants){const n=e.contains.find((e=>"interpol"===e.label))
+;n.keywords=l;const t=[...c,...g,...p,f,O,...C];n.contains=[...t,{begin:/\(/,
+end:/\)/,contains:["self",...t]}]}return{name:"Swift",keywords:l,
+contains:[...a,$,z,{beginKeywords:"struct protocol class extension enum actor",
+end:"\\{",excludeEnd:!0,keywords:l,contains:[e.inherit(e.TITLE_MODE,{
+className:"title.class",begin:/[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/}),...c]
+},F,U,{beginKeywords:"import",end:/$/,contains:[...a],relevance:0
+},S,...c,...g,...p,f,O,...C,...T,R,I]}},grmr_typescript:e=>{
+const n=Oe(e),t=_e,a=["any","void","number","boolean","string","object","never","symbol","bigint","unknown"],i={
+beginKeywords:"namespace",end:/\{/,excludeEnd:!0,
+contains:[n.exports.CLASS_REFERENCE]},r={beginKeywords:"interface",end:/\{/,
+excludeEnd:!0,keywords:{keyword:"interface extends",built_in:a},
+contains:[n.exports.CLASS_REFERENCE]},s={$pattern:_e,
+keyword:he.concat(["type","namespace","interface","public","private","protected","implements","declare","abstract","readonly","enum","override"]),
+literal:fe,built_in:ve.concat(a),"variable.language":we},o={className:"meta",
+begin:"@"+t},l=(e,n,t)=>{const a=e.contains.findIndex((e=>e.label===n))
+;if(-1===a)throw Error("can not find mode to replace");e.contains.splice(a,1,t)}
+;return Object.assign(n.keywords,s),
+n.exports.PARAMS_CONTAINS.push(o),n.contains=n.contains.concat([o,i,r]),
+l(n,"shebang",e.SHEBANG()),l(n,"use_strict",{className:"meta",relevance:10,
+begin:/^\s*['"]use strict['"]/
+}),n.contains.find((e=>"func.def"===e.label)).relevance=0,Object.assign(n,{
+name:"TypeScript",aliases:["ts","tsx","mts","cts"]}),n},grmr_vbnet:e=>{
+const n=e.regex,t=/\d{1,2}\/\d{1,2}\/\d{4}/,a=/\d{4}-\d{1,2}-\d{1,2}/,i=/(\d|1[012])(:\d+){0,2} *(AM|PM)/,r=/\d{1,2}(:\d{1,2}){1,2}/,s={
+className:"literal",variants:[{begin:n.concat(/# */,n.either(a,t),/ *#/)},{
+begin:n.concat(/# */,r,/ *#/)},{begin:n.concat(/# */,i,/ *#/)},{
+begin:n.concat(/# */,n.either(a,t),/ +/,n.either(i,r),/ *#/)}]
+},o=e.COMMENT(/'''/,/$/,{contains:[{className:"doctag",begin:/<\/?/,end:/>/}]
+}),l=e.COMMENT(null,/$/,{variants:[{begin:/'/},{begin:/([\t ]|^)REM(?=\s)/}]})
+;return{name:"Visual Basic .NET",aliases:["vb"],case_insensitive:!0,
+classNameAliases:{label:"symbol"},keywords:{
+keyword:"addhandler alias aggregate ansi as async assembly auto binary by byref byval call case catch class compare const continue custom declare default delegate dim distinct do each equals else elseif end enum erase error event exit explicit finally for friend from function get global goto group handles if implements imports in inherits interface into iterator join key let lib loop me mid module mustinherit mustoverride mybase myclass namespace narrowing new next notinheritable notoverridable of off on operator option optional order overloads overridable overrides paramarray partial preserve private property protected public raiseevent readonly redim removehandler resume return select set shadows shared skip static step stop structure strict sub synclock take text then throw to try unicode until using when where while widening with withevents writeonly yield",
+built_in:"addressof and andalso await directcast gettype getxmlnamespace is isfalse isnot istrue like mod nameof new not or orelse trycast typeof xor cbool cbyte cchar cdate cdbl cdec cint clng cobj csbyte cshort csng cstr cuint culng cushort",
+type:"boolean byte char date decimal double integer long object sbyte short single string uinteger ulong ushort",
+literal:"true false nothing"},
+illegal:"//|\\{|\\}|endif|gosub|variant|wend|^\\$ ",contains:[{
+className:"string",begin:/"(""|[^/n])"C\b/},{className:"string",begin:/"/,
+end:/"/,illegal:/\n/,contains:[{begin:/""/}]},s,{className:"number",relevance:0,
+variants:[{begin:/\b\d[\d_]*((\.[\d_]+(E[+-]?[\d_]+)?)|(E[+-]?[\d_]+))[RFD@!#]?/
+},{begin:/\b\d[\d_]*((U?[SIL])|[%&])?/},{begin:/&H[\dA-F_]+((U?[SIL])|[%&])?/},{
+begin:/&O[0-7_]+((U?[SIL])|[%&])?/},{begin:/&B[01_]+((U?[SIL])|[%&])?/}]},{
+className:"label",begin:/^\w+:/},o,l,{className:"meta",
+begin:/[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
+end:/$/,keywords:{
+keyword:"const disable else elseif enable end externalsource if region then"},
+contains:[l]}]}},grmr_wasm:e=>{e.regex;const n=e.COMMENT(/\(;/,/;\)/)
+;return n.contains.push("self"),{name:"WebAssembly",keywords:{$pattern:/[\w.]+/,
+keyword:["anyfunc","block","br","br_if","br_table","call","call_indirect","data","drop","elem","else","end","export","func","global.get","global.set","local.get","local.set","local.tee","get_global","get_local","global","if","import","local","loop","memory","memory.grow","memory.size","module","mut","nop","offset","param","result","return","select","set_global","set_local","start","table","tee_local","then","type","unreachable"]
+},contains:[e.COMMENT(/;;/,/$/),n,{match:[/(?:offset|align)/,/\s*/,/=/],
+className:{1:"keyword",3:"operator"}},{className:"variable",begin:/\$[\w_]+/},{
+match:/(\((?!;)|\))+/,className:"punctuation",relevance:0},{
+begin:[/(?:func|call|call_indirect)/,/\s+/,/\$[^\s)]+/],className:{1:"keyword",
+3:"title.function"}},e.QUOTE_STRING_MODE,{match:/(i32|i64|f32|f64)(?!\.)/,
+className:"type"},{className:"keyword",
+match:/\b(f32|f64|i32|i64)(?:\.(?:abs|add|and|ceil|clz|const|convert_[su]\/i(?:32|64)|copysign|ctz|demote\/f64|div(?:_[su])?|eqz?|extend_[su]\/i32|floor|ge(?:_[su])?|gt(?:_[su])?|le(?:_[su])?|load(?:(?:8|16|32)_[su])?|lt(?:_[su])?|max|min|mul|nearest|neg?|or|popcnt|promote\/f32|reinterpret\/[fi](?:32|64)|rem_[su]|rot[lr]|shl|shr_[su]|store(?:8|16|32)?|sqrt|sub|trunc(?:_[su]\/f(?:32|64))?|wrap\/i64|xor))\b/
+},{className:"number",relevance:0,
+match:/[+-]?\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|0x[\da-fA-F](?:_?[\da-fA-F])*(?:\.[\da-fA-F](?:_?[\da-fA-D])*)?(?:[pP][+-]?\d(?:_?\d)*)?)\b|\binf\b|\bnan(?::0x[\da-fA-F](?:_?[\da-fA-D])*)?\b/
+}]}},grmr_xml:e=>{
+const n=e.regex,t=n.concat(/[\p{L}_]/u,n.optional(/[\p{L}0-9_.-]*:/u),/[\p{L}0-9_.-]*/u),a={
+className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},i={begin:/\s/,
+contains:[{className:"keyword",begin:/#?[a-z_][a-z1-9_-]+/,illegal:/\n/}]
+},r=e.inherit(i,{begin:/\(/,end:/\)/}),s=e.inherit(e.APOS_STRING_MODE,{
+className:"string"}),o=e.inherit(e.QUOTE_STRING_MODE,{className:"string"}),l={
+endsWithParent:!0,illegal:/</,relevance:0,contains:[{className:"attr",
+begin:/[\p{L}0-9._:-]+/u,relevance:0},{begin:/=\s*/,relevance:0,contains:[{
+className:"string",endsParent:!0,variants:[{begin:/"/,end:/"/,contains:[a]},{
+begin:/'/,end:/'/,contains:[a]},{begin:/[^\s"'=<>`]+/}]}]}]};return{
+name:"HTML, XML",
+aliases:["html","xhtml","rss","atom","xjb","xsd","xsl","plist","wsf","svg"],
+case_insensitive:!0,unicodeRegex:!0,contains:[{className:"meta",begin:/<![a-z]/,
+end:/>/,relevance:10,contains:[i,o,s,r,{begin:/\[/,end:/\]/,contains:[{
+className:"meta",begin:/<![a-z]/,end:/>/,contains:[i,r,o,s]}]}]
+},e.COMMENT(/<!--/,/-->/,{relevance:10}),{begin:/<!\[CDATA\[/,end:/\]\]>/,
+relevance:10},a,{className:"meta",end:/\?>/,variants:[{begin:/<\?xml/,
+relevance:10,contains:[o]},{begin:/<\?[a-z][a-z0-9]+/}]},{className:"tag",
+begin:/<style(?=\s|>)/,end:/>/,keywords:{name:"style"},contains:[l],starts:{
+end:/<\/style>/,returnEnd:!0,subLanguage:["css","xml"]}},{className:"tag",
+begin:/<script(?=\s|>)/,end:/>/,keywords:{name:"script"},contains:[l],starts:{
+end:/<\/script>/,returnEnd:!0,subLanguage:["javascript","handlebars","xml"]}},{
+className:"tag",begin:/<>|<\/>/},{className:"tag",
+begin:n.concat(/</,n.lookahead(n.concat(t,n.either(/\/>/,/>/,/\s/)))),
+end:/\/?>/,contains:[{className:"name",begin:t,relevance:0,starts:l}]},{
+className:"tag",begin:n.concat(/<\//,n.lookahead(n.concat(t,/>/))),contains:[{
+className:"name",begin:t,relevance:0},{begin:/>/,relevance:0,endsParent:!0}]}]}
+},grmr_yaml:e=>{
+const n="true false yes no null",t="[\\w#;/?:@&=+$,.~*'()[\\]]+",a={
+className:"string",relevance:0,variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/
+},{begin:/\S+/}],contains:[e.BACKSLASH_ESCAPE,{className:"template-variable",
+variants:[{begin:/\{\{/,end:/\}\}/},{begin:/%\{/,end:/\}/}]}]},i=e.inherit(a,{
+variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/},{begin:/[^\s,{}[\]]+/}]}),r={
+end:",",endsWithParent:!0,excludeEnd:!0,keywords:n,relevance:0},s={begin:/\{/,
+end:/\}/,contains:[r],illegal:"\\n",relevance:0},o={begin:"\\[",end:"\\]",
+contains:[r],illegal:"\\n",relevance:0},l=[{className:"attr",variants:[{
+begin:"\\w[\\w :\\/.-]*:(?=[ \t]|$)"},{begin:'"\\w[\\w :\\/.-]*":(?=[ \t]|$)'},{
+begin:"'\\w[\\w :\\/.-]*':(?=[ \t]|$)"}]},{className:"meta",begin:"^---\\s*$",
+relevance:10},{className:"string",
+begin:"[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*"},{
+begin:"<%[%=-]?",end:"[%-]?%>",subLanguage:"ruby",excludeBegin:!0,excludeEnd:!0,
+relevance:0},{className:"type",begin:"!\\w+!"+t},{className:"type",
+begin:"!<"+t+">"},{className:"type",begin:"!"+t},{className:"type",begin:"!!"+t
+},{className:"meta",begin:"&"+e.UNDERSCORE_IDENT_RE+"$"},{className:"meta",
+begin:"\\*"+e.UNDERSCORE_IDENT_RE+"$"},{className:"bullet",begin:"-(?=[ ]|$)",
+relevance:0},e.HASH_COMMENT_MODE,{beginKeywords:n,keywords:{literal:n}},{
+className:"number",
+begin:"\\b[0-9]{4}(-[0-9][0-9]){0,2}([Tt \\t][0-9][0-9]?(:[0-9][0-9]){2})?(\\.[0-9]*)?([ \\t])*(Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?\\b"
+},{className:"number",begin:e.C_NUMBER_RE+"\\b",relevance:0},s,o,a],c=[...l]
+;return c.pop(),c.push(i),r.contains=c,{name:"YAML",case_insensitive:!0,
+aliases:["yml"],contains:l}}});const He=ae;for(const e of Object.keys(Ke)){
+const n=e.replace("grmr_","").replace("_","-");He.registerLanguage(n,Ke[e])}
+return He}()
+;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);

--- a/docs/src/theme/highlight/languages/bash.min.js
+++ b/docs/src/theme/highlight/languages/bash.min.js
@@ -1,0 +1,20 @@
+/*! `bash` grammar compiled for Highlight.js 11.9.0 */
+(()=>{var e=(()=>{"use strict";return e=>{const s=e.regex,t={},n={begin:/\$\{/,
+end:/\}/,contains:["self",{begin:/:-/,contains:[t]}]};Object.assign(t,{
+className:"variable",variants:[{
+begin:s.concat(/\$[\w\d#@][\w\d_]*/,"(?![\\w\\d])(?![$])")},n]});const a={
+className:"subst",begin:/\$\(/,end:/\)/,contains:[e.BACKSLASH_ESCAPE]},i={
+begin:/<<-?\s*(?=\w+)/,starts:{contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,
+end:/(\w+)/,className:"string"})]}},c={className:"string",begin:/"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,t,a]};a.contains.push(c);const o={begin:/\$?\(\(/,
+end:/\)\)/,contains:[{begin:/\d+#[0-9a-f]+/,className:"number"},e.NUMBER_MODE,t]
+},r=e.SHEBANG({binary:"(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",relevance:10
+}),l={className:"function",begin:/\w[\w\d_]*\s*\(\s*\)\s*\{/,returnBegin:!0,
+contains:[e.inherit(e.TITLE_MODE,{begin:/\w[\w\d_]*/})],relevance:0};return{
+name:"Bash",aliases:["sh"],keywords:{$pattern:/\b[a-z][a-z0-9._-]+\b/,
+keyword:["if","then","else","elif","fi","for","while","until","in","do","done","case","esac","function","select"],
+literal:["true","false"],
+built_in:["break","cd","continue","eval","exec","exit","export","getopts","hash","pwd","readonly","return","shift","test","times","trap","umask","unset","alias","bind","builtin","caller","command","declare","echo","enable","help","let","local","logout","mapfile","printf","read","readarray","source","type","typeset","ulimit","unalias","set","shopt","autoload","bg","bindkey","bye","cap","chdir","clone","comparguments","compcall","compctl","compdescribe","compfiles","compgroups","compquote","comptags","comptry","compvalues","dirs","disable","disown","echotc","echoti","emulate","fc","fg","float","functions","getcap","getln","history","integer","jobs","kill","limit","log","noglob","popd","print","pushd","pushln","rehash","sched","setcap","setopt","stat","suspend","ttyctl","unfunction","unhash","unlimit","unsetopt","vared","wait","whence","where","which","zcompile","zformat","zftp","zle","zmodload","zparseopts","zprof","zpty","zregexparse","zsocket","zstyle","ztcp","chcon","chgrp","chown","chmod","cp","dd","df","dir","dircolors","ln","ls","mkdir","mkfifo","mknod","mktemp","mv","realpath","rm","rmdir","shred","sync","touch","truncate","vdir","b2sum","base32","base64","cat","cksum","comm","csplit","cut","expand","fmt","fold","head","join","md5sum","nl","numfmt","od","paste","ptx","pr","sha1sum","sha224sum","sha256sum","sha384sum","sha512sum","shuf","sort","split","sum","tac","tail","tr","tsort","unexpand","uniq","wc","arch","basename","chroot","date","dirname","du","echo","env","expr","factor","groups","hostid","id","link","logname","nice","nohup","nproc","pathchk","pinky","printenv","printf","pwd","readlink","runcon","seq","sleep","stat","stdbuf","stty","tee","test","timeout","tty","uname","unlink","uptime","users","who","whoami","yes"]
+},contains:[r,e.SHEBANG(),l,o,e.HASH_COMMENT_MODE,i,{match:/(\/[a-z._-]+)+/},c,{
+match:/\\"/},{className:"string",begin:/'/,end:/'/},{match:/\\'/},t]}}})()
+;hljs.registerLanguage("bash",e)})();

--- a/docs/src/theme/highlight/languages/groovy.min.js
+++ b/docs/src/theme/highlight/languages/groovy.min.js
@@ -1,0 +1,21 @@
+/*! `groovy` grammar compiled for Highlight.js 11.9.0 */
+(()=>{var e=(()=>{"use strict";function e(e,a={}){return a.variants=e,a}
+return a=>{
+const n=a.regex,t="[A-Za-z0-9_$]+",r=e([a.C_LINE_COMMENT_MODE,a.C_BLOCK_COMMENT_MODE,a.COMMENT("/\\*\\*","\\*/",{
+relevance:0,contains:[{begin:/\w+@/,relevance:0},{className:"doctag",
+begin:"@[A-Za-z]+"}]})]),s={className:"regexp",begin:/~?\/[^\/\n]+\//,
+contains:[a.BACKSLASH_ESCAPE]
+},i=e([a.BINARY_NUMBER_MODE,a.C_NUMBER_MODE]),l=e([{begin:/"""/,end:/"""/},{
+begin:/'''/,end:/'''/},{begin:"\\$/",end:"/\\$",relevance:10
+},a.APOS_STRING_MODE,a.QUOTE_STRING_MODE],{className:"string"}),c={
+match:[/(class|interface|trait|enum|record|extends|implements)/,/\s+/,a.UNDERSCORE_IDENT_RE],
+scope:{1:"keyword",3:"title.class"}};return{name:"Groovy",keywords:{
+"variable.language":"this super",literal:"true false null",
+type:["byte","short","char","int","long","boolean","float","double","void"],
+keyword:["def","as","in","assert","trait","abstract","static","volatile","transient","public","private","protected","synchronized","final","class","interface","enum","if","else","for","while","switch","case","break","default","continue","throw","throws","try","catch","finally","implements","extends","new","import","package","return","instanceof","var"]
+},contains:[a.SHEBANG({binary:"groovy",relevance:10}),r,l,s,i,c,{
+className:"meta",begin:"@[A-Za-z]+",relevance:0},{className:"attr",
+begin:t+"[ \t]*:",relevance:0},{begin:/\?/,end:/:/,relevance:0,
+contains:[r,l,s,i,"self"]},{className:"symbol",
+begin:"^[ \t]*"+n.lookahead(t+":"),excludeBegin:!0,end:t+":",relevance:0}],
+illegal:/#|<\//}}})();hljs.registerLanguage("groovy",e)})();

--- a/docs/src/theme/highlight/languages/java.min.js
+++ b/docs/src/theme/highlight/languages/java.min.js
@@ -1,0 +1,38 @@
+/*! `java` grammar compiled for Highlight.js 11.9.0 */
+(()=>{var e=(()=>{"use strict"
+;var e="[0-9](_*[0-9])*",a=`\\.(${e})`,n="[0-9a-fA-F](_*[0-9a-fA-F])*",s={
+className:"number",variants:[{
+begin:`(\\b(${e})((${a})|\\.)?|(${a}))[eE][+-]?(${e})[fFdD]?\\b`},{
+begin:`\\b(${e})((${a})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{begin:`(${a})[fFdD]?\\b`
+},{begin:`\\b(${e})[fFdD]\\b`},{
+begin:`\\b0[xX]((${n})\\.?|(${n})?\\.(${n}))[pP][+-]?(${e})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${n})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};function t(e,a,n){return-1===n?"":e.replace(a,(s=>t(e,a,n-1)))}
+return e=>{
+const a=e.regex,n="[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",i=n+t("(?:<"+n+"~~~(?:\\s*,\\s*"+n+"~~~)*>)?",/~~~/g,2),r={
+keyword:["synchronized","abstract","private","var","static","if","const ","for","while","strictfp","finally","protected","import","native","final","void","enum","else","break","transient","catch","instanceof","volatile","case","assert","package","default","public","try","switch","continue","throws","protected","public","private","module","requires","exports","do","sealed","yield","permits"],
+literal:["false","true","null"],
+type:["char","boolean","long","float","int","byte","short","double"],
+built_in:["super","this"]},l={className:"meta",begin:"@"+n,contains:[{
+begin:/\(/,end:/\)/,contains:["self"]}]},c={className:"params",begin:/\(/,
+end:/\)/,keywords:r,relevance:0,contains:[e.C_BLOCK_COMMENT_MODE],endsParent:!0}
+;return{name:"Java",aliases:["jsp"],keywords:r,illegal:/<\/|#/,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{begin:/\w+@/,
+relevance:0},{className:"doctag",begin:"@[A-Za-z]+"}]}),{
+begin:/import java\.[a-z]+\./,keywords:"import",relevance:2
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{begin:/"""/,end:/"""/,
+className:"string",contains:[e.BACKSLASH_ESCAPE]
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{
+match:[/\b(?:class|interface|enum|extends|implements|new)/,/\s+/,n],className:{
+1:"keyword",3:"title.class"}},{match:/non-sealed/,scope:"keyword"},{
+begin:[a.concat(/(?!else)/,n),/\s+/,n,/\s+/,/=(?!=)/],className:{1:"type",
+3:"variable",5:"operator"}},{begin:[/record/,/\s+/,n],className:{1:"keyword",
+3:"title.class"},contains:[c,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"new throw return else",relevance:0},{
+begin:["(?:"+i+"\\s+)",e.UNDERSCORE_IDENT_RE,/\s*(?=\()/],className:{
+2:"title.function"},keywords:r,contains:[{className:"params",begin:/\(/,
+end:/\)/,keywords:r,relevance:0,
+contains:[l,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,s,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},s,l]}}})()
+;hljs.registerLanguage("java",e)})();

--- a/docs/src/theme/highlight/languages/kotlin.min.js
+++ b/docs/src/theme/highlight/languages/kotlin.min.js
@@ -1,0 +1,46 @@
+/*! `kotlin` grammar compiled for Highlight.js 11.9.0 */
+(()=>{var e=(()=>{"use strict"
+;var e="[0-9](_*[0-9])*",n=`\\.(${e})`,a="[0-9a-fA-F](_*[0-9a-fA-F])*",i={
+className:"number",variants:[{
+begin:`(\\b(${e})((${n})|\\.)?|(${n}))[eE][+-]?(${e})[fFdD]?\\b`},{
+begin:`\\b(${e})((${n})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{begin:`(${n})[fFdD]?\\b`
+},{begin:`\\b(${e})[fFdD]\\b`},{
+begin:`\\b0[xX]((${a})\\.?|(${a})?\\.(${a}))[pP][+-]?(${e})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${a})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};return e=>{const n={
+keyword:"abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual",
+built_in:"Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
+literal:"true false null"},a={className:"symbol",begin:e.UNDERSCORE_IDENT_RE+"@"
+},s={className:"subst",begin:/\$\{/,end:/\}/,contains:[e.C_NUMBER_MODE]},t={
+className:"variable",begin:"\\$"+e.UNDERSCORE_IDENT_RE},r={className:"string",
+variants:[{begin:'"""',end:'"""(?=[^"])',contains:[t,s]},{begin:"'",end:"'",
+illegal:/\n/,contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"',illegal:/\n/,
+contains:[e.BACKSLASH_ESCAPE,t,s]}]};s.contains.push(r);const l={
+className:"meta",
+begin:"@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*"+e.UNDERSCORE_IDENT_RE+")?"
+},c={className:"meta",begin:"@"+e.UNDERSCORE_IDENT_RE,contains:[{begin:/\(/,
+end:/\)/,contains:[e.inherit(r,{className:"string"}),"self"]}]
+},o=i,b=e.COMMENT("/\\*","\\*/",{contains:[e.C_BLOCK_COMMENT_MODE]}),E={
+variants:[{className:"type",begin:e.UNDERSCORE_IDENT_RE},{begin:/\(/,end:/\)/,
+contains:[]}]},d=E;return d.variants[1].contains=[E],E.variants[1].contains=[d],
+{name:"Kotlin",aliases:["kt","kts"],keywords:n,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"}]}),e.C_LINE_COMMENT_MODE,b,{className:"keyword",
+begin:/\b(break|continue|return|this)\b/,starts:{contains:[{className:"symbol",
+begin:/@\w+/}]}},a,l,c,{className:"function",beginKeywords:"fun",end:"[(]|$",
+returnBegin:!0,excludeEnd:!0,keywords:n,relevance:5,contains:[{
+begin:e.UNDERSCORE_IDENT_RE+"\\s*\\(",returnBegin:!0,relevance:0,
+contains:[e.UNDERSCORE_TITLE_MODE]},{className:"type",begin:/</,end:/>/,
+keywords:"reified",relevance:0},{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,relevance:0,contains:[{begin:/:/,end:/[=,\/]/,
+endsWithParent:!0,contains:[E,e.C_LINE_COMMENT_MODE,b],relevance:0
+},e.C_LINE_COMMENT_MODE,b,l,c,r,e.C_NUMBER_MODE]},b]},{
+begin:[/class|interface|trait/,/\s+/,e.UNDERSCORE_IDENT_RE],beginScope:{
+3:"title.class"},keywords:"class interface trait",end:/[:\{(]|$/,excludeEnd:!0,
+illegal:"extends implements",contains:[{
+beginKeywords:"public protected internal private constructor"
+},e.UNDERSCORE_TITLE_MODE,{className:"type",begin:/</,end:/>/,excludeBegin:!0,
+excludeEnd:!0,relevance:0},{className:"type",begin:/[,:]\s*/,end:/[<\(,){\s]|$/,
+excludeBegin:!0,returnEnd:!0},l,c]},r,{className:"meta",begin:"^#!/usr/bin/env",
+end:"$",illegal:"\n"},o]}}})();hljs.registerLanguage("kotlin",e)})();

--- a/docs/src/theme/highlight/styles/github-dark.min.css
+++ b/docs/src/theme/highlight/styles/github-dark.min.css
@@ -1,0 +1,10 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/.hljs{color:#c9d1d9;background:#0d1117}.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_{color:#ff7b72}.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_{color:#d2a8ff}.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable{color:#79c0ff}.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#a5d6ff}.hljs-built_in,.hljs-symbol{color:#ffa657}.hljs-code,.hljs-comment,.hljs-formula{color:#8b949e}.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag{color:#7ee787}.hljs-subst{color:#c9d1d9}.hljs-section{color:#1f6feb;font-weight:700}.hljs-bullet{color:#f2cc60}.hljs-emphasis{color:#c9d1d9;font-style:italic}.hljs-strong{color:#c9d1d9;font-weight:700}.hljs-addition{color:#aff5b4;background-color:#033a16}.hljs-deletion{color:#ffdcd7;background-color:#67060c}

--- a/docs/src/theme/tamboui.css
+++ b/docs/src/theme/tamboui.css
@@ -1,0 +1,790 @@
+/* ===== TamboUI Documentation Theme ===== */
+/* Modern documentation styling inspired by Starlight/Docusaurus */
+
+/* CSS Custom Properties */
+:root {
+    /* Colors - Light Mode */
+    --sl-color-white: #fff;
+    --sl-color-gray-1: #f5f6f8;
+    --sl-color-gray-2: #eceef2;
+    --sl-color-gray-3: #c2c6cf;
+    --sl-color-gray-4: #878d99;
+    --sl-color-gray-5: #545b68;
+    --sl-color-gray-6: #353a46;
+    --sl-color-black: #17191e;
+
+    --sl-color-accent: #0073e6;
+    --sl-color-accent-high: #0060bf;
+    --sl-color-accent-low: rgba(0, 115, 230, 0.1);
+
+    /* Semantic colors */
+    --sl-color-bg: var(--sl-color-white);
+    --sl-color-bg-nav: var(--sl-color-gray-1);
+    --sl-color-bg-sidebar: var(--sl-color-gray-1);
+    --sl-color-bg-inline-code: var(--sl-color-gray-2);
+    --sl-color-hairline: var(--sl-color-gray-2);
+    --sl-color-hairline-light: var(--sl-color-gray-1);
+    --sl-color-text: var(--sl-color-gray-6);
+    --sl-color-text-accent: var(--sl-color-accent-high);
+    --sl-color-text-invert: var(--sl-color-white);
+
+    /* Code block colors */
+    --sl-color-bg-code: #1e1e2e;
+    --sl-color-text-code: #cdd6f4;
+
+    /* Layout */
+    --sl-nav-height: 3.5rem;
+    --sl-sidebar-width: 18rem;
+    --sl-content-width: 50rem;
+    --sl-nav-pad-x: 1rem;
+    --sl-content-pad-x: 2rem;
+
+    /* Typography */
+    --sl-font-system: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    --sl-font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace;
+
+    /* Transitions */
+    --sl-transition-fast: 0.15s ease;
+}
+
+/* Dark Mode */
+[data-theme="dark"],
+.dark {
+    --sl-color-bg: #17191e;
+    --sl-color-bg-nav: #1e2027;
+    --sl-color-bg-sidebar: #1e2027;
+    --sl-color-bg-inline-code: #282a36;
+    --sl-color-hairline: #2e3038;
+    --sl-color-hairline-light: #252730;
+    --sl-color-text: #e0e2e7;
+    --sl-color-text-accent: #58a6ff;
+
+    --sl-color-gray-1: #252730;
+    --sl-color-gray-2: #2e3038;
+    --sl-color-gray-3: #454952;
+    --sl-color-gray-4: #7c8191;
+    --sl-color-gray-5: #a8aebb;
+}
+
+/* Prefer dark mode by default for terminal tool docs */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --sl-color-bg: #17191e;
+        --sl-color-bg-nav: #1e2027;
+        --sl-color-bg-sidebar: #1e2027;
+        --sl-color-bg-inline-code: #282a36;
+        --sl-color-hairline: #2e3038;
+        --sl-color-hairline-light: #252730;
+        --sl-color-text: #e0e2e7;
+        --sl-color-text-accent: #58a6ff;
+
+        --sl-color-gray-1: #252730;
+        --sl-color-gray-2: #2e3038;
+        --sl-color-gray-3: #454952;
+        --sl-color-gray-4: #7c8191;
+        --sl-color-gray-5: #a8aebb;
+    }
+}
+
+/* ===== Reset & Base ===== */
+*, *::before, *::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+    scroll-padding-top: calc(var(--sl-nav-height) + 1rem);
+}
+
+body {
+    font-family: var(--sl-font-system);
+    font-size: 1rem;
+    line-height: 1.75;
+    color: var(--sl-color-text);
+    background: var(--sl-color-bg);
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
+}
+
+/* ===== Header ===== */
+#header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    height: var(--sl-nav-height);
+    background: var(--sl-color-bg-nav);
+    border-bottom: 1px solid var(--sl-color-hairline);
+    display: flex;
+    align-items: center;
+    padding: 0 var(--sl-nav-pad-x);
+    backdrop-filter: blur(8px);
+}
+
+#header h1 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+    color: var(--sl-color-text);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+#header h1::before {
+    content: "";
+    display: inline-block;
+    width: 1.5rem;
+    height: 1.5rem;
+    background: linear-gradient(135deg, var(--sl-color-accent) 0%, #7c3aed 100%);
+    border-radius: 4px;
+}
+
+#header .details {
+    margin-left: auto;
+    font-size: 0.875rem;
+    color: var(--sl-color-gray-4);
+}
+
+/* ===== Layout ===== */
+body.toc2 {
+    padding-top: var(--sl-nav-height);
+}
+
+body.toc2.toc-left #toc {
+    position: fixed;
+    top: var(--sl-nav-height);
+    left: 0;
+    width: var(--sl-sidebar-width);
+    height: calc(100vh - var(--sl-nav-height));
+    overflow-y: auto;
+    background: var(--sl-color-bg-sidebar);
+    border-right: 1px solid var(--sl-color-hairline);
+    padding: 1.5rem 1rem;
+    z-index: 50;
+}
+
+body.toc2.toc-left #content {
+    margin-left: var(--sl-sidebar-width);
+    max-width: calc(var(--sl-content-width) + 2 * var(--sl-content-pad-x));
+    padding: 2rem var(--sl-content-pad-x);
+}
+
+/* ===== Table of Contents ===== */
+#toc #toctitle {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sl-color-gray-4);
+    margin: 0 0 1rem 0;
+    padding: 0 0.5rem;
+}
+
+#toc ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+#toc > ul > li {
+    margin-bottom: 0.25rem;
+}
+
+#toc a {
+    display: block;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.875rem;
+    color: var(--sl-color-text);
+    text-decoration: none;
+    border-radius: 0.375rem;
+    transition: all var(--sl-transition-fast);
+}
+
+#toc a:hover {
+    color: var(--sl-color-text-accent);
+    background: var(--sl-color-accent-low);
+}
+
+#toc ul ul {
+    margin-left: 0.75rem;
+    padding-left: 0.75rem;
+    border-left: 1px solid var(--sl-color-hairline);
+}
+
+#toc ul ul a {
+    font-size: 0.8125rem;
+    color: var(--sl-color-gray-4);
+    padding: 0.25rem 0.75rem;
+}
+
+#toc ul ul a:hover {
+    color: var(--sl-color-text-accent);
+}
+
+/* ===== Typography ===== */
+h1, h2, h3, h4, h5, h6 {
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--sl-color-text);
+    margin-top: 2rem;
+    margin-bottom: 0.75rem;
+}
+
+h1 {
+    font-size: 2rem;
+    margin-top: 0;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--sl-color-hairline);
+}
+
+h2 {
+    font-size: 1.5rem;
+    color: var(--sl-color-text);
+    padding: 0.75rem 1rem;
+    margin-top: 3rem;
+    margin-left: -1rem;
+    margin-right: -1rem;
+    background: var(--sl-color-gray-1);
+    border-left: 4px solid var(--sl-color-accent);
+    border-radius: 0 0.5rem 0.5rem 0;
+}
+
+h3 {
+    font-size: 1.25rem;
+    color: var(--sl-color-text-accent);
+}
+
+h4 { font-size: 1.1rem; }
+h5 { font-size: 1rem; }
+
+p {
+    margin: 0.875rem 0;
+    line-height: 1.8;
+}
+
+/* Section anchors */
+h1 .anchor, h2 .anchor, h3 .anchor, h4 .anchor {
+    opacity: 0;
+    margin-left: 0.5rem;
+    color: var(--sl-color-gray-3);
+    text-decoration: none;
+    transition: opacity var(--sl-transition-fast);
+}
+
+h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor {
+    opacity: 1;
+}
+
+/* ===== Links ===== */
+a {
+    color: var(--sl-color-text-accent);
+    text-decoration: none;
+    transition: color var(--sl-transition-fast);
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+/* ===== Code Blocks ===== */
+.listingblock {
+    margin: 1.5rem 0;
+    position: relative;
+}
+
+.listingblock .title {
+    font-family: var(--sl-font-mono);
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--sl-color-gray-4);
+    background: var(--sl-color-gray-2);
+    padding: 0.5rem 1rem;
+    border-radius: 0.5rem 0.5rem 0 0;
+    border: 1px solid var(--sl-color-hairline);
+    border-bottom: none;
+}
+
+.listingblock pre {
+    margin: 0;
+    padding: 1rem 1.25rem;
+    background: var(--sl-color-bg-code);
+    color: var(--sl-color-text-code);
+    font-family: var(--sl-font-mono);
+    font-size: 0.875rem;
+    line-height: 1.7;
+    overflow-x: auto;
+    border-radius: 0.5rem;
+    border: 1px solid #313244;
+}
+
+.listingblock .title + .content pre {
+    border-radius: 0 0 0.5rem 0.5rem;
+}
+
+.listingblock pre code {
+    background: none;
+    padding: 0;
+    color: inherit;
+    font-size: inherit;
+}
+
+/* Inline code */
+code:not([class]),
+p code,
+li code,
+td code {
+    font-family: var(--sl-font-mono);
+    font-size: 0.875em;
+    padding: 0.125em 0.375em;
+    background: var(--sl-color-bg-inline-code);
+    border-radius: 0.25rem;
+    color: var(--sl-color-text);
+}
+
+/* ===== Tables ===== */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.9375rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+table th {
+    background: var(--sl-color-gray-1);
+    font-weight: 600;
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--sl-color-hairline);
+}
+
+table td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--sl-color-hairline-light);
+    vertical-align: top;
+}
+
+table tr:last-child td {
+    border-bottom: none;
+}
+
+table tr:hover td {
+    background: var(--sl-color-accent-low);
+}
+
+/* ===== Admonitions ===== */
+.admonitionblock {
+    margin: 1.5rem 0;
+}
+
+.admonitionblock > table {
+    border: none;
+    background: transparent;
+    margin: 0;
+}
+
+.admonitionblock > table tr:hover td {
+    background: transparent;
+}
+
+.admonitionblock td.icon {
+    width: 3rem;
+    padding: 1rem;
+    vertical-align: top;
+    border: none;
+}
+
+.admonitionblock td.content {
+    padding: 1rem 1rem 1rem 0;
+    border: none;
+    border-radius: 0.5rem;
+}
+
+.admonitionblock {
+    background: var(--sl-color-gray-1);
+    border-radius: 0.5rem;
+    border-left: 4px solid;
+}
+
+.admonitionblock.note { border-color: #3b82f6; }
+.admonitionblock.tip { border-color: #22c55e; }
+.admonitionblock.warning { border-color: #f59e0b; }
+.admonitionblock.caution { border-color: #ef4444; }
+.admonitionblock.important { border-color: #8b5cf6; }
+
+.admonitionblock .icon i {
+    font-size: 1.25rem;
+}
+
+.admonitionblock.note .icon i { color: #3b82f6; }
+.admonitionblock.tip .icon i { color: #22c55e; }
+.admonitionblock.warning .icon i { color: #f59e0b; }
+.admonitionblock.caution .icon i { color: #ef4444; }
+.admonitionblock.important .icon i { color: #8b5cf6; }
+
+/* ===== Lists ===== */
+ul, ol {
+    padding-left: 1.5rem;
+    margin: 1rem 0;
+}
+
+li {
+    margin: 0.5rem 0;
+    line-height: 1.7;
+}
+
+li > p {
+    margin: 0.25rem 0;
+}
+
+/* Tighter list spacing in sidebar */
+#toc li {
+    margin: 0.25rem 0;
+}
+
+/* Description lists */
+.dlist dt {
+    font-weight: 600;
+    margin-top: 1rem;
+    color: var(--sl-color-text);
+}
+
+.dlist dd {
+    margin-left: 1.5rem;
+    margin-bottom: 0.5rem;
+    color: var(--sl-color-gray-5);
+}
+
+/* ===== Blockquotes ===== */
+blockquote, .quoteblock {
+    margin: 1.5rem 0;
+    padding: 0.5rem 1.5rem;
+    border-left: 3px solid var(--sl-color-accent);
+    background: var(--sl-color-gray-1);
+    border-radius: 0 0.5rem 0.5rem 0;
+    color: var(--sl-color-gray-5);
+}
+
+/* ===== Images ===== */
+.imageblock {
+    margin: 1.5rem 0;
+}
+
+.imageblock img {
+    max-width: 100%;
+    border-radius: 0.5rem;
+    border: 1px solid var(--sl-color-hairline);
+}
+
+.imageblock .title {
+    font-size: 0.875rem;
+    color: var(--sl-color-gray-4);
+    text-align: center;
+    margin-top: 0.5rem;
+}
+
+/* ===== Sidebar blocks ===== */
+.sidebarblock {
+    background: var(--sl-color-gray-1);
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    margin: 1.5rem 0;
+    border: 1px solid var(--sl-color-hairline);
+}
+
+.sidebarblock > .content > .title {
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: var(--sl-color-text);
+}
+
+/* ===== Example blocks ===== */
+.exampleblock {
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    padding: 1.25rem;
+    margin: 1.5rem 0;
+    background: var(--sl-color-bg);
+}
+
+.exampleblock > .title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--sl-color-gray-4);
+    margin-bottom: 0.75rem;
+}
+
+/* ===== Footer ===== */
+#footer {
+    margin-top: 4rem;
+    padding: 2rem var(--sl-content-pad-x);
+    background: var(--sl-color-bg-nav);
+    border-top: 1px solid var(--sl-color-hairline);
+    text-align: center;
+    color: var(--sl-color-gray-4);
+    font-size: 0.875rem;
+}
+
+#footer-text {
+    margin: 0;
+}
+
+/* ===== Responsive ===== */
+@media (max-width: 72rem) {
+    body.toc2.toc-left #toc {
+        display: none;
+    }
+
+    body.toc2.toc-left #content {
+        margin-left: 0;
+        max-width: none;
+    }
+}
+
+@media (max-width: 48rem) {
+    :root {
+        --sl-content-pad-x: 1rem;
+        --sl-nav-pad-x: 1rem;
+    }
+
+    h1 { font-size: 1.75rem; }
+    h2 { font-size: 1.5rem; }
+    h3 { font-size: 1.25rem; }
+
+    .listingblock pre {
+        font-size: 0.8125rem;
+        padding: 0.875rem 1rem;
+    }
+
+    table {
+        font-size: 0.875rem;
+    }
+
+    table th, table td {
+        padding: 0.5rem 0.75rem;
+    }
+}
+
+/* ===== Syntax Highlighting Overrides ===== */
+.hljs {
+    background: transparent !important;
+}
+
+/* ===== Print ===== */
+@media print {
+    #header, #toc, #footer {
+        display: none;
+    }
+
+    body.toc2.toc-left #content {
+        margin-left: 0;
+        max-width: none;
+    }
+
+    .listingblock pre {
+        background: #f5f5f5 !important;
+        color: #333 !important;
+        border: 1px solid #ddd;
+    }
+}
+
+/* ===== Scrollbar styling ===== */
+#toc::-webkit-scrollbar {
+    width: 6px;
+}
+
+#toc::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+#toc::-webkit-scrollbar-thumb {
+    background: var(--sl-color-gray-3);
+    border-radius: 3px;
+}
+
+#toc::-webkit-scrollbar-thumb:hover {
+    background: var(--sl-color-gray-4);
+}
+
+/* ===== Theme Toggle ===== */
+.theme-toggle {
+    background: transparent;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    cursor: pointer;
+    padding: 0.5rem;
+    margin-left: auto;
+    margin-right: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--sl-color-text);
+    transition: all var(--sl-transition-fast);
+}
+
+.theme-toggle:hover {
+    background: var(--sl-color-accent-low);
+    border-color: var(--sl-color-accent);
+    color: var(--sl-color-text-accent);
+}
+
+.theme-toggle .icon-sun {
+    display: none;
+}
+
+.theme-toggle .icon-moon {
+    display: block;
+}
+
+[data-theme="dark"] .theme-toggle .icon-sun {
+    display: block;
+}
+
+[data-theme="dark"] .theme-toggle .icon-moon {
+    display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .theme-toggle .icon-sun {
+        display: block;
+    }
+    :root:not([data-theme="light"]) .theme-toggle .icon-moon {
+        display: none;
+    }
+}
+
+/* ===== Page Navigation in Sidebar ===== */
+.page-nav {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--sl-color-hairline);
+}
+
+.page-nav-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sl-color-gray-4);
+    margin: 0 0 0.75rem 0.5rem;
+}
+
+.page-nav-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.page-nav-list li {
+    margin: 0.125rem 0;
+}
+
+.page-nav-list a {
+    display: block;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--sl-color-gray-5);
+    text-decoration: none;
+    border-radius: 0.375rem;
+    border-left: 3px solid transparent;
+    transition: all var(--sl-transition-fast);
+}
+
+.page-nav-list a:hover {
+    color: var(--sl-color-text-accent);
+    background: var(--sl-color-accent-low);
+}
+
+.page-nav-list li.current a {
+    color: var(--sl-color-text-accent);
+    background: var(--sl-color-accent-low);
+    border-left-color: var(--sl-color-accent);
+    font-weight: 600;
+}
+
+.page-nav-list li.current a:hover {
+    background: var(--sl-color-accent-low);
+}
+
+/* ===== Prev/Next Navigation ===== */
+.prev-next-nav {
+    display: flex;
+    gap: 1.5rem;
+    margin: 3rem 0 2rem 0;
+    padding: 0 var(--sl-content-pad-x);
+    max-width: calc(var(--sl-content-width) + 2 * var(--sl-content-pad-x));
+}
+
+body.toc2.toc-left .prev-next-nav {
+    margin-left: var(--sl-sidebar-width);
+}
+
+.prev-next-nav a,
+.prev-next-nav .placeholder {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--sl-color-hairline);
+    border-radius: 0.5rem;
+    text-decoration: none;
+    transition: all var(--sl-transition-fast);
+}
+
+.prev-next-nav a:hover {
+    border-color: var(--sl-color-accent);
+    background: var(--sl-color-accent-low);
+}
+
+.prev-next-nav .placeholder {
+    visibility: hidden;
+}
+
+.prev-next-nav .prev {
+    align-items: flex-start;
+}
+
+.prev-next-nav .next {
+    align-items: flex-end;
+}
+
+.prev-next-nav .label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--sl-color-gray-4);
+    margin-bottom: 0.25rem;
+}
+
+.prev-next-nav .title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--sl-color-text-accent);
+}
+
+@media (max-width: 72rem) {
+    body.toc2.toc-left .prev-next-nav {
+        margin-left: 0;
+    }
+}
+
+@media (max-width: 48rem) {
+    .prev-next-nav {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .prev-next-nav .prev,
+    .prev-next-nav .next {
+        align-items: flex-start;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ animal-sniffer = "2.0.0"
 sniffer18-signature = "1.0"
 compile-testing = "0.21.0"
 gradle-tooling-api = "9.2.1"
+asciidoctor = "4.0.4"
 
 [libraries]
 jline = { module = "org.jline:jline", version.ref = "jline" }
@@ -26,6 +27,7 @@ oshi-core = { module = "com.github.oshi:oshi-core", version.ref = "oshi" }
 sniffer18-signature = { module = "org.codehaus.mojo.signature:java18", version.ref = "sniffer18-signature" }
 compile-testing = { module = "com.google.testing.compile:compile-testing", version.ref = "compile-testing" }
 gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "gradle-tooling-api" }
+asciidoctor-plugin = { module = "org.asciidoctor:asciidoctor-gradle-jvm", version.ref = "asciidoctor" }
 
 [bundles]
 testing = ["junit-jupiter", "junit-platform-launcher", "assertj-core"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,8 @@ val modules = listOf(
     "tamboui-picocli",
     "tamboui-toolkit",
     "tamboui-annotations",
-    "tamboui-processor"
+    "tamboui-processor",
+    "docs"
 )
 
 include(*modules.toTypedArray())


### PR DESCRIPTION
This commit adds documentation to TamboUI. It makes use of Asciidoctor with a custom CSS for a more polished look. At the moment, the documentation DOES NOT include screenshots or animations. We will probably want to generate these automatically and publish them alongside the docs.

The documentation can be generated by calling:

    ./gradlew asciidoc

Then open the `docs/build/docs/index.html` file.

Preview:

[docs.tar.gz](https://github.com/user-attachments/files/24545555/docs.tar.gz)

@maxandersen at the moment this doesn't deal with docs publishing. I know you have ideas and that you mentioned that SVG couldn't be rendered on GitHub Pages. Is that true? Sounds strange. But anyway we should have a way to automate screenshots.
