### PR TITLE
feat: add hyperlink

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/style/Hyperlink.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Hyperlink.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.style;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents a hyperlink that can be attached to a Style.
+ * <p>
+ * Hyperlinks use the OSC8 protocol (https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) to create
+ * clickable links in terminal emulators that support it.
+ * <p>
+ * The hyperlink consists of:
+ * <ul>
+ *   <li>A URL - the target of the link (required)</li>
+ *   <li>An optional ID - used to group multiple cells into a single link</li>
+ * </ul>
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * Style style = Style.create().hyperlink("https://example.com");
+ * // Or with an ID to group multiple cells:
+ * Style style = Style.create().hyperlink("https://example.com", "link1");
+ * }</pre>
+ */
+public final class Hyperlink {
+
+    private final String url;
+    private final String id;
+
+    private Hyperlink(String url, String id) {
+        this.url = Objects.requireNonNull(url, "URL cannot be null");
+        this.id = id;
+    }
+
+    /**
+     * Creates a hyperlink with just a URL.
+     *
+     * @param url the URL for the hyperlink
+     * @return a new Hyperlink instance
+     */
+    public static Hyperlink of(String url) {
+        return new Hyperlink(url, null);
+    }
+
+    /**
+     * Creates a hyperlink with a URL and an ID.
+     * The ID can be used to group multiple cells into a single link.
+     *
+     * @param url the URL for the hyperlink
+     * @param id the optional ID for grouping cells
+     * @return a new Hyperlink instance
+     */
+    public static Hyperlink of(String url, String id) {
+        return new Hyperlink(url, id);
+    }
+
+    
+    /**
+     * Returns the URL of this hyperlink.
+     *
+     * @return the URL
+     */
+    public String url() {
+        return url;
+    }
+
+    /**
+     * Returns the ID of this hyperlink, if set.
+     *
+     * @return the ID, or empty if not set
+     */
+    public Optional<String> id() {
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Hyperlink)) {
+            return false;
+        }
+        Hyperlink hyperlink = (Hyperlink) o;
+        return url.equals(hyperlink.url) && Objects.equals(id, hyperlink.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(url, id);
+    }
+
+    @Override
+    public String toString() {
+        if (id != null) {
+            return String.format("Hyperlink[url=%s, id=%s]", url, id);
+        }
+        return String.format("Hyperlink[url=%s]", url);
+    }
+}

--- a/tamboui-core/src/main/java/dev/tamboui/style/Style.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Style.java
@@ -76,7 +76,7 @@ public final class Style {
      * @return a new style instance
      */
     public Style fg(Color color) {
-        return new Style(color, bg, underlineColor, addModifiers, subModifiers);
+        return new Style(color, bg, underlineColor, addModifiers, subModifiers, extensions);
     }
 
     /** Shorthand for {@link #fg(Color)} with {@link Color#BLACK}. */
@@ -133,7 +133,7 @@ public final class Style {
      * @return a new style instance
      */
     public Style bg(Color color) {
-        return new Style(fg, color, underlineColor, addModifiers, subModifiers);
+        return new Style(fg, color, underlineColor, addModifiers, subModifiers, extensions);
     }
 
     /** Shorthand for {@link #bg(Color)} with {@link Color#BLACK}. */
@@ -185,7 +185,7 @@ public final class Style {
      * @return a new style instance
      */
     public Style underlineColor(Color color) {
-        return new Style(fg, bg, color, addModifiers, subModifiers);
+        return new Style(fg, bg, color, addModifiers, subModifiers, extensions);
     }
 
     // Modifier methods
@@ -199,7 +199,7 @@ public final class Style {
         newAdd.add(modifier);
         EnumSet<Modifier> newSub = EnumSet.copyOf(subModifiers);
         newSub.remove(modifier);
-        return new Style(fg, bg, underlineColor, newAdd, newSub);
+        return new Style(fg, bg, underlineColor, newAdd, newSub, extensions);
     }
 
     /**
@@ -211,7 +211,7 @@ public final class Style {
         newAdd.remove(modifier);
         EnumSet<Modifier> newSub = EnumSet.copyOf(subModifiers);
         newSub.add(modifier);
-        return new Style(fg, bg, underlineColor, newAdd, newSub);
+        return new Style(fg, bg, underlineColor, newAdd, newSub, extensions);
     }
 
     /** Enables bold text. */
@@ -292,6 +292,49 @@ public final class Style {
     /** Disables strikethrough. */
     public Style notCrossedOut() {
         return removeModifier(Modifier.CROSSED_OUT);
+    }
+
+    // Hyperlink methods
+
+    /**
+     * Returns a new style with the given hyperlink.
+     *
+     * @param url the URL for the hyperlink
+     * @return a new style instance with the hyperlink
+     */
+    public Style hyperlink(String url) {
+        return withExtension(Hyperlink.class, Hyperlink.of(url));
+    }
+
+    /**
+     * Returns a new style with the given hyperlink and ID.
+     * The ID can be used to group multiple cells into a single link.
+     *
+     * @param url the URL for the hyperlink
+     * @param id the optional ID for grouping cells
+     * @return a new style instance with the hyperlink
+     */
+    public Style hyperlink(String url, String id) {
+        return withExtension(Hyperlink.class, Hyperlink.of(url, id));
+    }
+
+    /**
+     * Returns a new style with the given hyperlink.
+     *
+     * @param hyperlink the hyperlink to attach
+     * @return a new style instance with the hyperlink
+     */
+    public Style hyperlink(Hyperlink hyperlink) {
+        return withExtension(Hyperlink.class, hyperlink);
+    }
+
+    /**
+     * Returns the hyperlink attached to this style, if any.
+     *
+     * @return the hyperlink, or empty if not set
+     */
+    public Optional<Hyperlink> hyperlink() {
+        return extension(Hyperlink.class);
     }
 
     // Extension methods for storing additional properties

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/AnsiStringBuilder.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/AnsiStringBuilder.java
@@ -6,6 +6,7 @@ package dev.tamboui.terminal;
 
 import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
 
@@ -147,5 +148,50 @@ public final class AnsiStringBuilder {
             return "58;2;" + rgb.r() + ";" + rgb.g() + ";" + rgb.b();
         }
         return "";
+    }
+
+    /**
+     * Generates an OSC8 hyperlink escape sequence to start a hyperlink.
+     * <p>
+     * OSC8 format: {@code \033]8;id=<id>;<url>\033\\}
+     * If no ID is provided, the format is: {@code \033]8;;<url>\033\\}
+     *
+     * @param hyperlink the hyperlink to generate a sequence for
+     * @return the OSC8 escape sequence to start the hyperlink
+     */
+    public static String hyperlinkStart(Hyperlink hyperlink) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ESC).append("]8;");
+        if (hyperlink.id().isPresent()) {
+            sb.append("id=").append(escapeOscParam(hyperlink.id().get()));
+        }
+        sb.append(";");
+        sb.append(escapeOscParam(hyperlink.url()));
+        sb.append(ESC).append("\\");
+        return sb.toString();
+    }
+
+    /**
+     * Generates an OSC8 escape sequence to end a hyperlink.
+     * <p>
+     * Format: {@code \033]8;;\033\\}
+     *
+     * @return the OSC8 escape sequence to end the hyperlink
+     */
+    public static String hyperlinkEnd() {
+        return ESC + "]8;;" + ESC + "\\";
+    }
+
+    /**
+     * Escapes special characters in OSC parameter values.
+     * <p>
+     * According to the OSC8 specification, semicolons and backslashes need to be escaped.
+     *
+     * @param param the parameter value to escape
+     * @return the escaped parameter value
+     */
+    private static String escapeOscParam(String param) {
+        // Escape backslashes and semicolons
+        return param.replace("\\", "\\\\").replace(";", "\\;");
     }
 }

--- a/tamboui-core/src/main/java/dev/tamboui/text/Line.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/Line.java
@@ -110,6 +110,14 @@ public final class Line {
         return patchStyle(Style.EMPTY.underlined());
     }
 
+    public Line hyperlink(String url) {
+        return patchStyle(Style.EMPTY.hyperlink(url));
+    }
+
+    public Line hyperlink(String url, String id) {
+        return patchStyle(Style.EMPTY.hyperlink(url, id));
+    }
+
     /**
      * Returns the raw text content without styling.
      */

--- a/tamboui-core/src/main/java/dev/tamboui/text/Span.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/Span.java
@@ -98,6 +98,14 @@ public final class Span {
         return new Span(content, style.crossedOut());
     }
 
+    public Span hyperlink(String url) {
+        return new Span(content, style.hyperlink(url));
+    }
+
+    public Span hyperlink(String url, String id) {
+        return new Span(content, style.hyperlink(url, id));
+    }
+
     // Color convenience methods
 
     public Span black() {

--- a/tamboui-core/src/main/java/dev/tamboui/text/Text.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/Text.java
@@ -138,6 +138,14 @@ public final class Text {
         return patchStyle(Style.EMPTY.underlined());
     }
 
+    public Text hyperlink(String url) {
+        return patchStyle(Style.EMPTY.hyperlink(url));
+    }
+
+    public Text hyperlink(String url, String id) {
+        return patchStyle(Style.EMPTY.hyperlink(url, id));
+    }
+
     /**
      * Returns the raw text content without styling.
      */

--- a/tamboui-core/src/test/java/dev/tamboui/style/StyleTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/style/StyleTest.java
@@ -93,4 +93,37 @@ class StyleTest {
 
         assertThat(merged.fg()).contains(Color.GREEN);
     }
+
+    @Test
+    @DisplayName("Style hyperlink stores url")
+    void hyperlinkUrl() {
+        Style style = Style.EMPTY.hyperlink("https://example.com");
+        assertThat(style.hyperlink()).contains(Hyperlink.of("https://example.com"));
+    }
+
+    @Test
+    @DisplayName("Style hyperlink stores url and id")
+    void hyperlinkUrlAndId() {
+        Style style = Style.EMPTY.hyperlink("https://example.com", "link-1");
+        assertThat(style.hyperlink()).contains(Hyperlink.of("https://example.com", "link-1"));
+    }
+
+    @Test
+    @DisplayName("Style hyperlink accepts Hyperlink instance")
+    void hyperlinkInstance() {
+        Hyperlink hyperlink = Hyperlink.of("https://example.com", "link-2");
+        Style style = Style.EMPTY.hyperlink(hyperlink);
+        assertThat(style.hyperlink()).contains(hyperlink);
+    }
+
+    @Test
+    @DisplayName("Style preserves hyperlink across style modifiers")
+    void hyperlinkPreservedAcrossModifiers() {
+        Style style = Style.EMPTY.hyperlink("https://example.com")
+            .fg(Color.RED)
+            .underlined();
+
+        assertThat(style.hyperlink()).contains(Hyperlink.of("https://example.com"));
+    }
+
 }

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/AnsiStringBuilderTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/AnsiStringBuilderTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025 TamboUI Contributors
+a * Copyright (c) 2025 TamboUI Contributors
  * SPDX-License-Identifier: MIT
  */
 package dev.tamboui.terminal;
 
 import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
 import org.junit.jupiter.api.DisplayName;
@@ -168,4 +169,36 @@ class AnsiStringBuilderTest {
         String result = AnsiStringBuilder.underlineColorToAnsi(Color.RED);
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("hyperlinkStart without id")
+    void hyperlinkStartWithoutId() {
+        Hyperlink hyperlink = Hyperlink.of("https://example.com");
+        String result = AnsiStringBuilder.hyperlinkStart(hyperlink);
+        assertThat(result).isEqualTo("\u001b]8;;https://example.com\u001b\\");
+    }
+
+    @Test
+    @DisplayName("hyperlinkStart with id")
+    void hyperlinkStartWithId() {
+        Hyperlink hyperlink = Hyperlink.of("https://example.com", "link-1");
+        String result = AnsiStringBuilder.hyperlinkStart(hyperlink);
+        assertThat(result).isEqualTo("\u001b]8;id=link-1;https://example.com\u001b\\");
+    }
+
+    @Test
+    @DisplayName("hyperlinkStart escapes id and url")
+    void hyperlinkStartEscapesParams() {
+        Hyperlink hyperlink = Hyperlink.of("https://example.com/a;b\\c", "id;1\\2");
+        String result = AnsiStringBuilder.hyperlinkStart(hyperlink);
+        assertThat(result).isEqualTo("\u001b]8;id=id\\;1\\\\2;https://example.com/a\\;b\\\\c\u001b\\");
+    }
+
+    @Test
+    @DisplayName("hyperlinkEnd sequence")
+    void hyperlinkEndSequence() {
+        String result = AnsiStringBuilder.hyperlinkEnd();
+        assertThat(result).isEqualTo("\u001b]8;;\u001b\\");
+    }
+
 }

--- a/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/PanamaBackendHyperlinkTest.java
+++ b/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/PanamaBackendHyperlinkTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.backend.panama;
+
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.buffer.CellUpdate;
+import dev.tamboui.layout.Size;
+import dev.tamboui.style.Style;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PanamaBackendHyperlinkTest {
+
+    @Test
+    @DisplayName("draw emits OSC8 start and end around linked cell")
+    void hyperlinkStartAndEndAroundCell() throws IOException {
+        FakeTerminal terminal = new FakeTerminal();
+        PanamaBackend backend = new PanamaBackend(terminal);
+
+        Style style = Style.EMPTY.hyperlink("https://example.com");
+        List<CellUpdate> updates = List.of(new CellUpdate(0, 0, new Cell("A", style)));
+
+        backend.draw(updates);
+        backend.flush();
+
+        String output = terminal.output();
+        String start = "\u001b]8;;https://example.com\u001b\\";
+        String end = "\u001b]8;;\u001b\\";
+
+        int startIndex = output.indexOf(start);
+        int endIndex = output.indexOf(end);
+        int symbolIndex = output.indexOf("A");
+
+        assertThat(startIndex).isGreaterThanOrEqualTo(0);
+        assertThat(endIndex).isGreaterThan(startIndex);
+        assertThat(symbolIndex).isGreaterThan(startIndex);
+        assertThat(symbolIndex).isLessThan(endIndex);
+    }
+
+    @Test
+    @DisplayName("draw ends hyperlink before next non-linked cell")
+    void hyperlinkEndsBeforePlainCell() throws IOException {
+        FakeTerminal terminal = new FakeTerminal();
+        PanamaBackend backend = new PanamaBackend(terminal);
+
+        Style linkStyle = Style.EMPTY.hyperlink("https://example.com", "link-1");
+        List<CellUpdate> updates = Arrays.asList(
+            new CellUpdate(0, 0, new Cell("A", linkStyle)),
+            new CellUpdate(1, 0, new Cell("B", Style.EMPTY))
+        );
+
+        backend.draw(updates);
+        backend.flush();
+
+        String output = terminal.output();
+        String start = "\u001b]8;id=link-1;https://example.com\u001b\\";
+        String end = "\u001b]8;;\u001b\\";
+
+        int startIndex = output.indexOf(start);
+        int endIndex = output.indexOf(end);
+        int bIndex = output.indexOf("B");
+
+        assertThat(startIndex).isGreaterThanOrEqualTo(0);
+        assertThat(endIndex).isGreaterThan(startIndex);
+        assertThat(bIndex).isGreaterThan(endIndex);
+    }
+
+    private static final class FakeTerminal implements PlatformTerminal {
+        private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        @Override
+        public void enableRawMode() {
+        }
+
+        @Override
+        public void disableRawMode() {
+        }
+
+        @Override
+        public Size getSize() {
+            return new Size(80, 24);
+        }
+
+        @Override
+        public int read(int timeoutMs) {
+            return -1;
+        }
+
+        @Override
+        public int peek(int timeoutMs) {
+            return -1;
+        }
+
+        @Override
+        public void write(byte[] data) throws IOException {
+            output.write(data);
+        }
+
+        @Override
+        public void write(byte[] buffer, int offset, int length) throws IOException {
+            output.write(buffer, offset, length);
+        }
+
+        @Override
+        public void write(String s) throws IOException {
+            output.write(s.getBytes(StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public Charset getCharset() {
+            return StandardCharsets.UTF_8;
+        }
+
+        @Override
+        public boolean isRawModeEnabled() {
+            return false;
+        }
+
+        @Override
+        public void onResize(Runnable handler) {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        String output() {
+            return new String(output.toByteArray(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/tamboui-widgets/demos/block-demo/src/main/java/dev/tamboui/demo/BlockDemo.java
+++ b/tamboui-widgets/demos/block-demo/src/main/java/dev/tamboui/demo/BlockDemo.java
@@ -38,6 +38,7 @@ import java.io.IOException;
  * - Titles (top and bottom)
  * - Padding
  * - Different border combinations
+ * - Hyperlinks in titles
  */
 public class BlockDemo {
 
@@ -270,16 +271,25 @@ public class BlockDemo {
             .build();
         frame.renderWidget(paddedContent, padded.inner(rows.get(0)));
 
-        // Block with top and bottom titles
+        // Block with top and bottom titles (with hyperlinks)
         Block titled = Block.builder()
             .borders(Borders.ALL)
             .borderType(BorderType.ROUNDED)
             .borderStyle(Style.EMPTY.fg(Color.YELLOW))
             .title(Title.from(
-                Line.from(Span.raw("Top Title").bold().yellow())
+                Line.from(
+                    Span.raw("TamboUI ").bold().yellow(),
+                    Span.raw("Docs").hyperlink("https://tamboui.dev").underlined().cyan()
+                )
             ).centered())
             .titleBottom(Title.from(
-                Line.from(Span.raw("Bottom Title").dim())
+                Line.from(
+                    Span.raw("GitHub: ").dim(),
+                    Span.raw("tamboui/tamboui")
+                        .hyperlink("https://github.com/tamboui/tamboui")
+                        .underlined()
+                        .blue()
+                )
             ).right())
             .build();
         frame.renderWidget(titled, rows.get(1));
@@ -287,8 +297,8 @@ public class BlockDemo {
         Paragraph titledContent = Paragraph.builder()
             .text(Text.from(
                 Line.from("This block has both"),
-                Line.from("a top title and"),
-                Line.from("a bottom title.")
+                Line.from("a top title with hyperlink"),
+                Line.from("and a bottom title with hyperlink.")
             ))
             .block(Block.empty())
             .build();

--- a/tamboui-widgets/demos/paragraph-demo/src/main/java/dev/tamboui/demo/ParagraphDemo.java
+++ b/tamboui-widgets/demos/paragraph-demo/src/main/java/dev/tamboui/demo/ParagraphDemo.java
@@ -42,6 +42,7 @@ import java.io.IOException;
  * - Colored text
  * - Scroll support
  * - Block integration
+ * - Hyperlinks (OSC8)
  */
 public class ParagraphDemo {
 
@@ -138,10 +139,18 @@ public class ParagraphDemo {
      * Render a paragraph with centered text alignment.
      */
     private void renderCenteredParagraph(Frame frame, Rect area) {
-        String text = "Centered text\nwith multiple lines.\nCheck out the recipe!";
+        Text text = Text.from(
+            Line.from("Centered text"),
+            Line.from("with multiple lines."),
+            Line.from(
+                Span.raw("Visit "),
+                Span.raw("https://tamboui.dev").hyperlink("https://tamboui.dev").underlined().cyan(),
+                Span.raw(" for docs!")
+            )
+        );
         
         Paragraph paragraph = Paragraph.builder()
-            .text(Text.from(text))
+            .text(text)
             .style(Style.EMPTY.fg(Color.WHITE))
             .alignment(Alignment.CENTER)
             .block(Block.builder()
@@ -180,7 +189,15 @@ public class ParagraphDemo {
                 Span.styled(secretIngredient, Style.EMPTY.fg(Color.RED).bold())
             ),
             Line.from("Instructions:").bold().fg(Color.YELLOW),
-            Line.from(longLine).fg(Color.GREEN).italic()
+            Line.from(longLine).fg(Color.GREEN).italic(),
+            Line.from(""),
+            Line.from(
+                Span.raw("Full recipe at: ").dim(),
+                Span.raw("https://example.com/ratatouille")
+                    .hyperlink("https://example.com/ratatouille", "recipe-link")
+                    .underlined()
+                    .cyan()
+            )
         );
 
         Paragraph paragraph = Paragraph.builder()

--- a/tamboui-widgets/demos/table-demo/src/main/java/dev/tamboui/demo/TableDemo.java
+++ b/tamboui-widgets/demos/table-demo/src/main/java/dev/tamboui/demo/TableDemo.java
@@ -237,6 +237,8 @@ public class TableDemo {
 
         if (selected != null && selected < DATA.size()) {
             String[] data = DATA.get(selected);
+            // Create a search URL for the location
+            String locationUrl = "https://maps.example.com/search?q=" + data[4].replace(" ", "+");
             detailsText = Text.from(
                 Line.from(
                     Span.raw("Name: ").bold(),
@@ -252,7 +254,17 @@ public class TableDemo {
                     Span.raw("  |  Salary: ").bold(),
                     Span.raw(data[3]).magenta(),
                     Span.raw("  |  Location: ").bold(),
-                    Span.raw(data[4]).blue()
+                    Span.raw(data[4])
+                        .hyperlink(locationUrl)
+                        .underlined()
+                        .blue()
+                ),
+                Line.from(
+                    Span.raw("Email: ").bold(),
+                    Span.raw(data[0].toLowerCase().replace(" ", ".") + "@company.com")
+                        .hyperlink("mailto:" + data[0].toLowerCase().replace(" ", ".") + "@company.com")
+                        .underlined()
+                        .cyan()
                 )
             );
         } else {

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
@@ -6,12 +6,16 @@ package dev.tamboui.widgets.paragraph;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.PropertyKey;
 import dev.tamboui.style.StylePropertyResolver;
 import dev.tamboui.style.StandardPropertyKeys;
@@ -291,10 +295,15 @@ public final class Paragraph implements Widget {
         List<Line> wrapped = new ArrayList<>();
         List<Span> currentSpans = new ArrayList<>();
         int currentWidth = 0;
+        // Track hyperlinks that need IDs for multi-line wrapping
+        Map<String, String> hyperlinkIds = new HashMap<>();
 
         for (Span span : line.spans()) {
             String content = span.content();
             Style spanStyle = span.style();
+            
+            // Ensure hyperlinks have IDs when wrapping across lines
+            Style wrappedStyle = ensureHyperlinkIdForWrapping(spanStyle, hyperlinkIds);
 
             int i = 0;
             while (i < content.length()) {
@@ -310,7 +319,7 @@ public final class Paragraph implements Widget {
                 int end = Math.min(i + remainingWidth, content.length());
                 String chunk = content.substring(i, end);
 
-                currentSpans.add(new Span(chunk, spanStyle));
+                currentSpans.add(new Span(chunk, wrappedStyle));
                 currentWidth += chunk.length();
                 i = end;
             }
@@ -324,41 +333,144 @@ public final class Paragraph implements Widget {
     }
 
     private List<Line> wrapLineByWord(Line line, int maxWidth) {
+        // Build a character-to-style mapping to preserve span information
+        List<Span> spans = line.spans();
+        if (spans.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // Build full text and track which span each character belongs to
+        StringBuilder fullText = new StringBuilder();
+        List<Style> charStyles = new ArrayList<>();
+        Map<String, String> hyperlinkIds = new HashMap<>();
+
+        for (Span span : spans) {
+            String content = span.content();
+            Style spanStyle = span.style();
+            
+            // Ensure hyperlinks have IDs when wrapping across lines
+            Style wrappedStyle = ensureHyperlinkIdForWrapping(spanStyle, hyperlinkIds);
+            
+            for (int i = 0; i < content.length(); i++) {
+                fullText.append(content.charAt(i));
+                charStyles.add(wrappedStyle);
+            }
+        }
+
+        String text = fullText.toString();
         List<Line> wrapped = new ArrayList<>();
-        String fullText = lineToString(line);
-        Style lineStyle = getLineStyle(line);
+        int pos = 0;
 
-        String[] words = fullText.split("(?<=\\s)|(?=\\s)");
-        StringBuilder currentLine = new StringBuilder();
-
-        for (String word : words) {
-            if (currentLine.length() + word.length() <= maxWidth) {
-                currentLine.append(word);
-            } else {
-                if (currentLine.length() > 0) {
-                    wrapped.add(Line.from(new Span(stripTrailing(currentLine.toString()), lineStyle)));
-                    currentLine = new StringBuilder();
-                }
-                // Handle words longer than maxWidth
-                if (word.length() > maxWidth) {
-                    // Break long word by character
-                    String remaining = word;
-                    while (remaining.length() > maxWidth) {
-                        wrapped.add(Line.from(new Span(remaining.substring(0, maxWidth), lineStyle)));
-                        remaining = remaining.substring(maxWidth);
+        while (pos < text.length()) {
+            // Find the next word break point
+            int lineEnd = findNextWordBreak(text, pos, maxWidth);
+            
+            // Extract the line and reconstruct spans with correct styles
+            List<Span> lineSpans = new ArrayList<>();
+            int spanStart = pos;
+            Style currentStyle = charStyles.get(pos);
+            
+            for (int i = pos; i < lineEnd; i++) {
+                Style charStyle = charStyles.get(i);
+                if (!charStyle.equals(currentStyle)) {
+                    // Style changed, create a span for the previous style
+                    if (spanStart < i) {
+                        lineSpans.add(new Span(text.substring(spanStart, i), currentStyle));
                     }
-                    currentLine.append(remaining);
-                } else {
-                    currentLine.append(stripLeading(word));
+                    spanStart = i;
+                    currentStyle = charStyle;
+                }
+            }
+            
+            // Add the final span
+            if (spanStart < lineEnd) {
+                lineSpans.add(new Span(text.substring(spanStart, lineEnd), currentStyle));
+            }
+            
+            wrapped.add(Line.from(lineSpans));
+            pos = lineEnd;
+            
+            // Skip leading whitespace at the start of next line (but preserve trailing whitespace on current line)
+            // Only skip if we broke at a word boundary (whitespace), not if we broke mid-word
+            if (lineEnd < text.length() && Character.isWhitespace(text.charAt(lineEnd - 1))) {
+                // We already included the whitespace in the line, so skip it for the next line
+                while (pos < text.length() && Character.isWhitespace(text.charAt(pos))) {
+                    pos++;
                 }
             }
         }
 
-        if (currentLine.length() > 0) {
-            wrapped.add(Line.from(new Span(stripTrailing(currentLine.toString()), lineStyle)));
+        return wrapped;
+    }
+
+    /**
+     * Finds the next word break point for word wrapping.
+     * Tries to break at word boundaries, but breaks by character if word is too long.
+     *
+     * @param text the full text
+     * @param startPos the starting position
+     * @param maxWidth the maximum width for the line
+     * @return the position to break at (exclusive)
+     */
+    private int findNextWordBreak(String text, int startPos, int maxWidth) {
+        int textLength = text.length();
+        int maxEnd = Math.min(startPos + maxWidth, textLength);
+        
+        // If we can fit everything, return the end
+        if (maxEnd >= textLength) {
+            return textLength;
+        }
+        
+        // Look backwards from maxEnd for a word boundary (whitespace)
+        for (int i = maxEnd - 1; i > startPos; i--) {
+            if (Character.isWhitespace(text.charAt(i))) {
+                return i + 1; // Break after whitespace
+            }
+        }
+        
+        // No word boundary found - check if we can break at punctuation
+        for (int i = maxEnd - 1; i > startPos; i--) {
+            char c = text.charAt(i);
+            if (c == '-' || c == '/' || c == '\\') {
+                return i + 1; // Break after punctuation
+            }
+        }
+        
+        // No good break point - break at character boundary (for long words)
+        return maxEnd;
+    }
+
+    /**
+     * Ensures that a hyperlink has an ID when it will wrap across multiple lines.
+     * This allows all wrapped chunks to share the same ID and form one continuous link.
+     *
+     * @param style the style that may contain a hyperlink
+     * @param hyperlinkIds a map to track and reuse IDs for the same URL
+     * @return a style with an ID-assigned hyperlink if needed
+     */
+    private Style ensureHyperlinkIdForWrapping(Style style, java.util.Map<String, String> hyperlinkIds) {
+        Optional<Hyperlink> hyperlinkOpt = style.hyperlink();
+        if (!hyperlinkOpt.isPresent()) {
+            return style;
         }
 
-        return wrapped;
+        Hyperlink hyperlink = hyperlinkOpt.get();
+        // If hyperlink already has an ID, use it as-is
+        if (hyperlink.id().isPresent()) {
+            return style;
+        }
+
+        // Generate or reuse an ID for this URL
+        String url = hyperlink.url();
+        String id = hyperlinkIds.get(url);
+        if (id == null) {
+            // Generate a simple ID based on URL hash
+            id = "link-" + Math.abs(url.hashCode());
+            hyperlinkIds.put(url, id);
+        }
+
+        // Return style with hyperlink that has an ID
+        return style.hyperlink(url, id);
     }
 
     // Java 8 compatible alternatives to String.stripLeading() and stripTrailing()

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/paragraph/ParagraphTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/paragraph/ParagraphTest.java
@@ -9,6 +9,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -17,6 +18,11 @@ import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.text.Overflow;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -331,5 +337,190 @@ class ParagraphTest {
         Buffer expected = Buffer.empty(area);
         expected.setString(0, 0, "He", Style.EMPTY);
         BufferAssertions.assertThat(buffer).isEqualTo(expected);
+    }
+
+    // ========== Hyperlink Tests ==========
+
+    @Test
+    @DisplayName("Hyperlink wraps across multiple lines with WRAP_CHARACTER")
+    void hyperlinkWrapsAcrossLinesCharacter() {
+        String longUrl = "https://example.com/very/long/url/that/will/wrap";
+        Paragraph paragraph = Paragraph.builder()
+            .text(Text.from(Line.from(
+                Span.raw("Visit "),
+                Span.raw(longUrl).hyperlink("https://example.com/very/long/url/that/will/wrap")
+            )))
+            .overflow(Overflow.WRAP_CHARACTER)
+            .build();
+        Rect area = new Rect(0, 0, 15, 5);
+        Buffer buffer = Buffer.empty(area);
+
+        paragraph.render(area, buffer);
+
+        // Find hyperlink cells across all lines
+        List<Hyperlink> foundHyperlinks = new ArrayList<>();
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                Hyperlink link = buffer.get(x, y).style().hyperlink().orElse(null);
+                if (link != null) {
+                    foundHyperlinks.add(link);
+                }
+            }
+        }
+        
+        // Should have found hyperlink cells
+        assertThat(foundHyperlinks).isNotEmpty();
+        
+        // All hyperlinks should have the same URL and ID
+        Hyperlink firstLink = foundHyperlinks.get(0);
+        assertThat(firstLink.url()).isEqualTo("https://example.com/very/long/url/that/will/wrap");
+        assertThat(firstLink.id()).isPresent();
+        
+        for (Hyperlink link : foundHyperlinks) {
+            assertThat(link.url()).isEqualTo("https://example.com/very/long/url/that/will/wrap");
+            assertThat(link.id()).isPresent();
+            assertThat(link.id()).isEqualTo(firstLink.id());
+        }
+        
+        // Verify hyperlink spans multiple lines by checking we have links on different rows
+        Set<Integer> rowsWithLinks = new HashSet<>();
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                if (buffer.get(x, y).style().hyperlink().isPresent()) {
+                    rowsWithLinks.add(y);
+                }
+            }
+        }
+        assertThat(rowsWithLinks.size()).isGreaterThan(1); // Should span multiple lines
+    }
+
+    @Test
+    @DisplayName("Hyperlink wraps across multiple lines with WRAP_WORD")
+    void hyperlinkWrapsAcrossLinesWord() {
+        String longUrl = "https://example.com/very/long/url/that/will/wrap";
+        Paragraph paragraph = Paragraph.builder()
+            .text(Text.from(Line.from(
+                Span.raw("Visit "),
+                Span.raw(longUrl).hyperlink("https://example.com/very/long/url/that/will/wrap")
+            )))
+            .overflow(Overflow.WRAP_WORD)
+            .build();
+        Rect area = new Rect(0, 0, 20, 5);
+        Buffer buffer = Buffer.empty(area);
+
+        paragraph.render(area, buffer);
+
+        // Find hyperlink cells across all lines
+        List<Hyperlink> foundHyperlinks = new ArrayList<>();
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                Hyperlink link = buffer.get(x, y).style().hyperlink().orElse(null);
+                if (link != null) {
+                    foundHyperlinks.add(link);
+                }
+            }
+        }
+        
+        // Should have found hyperlink cells
+        assertThat(foundHyperlinks).isNotEmpty();
+        
+        // All hyperlinks should have the same URL and ID
+        Hyperlink firstLink = foundHyperlinks.get(0);
+        assertThat(firstLink.url()).isEqualTo("https://example.com/very/long/url/that/will/wrap");
+        assertThat(firstLink.id()).isPresent();
+        
+        for (Hyperlink link : foundHyperlinks) {
+            assertThat(link.url()).isEqualTo("https://example.com/very/long/url/that/will/wrap");
+            assertThat(link.id()).isPresent();
+            assertThat(link.id()).isEqualTo(firstLink.id());
+        }
+        
+        // Verify hyperlink spans multiple lines
+        Set<Integer> rowsWithLinks = new HashSet<>();
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                if (buffer.get(x, y).style().hyperlink().isPresent()) {
+                    rowsWithLinks.add(y);
+                }
+            }
+        }
+        assertThat(rowsWithLinks.size()).isGreaterThan(1); // Should span multiple lines
+    }
+
+    @Test
+    @DisplayName("Hyperlink with explicit ID wraps correctly")
+    void hyperlinkWithIdWrapsCorrectly() {
+        Paragraph paragraph = Paragraph.builder()
+            .text(Text.from(Line.from(
+                Span.raw("See "),
+                Span.raw("https://example.com/documentation").hyperlink("https://example.com/documentation", "doc-link"),
+                Span.raw(" for more info")
+            )))
+            .overflow(Overflow.WRAP_CHARACTER)
+            .build();
+        Rect area = new Rect(0, 0, 15, 3);
+        Buffer buffer = Buffer.empty(area);
+
+        paragraph.render(area, buffer);
+
+        // Find hyperlink cells and verify they all share the same ID
+        Hyperlink link1 = null;
+        Hyperlink link2 = null;
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                Hyperlink link = buffer.get(x, y).style().hyperlink().orElse(null);
+                if (link != null) {
+                    if (link1 == null) {
+                        link1 = link;
+                    } else if (link2 == null && !link.equals(link1)) {
+                        link2 = link;
+                    }
+                }
+            }
+        }
+        
+        assertThat(link1).isNotNull();
+        assertThat(link1.url()).isEqualTo("https://example.com/documentation");
+        assertThat(link1.id()).contains("doc-link");
+        // All hyperlink cells should share the same ID
+        assertThat(link2).isNull(); // Only one unique hyperlink should exist
+    }
+
+    @Test
+    @DisplayName("Multiple hyperlinks in same line wrap independently")
+    void multipleHyperlinksWrapIndependently() {
+        Paragraph paragraph = Paragraph.builder()
+            .text(Text.from(Line.from(
+                Span.raw("Visit "),
+                Span.raw("https://site1.com").hyperlink("https://site1.com"),
+                Span.raw(" and "),
+                Span.raw("https://site2.com").hyperlink("https://site2.com")
+            )))
+            .overflow(Overflow.WRAP_CHARACTER)
+            .build();
+        Rect area = new Rect(0, 0, 10, 5);
+        Buffer buffer = Buffer.empty(area);
+
+        paragraph.render(area, buffer);
+
+        // Both hyperlinks should be preserved and have different IDs
+        // (since they have different URLs, they'll get different auto-generated IDs)
+        boolean foundLink1 = false;
+        boolean foundLink2 = false;
+        for (int y = 0; y < area.height(); y++) {
+            for (int x = 0; x < area.width(); x++) {
+                Hyperlink link = buffer.get(x, y).style().hyperlink().orElse(null);
+                if (link != null) {
+                    if (link.url().equals("https://site1.com")) {
+                        foundLink1 = true;
+                    } else if (link.url().equals("https://site2.com")) {
+                        foundLink2 = true;
+                    }
+                }
+            }
+        }
+        
+        assertThat(foundLink1).isTrue();
+        assertThat(foundLink2).isTrue();
     }
 }


### PR DESCRIPTION
adds osc-8 hyperlinks as a Style. Makes it possible to put links almost anywhere - demos shows paragraph and block titles. even handle wrapping of urls.

pushing this for comments.

Reason I put it on draft is that in my further testing I noticed that Paragraph seem to now apply styles everywhere instead of only where it starts and begins...resulting in LOTS of links being kept in buffer.

This might be sideeffect of changes in here.


note: reason I put it in core is hyperlinks are needed/useful for markdown/up rendering so good to have as first class citizen.