### PR TITLE
fix: Ctrl+C handling to respect bindings instead of always generating SIGINT

### DIFF
--- a/tamboui-jline/src/main/java/dev/tamboui/backend/jline/JLineBackend.java
+++ b/tamboui-jline/src/main/java/dev/tamboui/backend/jline/JLineBackend.java
@@ -133,6 +133,11 @@ public class JLineBackend implements Backend {
     public void enableRawMode() throws IOException {
         savedAttributes = terminal.getAttributes();
         terminal.enterRawMode();
+        // Disable signal generation so Ctrl+C goes through the event system
+        // instead of generating SIGINT. This allows bindings to control quit behavior.
+        Attributes attrs = terminal.getAttributes();
+        attrs.setLocalFlag(Attributes.LocalFlag.ISIG, false);
+        terminal.setAttributes(attrs);
     }
 
     @Override

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -784,6 +784,10 @@ public final class Toolkit {
                 state.moveCursorToEnd();
                 return true;
             case CHAR:
+                // Don't consume characters with Ctrl or Alt modifiers - those are control sequences
+                if (event.modifiers().ctrl() || event.modifiers().alt()) {
+                    return false;
+                }
                 char c = event.character();
                 if (c >= 32 && c < 127) {
                     state.insert(c);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -234,6 +234,10 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
                 state.insert("    "); // 4 spaces for tab
                 return true;
             case CHAR:
+                // Don't consume characters with Ctrl or Alt modifiers - those are control sequences
+                if (event.modifiers().ctrl() || event.modifiers().alt()) {
+                    return false;
+                }
                 char c = event.character();
                 if (c >= 32 && c < 127) {
                     state.insert(c);


### PR DESCRIPTION
I got confused, because it seemed that apps were exiting with CTRL+C even if we didn't bind it. Two related bugs were fixed:

1. JLineBackend: Disable ISIG flag after entering raw mode so Ctrl+C goes through the event system instead of generating SIGINT. This allows quit behavior to be controlled by bindings.

2. TextAreaElement/Toolkit: Don't consume CHAR events with Ctrl or Alt modifiers. These are control sequences, not text input. This allows Ctrl+C (and other Ctrl combinations) to bubble up and be matched against bindings.

