### PR TITLE
fix: Ordered backend creation

### DIFF
--- a/buildSrc/src/main/kotlin/dev.tamboui.demo-project.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.demo-project.gradle.kts
@@ -12,7 +12,9 @@ plugins {
 dependencies {
     implementation(project(":tamboui-core"))
     implementation(project(":tamboui-widgets"))
+    // Order of backend dependencies matters: first one has higher priority
     runtimeOnly(project(":tamboui-panama-backend"))
+    runtimeOnly(project(":tamboui-jline"))
 }
 
 tasks.withType<JavaExec>().configureEach {


### PR DESCRIPTION
This commit changes how backend creation works. It is possible to have multiple backends on classpath, in which case, by default, they are tried _in order_. The first one that doesn't fail creation is used.

It is possible for a user to override that behavior by setting the `tamboui.backend` system property or `TAMBOUI_BACKEND` env var, in which case, the user can pick one, or pick many by ordering them (e.g `jline,panama`).

This fixes the docs generation that fail when using the panama backend (because it needs a real terminal).