### PR TITLE
Fix CSS style inheritance

### DIFF
--- a/tamboui-css/src/main/java/dev/tamboui/css/property/BorderTypeConverter.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/BorderTypeConverter.java
@@ -12,20 +12,12 @@ import java.util.Optional;
 /**
  * Converts CSS border-type values to BorderType enum.
  * <p>
- * Supports the following values:
+ * CSS values are derived from enum names by converting to lowercase and
+ * replacing underscores with hyphens. For example:
  * <ul>
- *   <li>{@code "plain"} - plain borders</li>
- *   <li>{@code "rounded"} - rounded corners</li>
- *   <li>{@code "double"} - double-line borders</li>
- *   <li>{@code "thick"} - thick borders</li>
- *   <li>{@code "light-double-dashed"} - light double-dashed borders</li>
- *   <li>{@code "heavy-double-dashed"} - heavy double-dashed borders</li>
- *   <li>{@code "light-triple-dashed"} - light triple-dashed borders</li>
- *   <li>{@code "heavy-triple-dashed"} - heavy triple-dashed borders</li>
- *   <li>{@code "light-quadruple-dashed"} - light quadruple-dashed borders</li>
- *   <li>{@code "heavy-quadruple-dashed"} - heavy quadruple-dashed borders</li>
- *   <li>{@code "quadrant-inside"} - quadrant inside borders</li>
- *   <li>{@code "quadrant-outside"} - quadrant outside borders</li>
+ *   <li>{@code NONE} becomes {@code "none"}</li>
+ *   <li>{@code PLAIN} becomes {@code "plain"}</li>
+ *   <li>{@code LIGHT_DOUBLE_DASHED} becomes {@code "light-double-dashed"}</li>
  * </ul>
  */
 public final class BorderTypeConverter implements PropertyConverter<BorderType> {
@@ -38,33 +30,12 @@ public final class BorderTypeConverter implements PropertyConverter<BorderType> 
 
         String resolved = PropertyConverter.resolveVariables(value.trim(), variables).toLowerCase();
 
-        switch (resolved) {
-            case "plain":
-                return Optional.of(BorderType.PLAIN);
-            case "rounded":
-                return Optional.of(BorderType.ROUNDED);
-            case "double":
-                return Optional.of(BorderType.DOUBLE);
-            case "thick":
-                return Optional.of(BorderType.THICK);
-            case "light-double-dashed":
-                return Optional.of(BorderType.LIGHT_DOUBLE_DASHED);
-            case "heavy-double-dashed":
-                return Optional.of(BorderType.HEAVY_DOUBLE_DASHED);
-            case "light-triple-dashed":
-                return Optional.of(BorderType.LIGHT_TRIPLE_DASHED);
-            case "heavy-triple-dashed":
-                return Optional.of(BorderType.HEAVY_TRIPLE_DASHED);
-            case "light-quadruple-dashed":
-                return Optional.of(BorderType.LIGHT_QUADRUPLE_DASHED);
-            case "heavy-quadruple-dashed":
-                return Optional.of(BorderType.HEAVY_QUADRUPLE_DASHED);
-            case "quadrant-inside":
-                return Optional.of(BorderType.QUADRANT_INSIDE);
-            case "quadrant-outside":
-                return Optional.of(BorderType.QUADRANT_OUTSIDE);
-            default:
-                return Optional.empty();
+        for (BorderType type : BorderType.values()) {
+            String cssValue = type.name().toLowerCase().replace('_', '-');
+            if (cssValue.equals(resolved)) {
+                return Optional.of(type);
+            }
         }
+        return Optional.empty();
     }
 }

--- a/tamboui-css/src/test/java/dev/tamboui/css/cascade/CssStyleResolverTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/cascade/CssStyleResolverTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.cascade;
+
+import dev.tamboui.layout.Alignment;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Modifier;
+import dev.tamboui.style.Style;
+import dev.tamboui.style.Width;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Padding;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CssStyleResolverTest {
+
+    @Test
+    void withFallbackReturnsThisWhenFallbackIsNull() {
+        CssStyleResolver resolver = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver result = resolver.withFallback(null);
+
+        assertThat(result).isSameAs(resolver);
+    }
+
+    @Test
+    void withFallbackUsesParentPropertiesWhenChildDoesNotHaveThem() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .foreground(Color.BLUE)
+                .background(Color.WHITE)
+                .borderType(BorderType.DOUBLE)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        // Child's foreground should override parent's
+        assertThat(merged.foreground()).contains(Color.RED);
+        // Parent's background should be inherited
+        assertThat(merged.background()).contains(Color.WHITE);
+        // Parent's borderType should be inherited
+        assertThat(merged.borderType()).contains(BorderType.DOUBLE);
+    }
+
+    @Test
+    void withFallbackChildPropertiesTakePrecedence() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .foreground(Color.BLUE)
+                .background(Color.WHITE)
+                .alignment(Alignment.CENTER)
+                .borderType(BorderType.PLAIN)
+                .width(Width.FILL)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .background(Color.BLACK)
+                .alignment(Alignment.LEFT)
+                .borderType(BorderType.DOUBLE)
+                .width(Width.FIT)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        // All properties should come from child since it has them all
+        assertThat(merged.foreground()).contains(Color.RED);
+        assertThat(merged.background()).contains(Color.BLACK);
+        assertThat(merged.alignment()).contains(Alignment.LEFT);
+        assertThat(merged.borderType()).contains(BorderType.DOUBLE);
+        assertThat(merged.width()).isEqualTo(Width.FIT);
+    }
+
+    @Test
+    void withFallbackMergesModifiersPreferringChild() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .addModifier(Modifier.BOLD)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .addModifier(Modifier.ITALIC)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        // Child has modifiers, so child's modifiers take precedence
+        assertThat(merged.modifiers()).containsExactly(Modifier.ITALIC);
+    }
+
+    @Test
+    void withFallbackInheritsModifiersWhenChildHasNone() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .addModifier(Modifier.BOLD)
+                .addModifier(Modifier.UNDERLINED)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        // Child has no modifiers, so parent's modifiers should be inherited
+        assertThat(merged.modifiers()).contains(Modifier.BOLD, Modifier.UNDERLINED);
+    }
+
+    @Test
+    void withFallbackHandlesEmptyModifiersOnBothSides() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .foreground(Color.BLUE)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        // Both have empty modifiers - should not cause EnumSet.copyOf issue
+        assertThat(merged.modifiers()).isEmpty();
+    }
+
+    @Test
+    void withFallbackMergesAdditionalProperties() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .property("border-color", "blue")
+                .property("parent-only", "value1")
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .property("border-color", "red")
+                .property("child-only", "value2")
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        // Child's border-color should override parent's
+        assertThat(merged.getProperty("border-color")).contains("red");
+        // Parent-only property should be inherited
+        assertThat(merged.getProperty("parent-only")).contains("value1");
+        // Child-only property should be present
+        assertThat(merged.getProperty("child-only")).contains("value2");
+    }
+
+    @Test
+    void withFallbackHandlesEmptyAdditionalPropertiesOnChild() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .property("key1", "value1")
+                .property("key2", "value2")
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        assertThat(merged.getProperty("key1")).contains("value1");
+        assertThat(merged.getProperty("key2")).contains("value2");
+    }
+
+    @Test
+    void withFallbackHandlesEmptyAdditionalPropertiesOnParent() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .foreground(Color.BLUE)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .property("key1", "value1")
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        assertThat(merged.getProperty("key1")).contains("value1");
+    }
+
+    @Test
+    void withFallbackInheritsPadding() {
+        Padding parentPadding = Padding.uniform(2);
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .padding(parentPadding)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        assertThat(merged.padding()).contains(parentPadding);
+    }
+
+    @Test
+    void toStyleIncludesInheritedProperties() {
+        CssStyleResolver parent = CssStyleResolver.builder()
+                .background(Color.WHITE)
+                .addModifier(Modifier.BOLD)
+                .build();
+
+        CssStyleResolver child = CssStyleResolver.builder()
+                .foreground(Color.RED)
+                .build();
+
+        CssStyleResolver merged = child.withFallback(parent);
+
+        Style style = merged.toStyle();
+        assertThat(style.fg()).contains(Color.RED);
+        assertThat(style.bg()).contains(Color.WHITE);
+        assertThat(style.addModifiers()).contains(Modifier.BOLD);
+    }
+}

--- a/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/ProgressCard.java
+++ b/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/ProgressCard.java
@@ -128,14 +128,7 @@ public final class ProgressCard extends Component<ProgressCard> {
         ))
                 .title(status.name())
                 .addClass(status.cssClass());
-
-        if (focused) {
-            // Clear focus indicator: double border + cyan
-            panel.doubleBorder().borderColor(Color.CYAN);
-        } else {
-            panel.rounded();
-        }
-
+        
         return panel.fill();
     }
 


### PR DESCRIPTION
This commit fixes the inheritance of CSS properties, which was broken since the refactor to use property resolvers. This was visible in the custom component demo, where you can dynamically override styles.

In addition this fixes the border type converter, which wasn't using all possible values.