### PR TITLE
fix: Add raw output to Panama backend

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/terminal/BackendFactory.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/BackendFactory.java
@@ -100,15 +100,11 @@ public final class BackendFactory {
             if (trimmedSpec.isEmpty()) {
                 continue;
             }
-            boolean isClassName = trimmedSpec.contains(".");
             BackendProvider provider = allProviders.stream()
-                    .filter(p -> isClassName
-                            ? p.getClass().getName().equals(trimmedSpec)
-                            : p.name().equals(trimmedSpec))
+                    .filter(p -> p.name().equals(trimmedSpec))
                     .findFirst()
                     .orElseThrow(() -> new IllegalStateException(
-                            "No BackendProvider found on classpath for " +
-                            (isClassName ? "class name" : "provider name") +
+                            "No BackendProvider found on classpath for provider name" +
                             " '" + trimmedSpec + "'.\n" +
                             "Add a backend dependency such as tamboui-jline."
                     ));
@@ -135,7 +131,6 @@ public final class BackendFactory {
         StringBuilder errors = new StringBuilder();
         for (BackendProvider provider : providers) {
             try {
-                System.err.println("Trying backend provider: " + provider.name());
                 return provider.create();
             } catch (Exception e) {
                 if (errors.length() > 0) {

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -203,6 +203,16 @@ public class PanamaBackend implements Backend {
     }
 
     @Override
+    public void writeRaw(byte[] data) throws IOException {
+        terminal.write(data);
+    }
+
+    @Override
+    public void writeRaw(String data) throws IOException {
+        terminal.write(data);
+    }
+
+    @Override
     public void close() throws IOException {
         try {
             // Reset state


### PR DESCRIPTION
This commit fixes missing support for raw output in the Panama backend. That's a trivial fix, but the PR to add image support was merged while Panama support wasn't, so the backend was not up-to-date. The consequence is that the image demo was broken.

This also removes the class name support in the backend factory as previously discussed.