### PR TITLE
feat: Automated docs publishing

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,38 @@
+name: Publish documentation
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+      - '[0-9]*'
+jobs:
+  publish_documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          ssh-key: "${{ secrets.DOCS_SSH_PRIVATE_KEY }}"
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '25'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Setup git for SSH push
+        env:
+          GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+          SSH_PRIVATE_KEY: "${{ secrets.DOCS_SSH_PRIVATE_KEY }}"
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          chmod 700 -R ~/.ssh
+          eval "$(ssh-agent -s)"
+          ssh-add
+          ssh git@github.com || true
+          git config --global user.name 'GitHub bot'
+          git config --global user.email 'tamboui-bot@users.noreply.github.com'
+      - name: Publish documentation
+        run: ./gradlew :docs:gitPublishPush

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation(libs.nexus.publishing.plugin)
     implementation(libs.animal.sniffer.plugin)
     implementation(libs.asciidoctor.plugin)
+    implementation(libs.git.publish.plugin)
 }
 
 java {

--- a/buildSrc/src/main/kotlin/dev.tamboui.docs.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.docs.gradle.kts
@@ -2,6 +2,7 @@ import dev.tamboui.build.GenerateDemosGalleryTask
 
 plugins {
     id("org.asciidoctor.jvm.convert")
+    id("org.ajoberstar.git-publish")
 }
 
 repositories {
@@ -98,4 +99,31 @@ tasks.asciidoctor {
             "github-repo" to "tamboui/tamboui"
         )
     )
+}
+
+// Git publish configuration for publishing documentation to tamboui.dev
+// For SNAPSHOT versions (main branch): publish to docs/main
+// For release versions (tags): publish to docs/<version>
+val targetFolder = providers.provider {
+    val version = project.version.toString()
+    if (version.endsWith("-SNAPSHOT")) "docs/main" else "docs/$version"
+}
+
+gitPublish {
+    repoUri.set("git@github.com:tamboui/tamboui.dev.git")
+    branch.set("gh-pages")
+    sign.set(false)
+
+    contents {
+        from(tasks.asciidoctor) {
+            into(targetFolder)
+        }
+    }
+
+    preserve {
+        include("**")
+        exclude(targetFolder.map { "$it/**" }.get())
+    }
+
+    commitMessage.set(targetFolder.map { "Publishing documentation to $it" })
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ sniffer18-signature = "1.0"
 compile-testing = "0.21.0"
 gradle-tooling-api = "9.2.1"
 asciidoctor = "4.0.4"
+git-publish = "3.0.1"
 
 [libraries]
 jline = { module = "org.jline:jline", version.ref = "jline" }
@@ -28,6 +29,7 @@ sniffer18-signature = { module = "org.codehaus.mojo.signature:java18", version.r
 compile-testing = { module = "com.google.testing.compile:compile-testing", version.ref = "compile-testing" }
 gradle-tooling-api = { module = "org.gradle:gradle-tooling-api", version.ref = "gradle-tooling-api" }
 asciidoctor-plugin = { module = "org.asciidoctor:asciidoctor-gradle-jvm", version.ref = "asciidoctor" }
+git-publish-plugin = { module = "org.ajoberstar.git-publish:org.ajoberstar.git-publish.gradle.plugin", version.ref = "git-publish" }
 
 [bundles]
 testing = ["junit-jupiter", "junit-platform-launcher", "assertj-core"]


### PR DESCRIPTION
This commit sets up the build to publish documentation automatically. It will publish the SNAPSHOT version of docs into the `main` directory, while version specific docs will be published in the corresponding folder.

This will require setting up an SSH key for this to work on CI.