### PR TITLE
feat: Automatic list navigation and container event forwarding

### DIFF
--- a/demos/demo-selector/src/main/java/dev/tamboui/demo/DemoSelector.java
+++ b/demos/demo-selector/src/main/java/dev/tamboui/demo/DemoSelector.java
@@ -210,27 +210,9 @@ public class DemoSelector extends ToolkitApp {
         var currentIdx = listState.selected();
         var current = currentIdx != null ? currentIdx : 0;
 
-        // Navigation using bindings
-        if (event.matches(Actions.MOVE_UP)) {
-            if (current > 0) {
-                listState.select(current - 1);
-            }
-            return EventResult.HANDLED;
-        }
-        if (event.matches(Actions.MOVE_DOWN)) {
-            if (current < listSize - 1) {
-                listState.select(current + 1);
-            }
-            return EventResult.HANDLED;
-        }
-        if (event.matches(Actions.HOME)) {
-            listState.select(0);
-            return EventResult.HANDLED;
-        }
-        if (event.matches(Actions.END)) {
-            listState.select(listSize - 1);
-            return EventResult.HANDLED;
-        }
+        // Note: Basic navigation (UP/DOWN/HOME/END) is now handled automatically
+        // by ListContainer via ContainerElement forwarding. Only custom behavior
+        // (section jumping, collapse/expand, filtering) needs manual handling.
 
         // PAGE_DOWN: Jump to next section
         if (event.matches(Actions.PAGE_DOWN)) {

--- a/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerKeyHandler.java
+++ b/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerKeyHandler.java
@@ -97,11 +97,7 @@ public class FileManagerKeyHandler {
             return EventResult.HANDLED;
         }
 
-        // Switch between panels
-        if (event.isFocusNext() || event.isFocusPrevious()) {
-            manager.switchSide();
-            return EventResult.HANDLED;
-        }
+        // Switch between panels (Tab is handled by focus system, left/right for quick switch)
         if (event.isLeft()) {
             manager.setActiveSide(FileManagerController.Side.LEFT);
             return EventResult.HANDLED;

--- a/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerView.java
+++ b/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerView.java
@@ -185,6 +185,13 @@ public class FileManagerView implements Element {
     }
 
     private Element browserRow(RenderContext context) {
+        // Sync focus with active side - when Tab changes focus, update the controller
+        if (context.isFocused("left") && !manager.isActive(FileManagerController.Side.LEFT)) {
+            manager.setActiveSide(FileManagerController.Side.LEFT);
+        } else if (context.isFocused("right") && !manager.isActive(FileManagerController.Side.RIGHT)) {
+            manager.setActiveSide(FileManagerController.Side.RIGHT);
+        }
+
         boolean leftActive = manager.isActive(FileManagerController.Side.LEFT);
         boolean rightActive = manager.isActive(FileManagerController.Side.RIGHT);
 
@@ -213,6 +220,7 @@ public class FileManagerView implements Element {
 
         return panel(browser.currentDirectory().toString(), fileListWrapper)
                 .id(id)
+                .focusable()
                 .rounded()
                 .titleEllipsisStart()
                 .borderColor(active ? Color.CYAN : Color.DARK_GRAY)

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/ContainerElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/ContainerElement.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.element;
+
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseEvent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Base class for container elements that hold children and forward events to them.
+ * <p>
+ * When a container receives an event it doesn't handle itself, it forwards the event
+ * to its children. This enables interactive elements (lists, text inputs) inside
+ * containers to receive events when their parent container is focused.
+ * <p>
+ * Subclasses should:
+ * <ul>
+ *   <li>Use {@link #children} to store child elements</li>
+ *   <li>Override {@link #renderContent} for layout-specific rendering</li>
+ * </ul>
+ *
+ * @param <T> the concrete container type for method chaining
+ */
+public abstract class ContainerElement<T extends ContainerElement<T>> extends StyledElement<T> {
+
+    protected final List<Element> children = new ArrayList<>();
+
+    /**
+     * Adds a child element.
+     *
+     * @param child the child to add
+     * @return this container for chaining
+     */
+    public T add(Element child) {
+        this.children.add(child);
+        return self();
+    }
+
+    /**
+     * Adds multiple child elements.
+     *
+     * @param children the children to add
+     * @return this container for chaining
+     */
+    public T add(Element... children) {
+        this.children.addAll(Arrays.asList(children));
+        return self();
+    }
+
+    /**
+     * Returns the list of children (for subclass access).
+     *
+     * @return the children list
+     */
+    protected List<Element> children() {
+        return children;
+    }
+
+    /**
+     * Handles key events by first trying custom handlers, then forwarding to children.
+     * <p>
+     * Children receive events with {@code focused=true} since they are within
+     * the focused container's subtree.
+     *
+     * @param event the key event
+     * @param focused whether this container is focused
+     * @return HANDLED if this container or a child handled the event
+     */
+    @Override
+    public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
+        // Let custom handler run first if set
+        EventResult result = super.handleKeyEvent(event, focused);
+        if (result.isHandled()) {
+            return result;
+        }
+
+        // Forward to children (they inherit focused state from parent)
+        for (Element child : children) {
+            if (child.handleKeyEvent(event, true) == EventResult.HANDLED) {
+                return EventResult.HANDLED;
+            }
+        }
+
+        return EventResult.UNHANDLED;
+    }
+
+    /**
+     * Handles mouse events by first trying custom handlers, then forwarding to children.
+     *
+     * @param event the mouse event
+     * @return HANDLED if this container or a child handled the event
+     */
+    @Override
+    public EventResult handleMouseEvent(MouseEvent event) {
+        // Let custom handler run first if set
+        EventResult result = super.handleMouseEvent(event);
+        if (result.isHandled()) {
+            return result;
+        }
+
+        // Forward to children
+        for (Element child : children) {
+            if (child.handleMouseEvent(event) == EventResult.HANDLED) {
+                return EventResult.HANDLED;
+            }
+        }
+
+        return EventResult.UNHANDLED;
+    }
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/StyledElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/StyledElement.java
@@ -242,9 +242,12 @@ public abstract class StyledElement<T extends StyledElement<T>> implements Eleme
 
     /**
      * Returns whether this element needs to be registered with the event router.
+     * <p>
+     * Elements are registered if they are focusable (to receive keyboard events),
+     * draggable, or have explicit event handlers.
      */
-    private boolean needsEventRouting() {
-        return draggable || keyHandler != null || mouseHandler != null;
+    protected boolean needsEventRouting() {
+        return focusable || draggable || keyHandler != null || mouseHandler != null;
     }
 
     /**

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -4,10 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.element.ContainerElement;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
@@ -21,9 +21,8 @@ import java.util.List;
 /**
  * A vertical layout container that arranges children in a column.
  */
-public final class Column extends StyledElement<Column> {
+public final class Column extends ContainerElement<Column> {
 
-    private final List<Element> children = new ArrayList<>();
     private int spacing = 0;
 
     public Column() {
@@ -38,22 +37,6 @@ public final class Column extends StyledElement<Column> {
      */
     public Column spacing(int spacing) {
         this.spacing = Math.max(0, spacing);
-        return this;
-    }
-
-    /**
-     * Adds a child element.
-     */
-    public Column add(Element child) {
-        this.children.add(child);
-        return this;
-    }
-
-    /**
-     * Adds multiple child elements.
-     */
-    public Column add(Element... children) {
-        this.children.addAll(Arrays.asList(children));
         return this;
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/DialogElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/DialogElement.java
@@ -4,9 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.element.ContainerElement;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
@@ -45,12 +45,11 @@ import java.util.List;
  * ).rounded().borderColor(Color.YELLOW)
  * }</pre>
  */
-public final class DialogElement extends StyledElement<DialogElement> {
+public final class DialogElement extends ContainerElement<DialogElement> {
 
     private String title;
     private BorderType borderType = BorderType.PLAIN;
     private Color borderColor;
-    private final List<Element> children = new ArrayList<>();
     private Integer fixedWidth;
     private Integer fixedHeight;
     private int minWidth = 20;
@@ -143,22 +142,6 @@ public final class DialogElement extends StyledElement<DialogElement> {
     }
 
     /**
-     * Adds a child element.
-     */
-    public DialogElement add(Element child) {
-        this.children.add(child);
-        return this;
-    }
-
-    /**
-     * Adds multiple child elements.
-     */
-    public DialogElement add(Element... children) {
-        this.children.addAll(Arrays.asList(children));
-        return this;
-    }
-
-    /**
      * Sets the callback to run when the dialog is confirmed (Enter key).
      *
      * @param callback the callback to run on confirmation
@@ -183,16 +166,16 @@ public final class DialogElement extends StyledElement<DialogElement> {
     /**
      * Handles key events for the dialog.
      * <p>
-     * Routes events to children first (e.g., TextInputElement handles text input).
+     * Routes events to children first (via ContainerElement).
      * Then handles Enter for confirm and Escape for cancel.
+     * Being modal, the dialog consumes all key events.
      */
     @Override
     public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
-        // Route to children first
-        for (Element child : children) {
-            if (child.handleKeyEvent(event, true) == EventResult.HANDLED) {
-                return EventResult.HANDLED;
-            }
+        // Route to children first (via ContainerElement)
+        EventResult result = super.handleKeyEvent(event, focused);
+        if (result.isHandled()) {
+            return result;
         }
 
         // Handle Escape to cancel

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -5,10 +5,10 @@
 package dev.tamboui.toolkit.elements;
 
 import dev.tamboui.css.cascade.CssStyleResolver;
+import dev.tamboui.toolkit.element.ContainerElement;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
@@ -36,7 +36,7 @@ import java.util.List;
  * resolved through the underlying {@link Block} widget.
  * Renders children vertically inside the bordered area.
  */
-public final class Panel extends StyledElement<Panel> {
+public final class Panel extends ContainerElement<Panel> {
 
     private String title;
     private String bottomTitle;
@@ -45,7 +45,6 @@ public final class Panel extends StyledElement<Panel> {
     private Color borderColor;
     private Color focusedBorderColor;
     private Padding padding;
-    private final List<Element> children = new ArrayList<>();
     private boolean fitToContent;
 
     public Panel() {
@@ -172,22 +171,6 @@ public final class Panel extends StyledElement<Panel> {
      */
     public Panel padding(Padding padding) {
         this.padding = padding;
-        return this;
-    }
-
-    /**
-     * Adds a child element.
-     */
-    public Panel add(Element child) {
-        this.children.add(child);
-        return this;
-    }
-
-    /**
-     * Adds multiple child elements.
-     */
-    public Panel add(Element... children) {
-        this.children.addAll(Arrays.asList(children));
         return this;
     }
 
@@ -327,4 +310,5 @@ public final class Panel extends StyledElement<Panel> {
             internalContext.registerElement(child, childArea);
         }
     }
+
 }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
@@ -4,10 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.element.ContainerElement;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
@@ -21,9 +21,8 @@ import java.util.List;
 /**
  * A horizontal layout container that arranges children in a row.
  */
-public final class Row extends StyledElement<Row> {
+public final class Row extends ContainerElement<Row> {
 
-    private final List<Element> children = new ArrayList<>();
     private int spacing = 0;
 
     public Row() {
@@ -38,22 +37,6 @@ public final class Row extends StyledElement<Row> {
      */
     public Row spacing(int spacing) {
         this.spacing = Math.max(0, spacing);
-        return this;
-    }
-
-    /**
-     * Adds a child element.
-     */
-    public Row add(Element child) {
-        this.children.add(child);
-        return this;
-    }
-
-    /**
-     * Adds multiple child elements.
-     */
-    public Row add(Element... children) {
-        this.children.addAll(Arrays.asList(children));
         return this;
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -184,13 +184,17 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
 
     /**
      * Handles a key event for text area input.
+     * <p>
+     * Note: The {@code focused} parameter is informational only.
+     * If the event reached this element, it should be processed.
      */
     @Override
     public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
+        // Text input requires focus - only handle events when focused
+        // to avoid multiple text areas in the same container all receiving input
         if (!focused) {
             return EventResult.UNHANDLED;
         }
-
         boolean handled = handleTextAreaKey(state, event);
         if (handled && changeListener != null) {
             changeListener.onTextChange(state.text());

--- a/tamboui-widgets/demos/scrollbar-demo/src/main/java/dev/tamboui/demo/ScrollbarDemo.java
+++ b/tamboui-widgets/demos/scrollbar-demo/src/main/java/dev/tamboui/demo/ScrollbarDemo.java
@@ -345,7 +345,7 @@ public class ScrollbarDemo {
         List<Rect> rows = Layout.vertical()
             .constraints(
                 Constraint.length(3),  // Description
-                Constraint.length(3),  // Horizontal scrollbar example
+                Constraint.length(5),  // Horizontal scrollbar example (needs room for block borders + scrollbar)
                 Constraint.fill(),     // Vertical scrollbar showcase
                 Constraint.length(1)   // Spacer
             )
@@ -393,6 +393,9 @@ public class ScrollbarDemo {
             .text(Text.from(content))
             .build();
         frame.renderWidget(para, contentArea);
+
+        // Update viewport content length based on actual scrollbar width
+        horizontalScrollState.viewportContentLength(scrollbarArea.width());
 
         // Horizontal scrollbar
         Scrollbar scrollbar = Scrollbar.builder()


### PR DESCRIPTION
This simplifies event handling, so that users don't have to make all components focusable to be able to react to events on one side, and have to re-implement the same logic everywhere. For example, the list container has a scrollbar, but it didn't come with an event handler, which means that all users had to implement it (probably copy and paste from samples).

This PR:

  - Adds ContainerElement base class that forwards unhandled events to children
  - Updates Panel, Row, Column, DialogElement to extend ContainerElement
  - Adds automatic keyboard navigation to ListContainer (arrows, page up/down, home/end)
  - Adds mouse wheel scrolling support to ListContainer