### PR TITLE
feat: Full CSS property coverage

### DIFF
--- a/docs/src/docs/asciidoc/styling.adoc
+++ b/docs/src/docs/asciidoc/styling.adoc
@@ -186,6 +186,8 @@ Panel {
 
 === Properties
 
+==== Style Properties
+
 [cols="1,2,2",options="header"]
 |===
 |Property |Values |Example
@@ -219,9 +221,149 @@ Panel {
 |`text-align: center;`
 
 |`width`
-|Integer (columns)
-|`width: 40;`
+|fit, fill
+|`width: fit;`
 |===
+
+==== Layout Properties
+
+These properties control how elements are sized and positioned within their containers.
+
+[cols="1,2,2",options="header"]
+|===
+|Property |Values |Example
+
+|`height`
+|Constraint for vertical sizing (used by Column)
+|`height: 5;` `height: fill;` `height: 50%;`
+
+|`width`
+|Constraint for horizontal sizing (used by Row)
+|`width: 10;` `width: fit;` `width: 25%;`
+
+|`flex`
+|Flex positioning mode
+|`flex: center;` `flex: space-between;`
+
+|`spacing`
+|Gap between children in cells
+|`spacing: 1;`
+
+|`margin`
+|Margin around element (single value or top right bottom left)
+|`margin: 2;` `margin: 1 2 1 2;`
+
+|`direction`
+|Layout direction for panels
+|`direction: horizontal;` `direction: vertical;`
+|===
+
+===== Constraint Values
+
+The `height` and `width` properties accept constraint values:
+
+[cols="1,3",options="header"]
+|===
+|Value |Description
+
+|`<number>`
+|Fixed size in cells (e.g., `height: 5;`)
+
+|`<number>%`
+|Percentage of available space (e.g., `width: 50%;`)
+
+|`fill`
+|Fill available space with weight 1 (e.g., `height: fill;`)
+
+|`fill(<weight>)`
+|Fill with specified weight (e.g., `height: fill(2);`)
+
+|`fit`
+|Size to content (e.g., `width: fit;`)
+
+|`min(<value>)`
+|Minimum size (e.g., `height: min(3);`)
+
+|`max(<value>)`
+|Maximum size (e.g., `height: max(10);`)
+
+|`<n>/<d>`
+|Ratio (e.g., `width: 1/3;`)
+|===
+
+===== Flex Values
+
+The `flex` property controls how remaining space is distributed:
+
+[cols="1,3",options="header"]
+|===
+|Value |Description
+
+|`start`
+|Position items at the start, remaining space at end
+
+|`center`
+|Center items, distribute remaining space on both sides
+
+|`end`
+|Position items at the end, remaining space at start
+
+|`space-between`
+|Distribute items with space between them
+
+|`space-around`
+|Distribute items with space around each
+
+|`space-evenly`
+|Distribute items with equal space between and around
+|===
+
+===== Layout Example
+
+This example shows how to use CSS layout properties to create a centered footer:
+
+[source,css]
+----
+/* Center the footer content */
+.footer-row {
+    flex: center;
+}
+
+/* Size text to content width, allowing flex to center */
+.footer-row .title {
+    width: fit;
+}
+
+.footer-row .dim {
+    width: fit;
+}
+
+/* Fixed heights for header/footer panels */
+.header-panel {
+    height: 3;
+}
+
+.footer-panel {
+    height: 3;
+}
+
+/* Main content fills remaining space */
+.main-content {
+    height: fill;
+}
+----
+
+[source,java]
+----
+column(
+    panel(header()).addClass("header-panel"),
+    panel(content()).addClass("main-content"),
+    panel(() -> row(
+        text("Status: ").addClass("title"),
+        text("Ready").addClass("dim")
+    ).addClass("footer-row")).addClass("footer-panel")
+)
+----
 
 Named colors: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, `dark-gray`, and their bright variants.
 

--- a/tamboui-core/src/main/java/dev/tamboui/layout/Constraint.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/Constraint.java
@@ -247,6 +247,34 @@ public interface Constraint {
     }
 
     /**
+     * Fit to content size.
+     * <p>
+     * When used, the container will query the element for its preferred size
+     * (via {@code preferredWidth()} or {@code preferredHeight()}).
+     */
+    final class Fit implements Constraint {
+        private static final Fit INSTANCE = new Fit();
+
+        private Fit() {
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof Fit;
+        }
+
+        @Override
+        public int hashCode() {
+            return Fit.class.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "Fit";
+        }
+    }
+
+    /**
      * Fill remaining space with given weight.
      */
     final class Fill implements Constraint {
@@ -367,5 +395,16 @@ public interface Constraint {
      */
     static Constraint fill() {
         return new Fill(1);
+    }
+
+    /**
+     * Creates a fit-to-content constraint.
+     * <p>
+     * The container will query the element for its preferred size.
+     *
+     * @return fit constraint
+     */
+    static Constraint fit() {
+        return Fit.INSTANCE;
     }
 }

--- a/tamboui-core/src/main/java/dev/tamboui/layout/Margin.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/Margin.java
@@ -126,6 +126,23 @@ public final class Margin {
         return top + bottom;
     }
 
+    /**
+     * Returns the inner area after applying this margin.
+     * <p>
+     * The returned rect is inset by the margin values on each side.
+     * If the margin would result in negative dimensions, returns an empty rect.
+     *
+     * @param area the outer area
+     * @return the inner area with margin applied
+     */
+    public Rect inner(Rect area) {
+        int newX = area.x() + left;
+        int newY = area.y() + top;
+        int newWidth = Math.max(0, area.width() - horizontalTotal());
+        int newHeight = Math.max(0, area.height() - verticalTotal());
+        return new Rect(newX, newY, newWidth, newHeight);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/tamboui-core/src/testFixtures/java/dev/tamboui/assertj/BufferAssert.java
+++ b/tamboui-core/src/testFixtures/java/dev/tamboui/assertj/BufferAssert.java
@@ -129,6 +129,26 @@ public final class BufferAssert extends AbstractAssert<BufferAssert, Buffer> {
         return this;
     }
 
+    /**
+     * Asserts that the symbol at the given position equals the expected symbol.
+     *
+     * @param x the x coordinate
+     * @param y the y coordinate
+     * @param expectedSymbol the expected symbol
+     * @return this assertion object
+     */
+    public BufferAssert hasSymbolAt(int x, int y, String expectedSymbol) {
+        isNotNull();
+
+        String actualSymbol = actual.get(x, y).symbol();
+        if (!actualSymbol.equals(expectedSymbol)) {
+            failWithMessage("Expected symbol at (%d, %d) to be <%s>, but was <%s>%n%nBuffer content:%n%s",
+                    x, y, expectedSymbol, actualSymbol, formatBuffer(actual));
+        }
+
+        return this;
+    }
+
     private String formatBuffer(Buffer buffer) {
         return BufferDiffFormatter.formatBuffer(buffer);
     }

--- a/tamboui-css/src/main/java/dev/tamboui/css/cascade/CascadeResolver.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/cascade/CascadeResolver.java
@@ -132,8 +132,28 @@ public final class CascadeResolver {
                             .ifPresent(builder::borderType);
                     break;
                 case "width":
-                    propertyRegistry.convertWidth(value, variables)
-                            .ifPresent(builder::width);
+                    propertyRegistry.convertConstraint(value, variables)
+                            .ifPresent(builder::widthConstraint);
+                    break;
+                case "flex":
+                    propertyRegistry.convertFlex(value, variables)
+                            .ifPresent(builder::flex);
+                    break;
+                case "direction":
+                    propertyRegistry.convertDirection(value, variables)
+                            .ifPresent(builder::direction);
+                    break;
+                case "margin":
+                    propertyRegistry.convertMargin(value, variables)
+                            .ifPresent(builder::margin);
+                    break;
+                case "spacing":
+                    propertyRegistry.convertSpacing(value, variables)
+                            .ifPresent(builder::spacing);
+                    break;
+                case "height":
+                    propertyRegistry.convertConstraint(value, variables)
+                            .ifPresent(builder::heightConstraint);
                     break;
                 default:
                     // Store as additional property for later use

--- a/tamboui-css/src/main/java/dev/tamboui/css/cascade/CssStyleResolver.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/cascade/CssStyleResolver.java
@@ -5,6 +5,10 @@
 package dev.tamboui.css.cascade;
 
 import dev.tamboui.layout.Alignment;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Direction;
+import dev.tamboui.layout.Flex;
+import dev.tamboui.layout.Margin;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.PropertyKey;
@@ -44,6 +48,12 @@ public final class CssStyleResolver implements StylePropertyResolver {
     private final Alignment alignment;
     private final BorderType borderType;
     private final Width width;
+    private final Flex flex;
+    private final Direction direction;
+    private final Margin margin;
+    private final Integer spacing;
+    private final Constraint heightConstraint;
+    private final Constraint widthConstraint;
     private final Map<String, String> additionalProperties;
 
     private CssStyleResolver(Color foreground,
@@ -53,6 +63,12 @@ public final class CssStyleResolver implements StylePropertyResolver {
                              Alignment alignment,
                              BorderType borderType,
                              Width width,
+                             Flex flex,
+                             Direction direction,
+                             Margin margin,
+                             Integer spacing,
+                             Constraint heightConstraint,
+                             Constraint widthConstraint,
                              Map<String, String> additionalProperties) {
         this.foreground = foreground;
         this.background = background;
@@ -63,6 +79,12 @@ public final class CssStyleResolver implements StylePropertyResolver {
         this.alignment = alignment;
         this.borderType = borderType;
         this.width = width;
+        this.flex = flex;
+        this.direction = direction;
+        this.margin = margin;
+        this.spacing = spacing;
+        this.heightConstraint = heightConstraint;
+        this.widthConstraint = widthConstraint;
         this.additionalProperties = Collections.unmodifiableMap(new HashMap<>(additionalProperties));
     }
 
@@ -72,8 +94,8 @@ public final class CssStyleResolver implements StylePropertyResolver {
      * @return an empty CssStyleResolver
      */
     public static CssStyleResolver empty() {
-        return new CssStyleResolver(null, null, null, null, null, null, null,
-                Collections.<String, String>emptyMap());
+        return new CssStyleResolver(null, null, null, null, null, null, null, null,
+                null, null, null, null, null, Collections.<String, String>emptyMap());
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -113,6 +135,18 @@ public final class CssStyleResolver implements StylePropertyResolver {
                 return (Optional<T>) Optional.ofNullable(alignment);
             case "border-type":
                 return (Optional<T>) Optional.ofNullable(borderType);
+            case "flex":
+                return (Optional<T>) Optional.ofNullable(flex);
+            case "direction":
+                return (Optional<T>) Optional.ofNullable(direction);
+            case "margin":
+                return (Optional<T>) Optional.ofNullable(margin);
+            case "spacing":
+                return (Optional<T>) Optional.ofNullable(spacing);
+            case "height":
+                return (Optional<T>) Optional.ofNullable(heightConstraint);
+            case "width":
+                return (Optional<T>) Optional.ofNullable(widthConstraint);
             default:
                 return getProperty(name).flatMap(key::convert);
         }
@@ -187,6 +221,60 @@ public final class CssStyleResolver implements StylePropertyResolver {
     }
 
     /**
+     * Returns the flex layout mode, if set.
+     *
+     * @return the flex mode
+     */
+    public Optional<Flex> flex() {
+        return Optional.ofNullable(flex);
+    }
+
+    /**
+     * Returns the layout direction, if set.
+     *
+     * @return the direction
+     */
+    public Optional<Direction> direction() {
+        return Optional.ofNullable(direction);
+    }
+
+    /**
+     * Returns the margin, if set.
+     *
+     * @return the margin
+     */
+    public Optional<Margin> margin() {
+        return Optional.ofNullable(margin);
+    }
+
+    /**
+     * Returns the spacing (gap between elements), if set.
+     *
+     * @return the spacing
+     */
+    public Optional<Integer> spacing() {
+        return Optional.ofNullable(spacing);
+    }
+
+    /**
+     * Returns the height constraint (for vertical layouts), if set.
+     *
+     * @return the height constraint
+     */
+    public Optional<Constraint> heightConstraint() {
+        return Optional.ofNullable(heightConstraint);
+    }
+
+    /**
+     * Returns the width constraint (for horizontal layouts), if set.
+     *
+     * @return the width constraint
+     */
+    public Optional<Constraint> widthConstraint() {
+        return Optional.ofNullable(widthConstraint);
+    }
+
+    /**
      * Returns additional properties not mapped to specific fields.
      *
      * @return the additional properties map
@@ -240,17 +328,24 @@ public final class CssStyleResolver implements StylePropertyResolver {
     public boolean hasProperties() {
         return foreground != null || background != null ||
                 !modifiers.isEmpty() || padding != null || alignment != null ||
-                borderType != null || width != null || !additionalProperties.isEmpty();
+                borderType != null || width != null || flex != null ||
+                direction != null || margin != null || spacing != null ||
+                heightConstraint != null || widthConstraint != null ||
+                !additionalProperties.isEmpty();
     }
 
     /**
      * Creates a new resolver that uses this resolver's properties but falls back
-     * to the given resolver for properties not set in this resolver.
+     * to the given resolver for CSS-inheritable properties not set in this resolver.
      * <p>
-     * This enables CSS property inheritance from parent elements to children.
+     * Per CSS semantics, only certain properties inherit from parent to child:
+     * <ul>
+     *   <li>Inheritable: color (foreground), text-style (modifiers), border-type</li>
+     *   <li>Non-inheritable: spacing, flex, direction, margin, padding, alignment, width, background</li>
+     * </ul>
      *
-     * @param fallback the fallback resolver for missing properties
-     * @return a new resolver with fallback behavior
+     * @param fallback the fallback resolver for missing inheritable properties
+     * @return a new resolver with fallback behavior for inheritable properties only
      */
     public CssStyleResolver withFallback(CssStyleResolver fallback) {
         if (fallback == null) {
@@ -261,13 +356,21 @@ public final class CssStyleResolver implements StylePropertyResolver {
                 : !fallback.modifiers.isEmpty() ? fallback.modifiers
                 : null;
         return new CssStyleResolver(
+                // Inheritable properties - fall back to parent
                 foreground != null ? foreground : fallback.foreground,
-                background != null ? background : fallback.background,
+                background,  // NOT inherited per CSS spec
                 mergedModifiers,
-                padding != null ? padding : fallback.padding,
-                alignment != null ? alignment : fallback.alignment,
-                borderType != null ? borderType : fallback.borderType,
-                width != null ? width : fallback.width,
+                // Non-inheritable properties - use only this element's values
+                padding,
+                alignment,
+                borderType != null ? borderType : fallback.borderType,  // Inherit for nested panels
+                width,
+                flex,       // Layout-specific, not inherited
+                direction,  // Layout-specific, not inherited
+                margin,           // Element-specific, not inherited
+                spacing,          // Layout-specific, not inherited
+                heightConstraint, // Element-specific, not inherited
+                widthConstraint,  // Element-specific, not inherited
                 mergeProperties(additionalProperties, fallback.additionalProperties)
         );
     }
@@ -304,6 +407,12 @@ public final class CssStyleResolver implements StylePropertyResolver {
         private Alignment alignment;
         private BorderType borderType;
         private Width width;
+        private Flex flex;
+        private Direction direction;
+        private Margin margin;
+        private Integer spacing;
+        private Constraint heightConstraint;
+        private Constraint widthConstraint;
         private final Map<String, String> additionalProperties = new HashMap<>();
 
         private Builder() {
@@ -398,6 +507,72 @@ public final class CssStyleResolver implements StylePropertyResolver {
         }
 
         /**
+         * Sets the flex layout mode.
+         *
+         * @param flex the flex mode
+         * @return this builder
+         */
+        public Builder flex(Flex flex) {
+            this.flex = flex;
+            return this;
+        }
+
+        /**
+         * Sets the layout direction.
+         *
+         * @param direction the direction
+         * @return this builder
+         */
+        public Builder direction(Direction direction) {
+            this.direction = direction;
+            return this;
+        }
+
+        /**
+         * Sets the margin.
+         *
+         * @param margin the margin
+         * @return this builder
+         */
+        public Builder margin(Margin margin) {
+            this.margin = margin;
+            return this;
+        }
+
+        /**
+         * Sets the spacing (gap between elements).
+         *
+         * @param spacing the spacing
+         * @return this builder
+         */
+        public Builder spacing(Integer spacing) {
+            this.spacing = spacing;
+            return this;
+        }
+
+        /**
+         * Sets the height constraint (for vertical layouts).
+         *
+         * @param constraint the height constraint
+         * @return this builder
+         */
+        public Builder heightConstraint(Constraint constraint) {
+            this.heightConstraint = constraint;
+            return this;
+        }
+
+        /**
+         * Sets the width constraint (for horizontal layouts).
+         *
+         * @param constraint the width constraint
+         * @return this builder
+         */
+        public Builder widthConstraint(Constraint constraint) {
+            this.widthConstraint = constraint;
+            return this;
+        }
+
+        /**
          * Adds an additional property.
          *
          * @param name  the property name
@@ -416,7 +591,8 @@ public final class CssStyleResolver implements StylePropertyResolver {
          */
         public CssStyleResolver build() {
             return new CssStyleResolver(foreground, background, modifiers, padding,
-                    alignment, borderType, width, additionalProperties);
+                    alignment, borderType, width, flex, direction, margin, spacing,
+                    heightConstraint, widthConstraint, additionalProperties);
         }
     }
 
@@ -440,6 +616,24 @@ public final class CssStyleResolver implements StylePropertyResolver {
         }
         if (borderType != null) {
             sb.append("borderType=").append(borderType).append(", ");
+        }
+        if (flex != null) {
+            sb.append("flex=").append(flex).append(", ");
+        }
+        if (direction != null) {
+            sb.append("direction=").append(direction).append(", ");
+        }
+        if (margin != null) {
+            sb.append("margin=").append(margin).append(", ");
+        }
+        if (spacing != null) {
+            sb.append("spacing=").append(spacing).append(", ");
+        }
+        if (heightConstraint != null) {
+            sb.append("height=").append(heightConstraint).append(", ");
+        }
+        if (widthConstraint != null) {
+            sb.append("width=").append(widthConstraint).append(", ");
         }
         if (!additionalProperties.isEmpty()) {
             sb.append("properties=").append(additionalProperties);

--- a/tamboui-css/src/main/java/dev/tamboui/css/property/ConstraintConverter.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/ConstraintConverter.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Constraint;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts CSS constraint values to Constraint objects.
+ * <p>
+ * Supports the following formats:
+ * <ul>
+ *   <li>{@code fill} - Fill with weight 1</li>
+ *   <li>{@code fill(2)} - Fill with specified weight</li>
+ *   <li>{@code 10} - Fixed length of 10 cells</li>
+ *   <li>{@code 50%} - 50% of available space</li>
+ *   <li>{@code min(10)} - Minimum 10 cells</li>
+ *   <li>{@code max(20)} - Maximum 20 cells</li>
+ *   <li>{@code 1/3} - Ratio (1 part of 3)</li>
+ * </ul>
+ */
+public final class ConstraintConverter implements PropertyConverter<Constraint> {
+
+    private static final Pattern FILL_PATTERN = Pattern.compile("fill(?:\\((\\d+)\\))?");
+    private static final Pattern PERCENT_PATTERN = Pattern.compile("(\\d+)%");
+    private static final Pattern MIN_PATTERN = Pattern.compile("min\\((\\d+)\\)");
+    private static final Pattern MAX_PATTERN = Pattern.compile("max\\((\\d+)\\)");
+    private static final Pattern RATIO_PATTERN = Pattern.compile("(\\d+)/(\\d+)");
+    private static final Pattern LENGTH_PATTERN = Pattern.compile("\\d+");
+
+    @Override
+    public Optional<Constraint> convert(String value, Map<String, String> variables) {
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        String resolved = PropertyConverter.resolveVariables(value.trim(), variables).toLowerCase();
+
+        // Try "fit" keyword
+        if ("fit".equals(resolved)) {
+            return Optional.of(Constraint.fit());
+        }
+
+        // Try fill pattern: "fill" or "fill(2)"
+        Matcher fillMatcher = FILL_PATTERN.matcher(resolved);
+        if (fillMatcher.matches()) {
+            String weight = fillMatcher.group(1);
+            if (weight != null) {
+                return Optional.of(Constraint.fill(Integer.parseInt(weight)));
+            }
+            return Optional.of(Constraint.fill());
+        }
+
+        // Try percentage pattern: "50%"
+        Matcher percentMatcher = PERCENT_PATTERN.matcher(resolved);
+        if (percentMatcher.matches()) {
+            int percent = Integer.parseInt(percentMatcher.group(1));
+            return Optional.of(Constraint.percentage(percent));
+        }
+
+        // Try min pattern: "min(10)"
+        Matcher minMatcher = MIN_PATTERN.matcher(resolved);
+        if (minMatcher.matches()) {
+            int minValue = Integer.parseInt(minMatcher.group(1));
+            return Optional.of(Constraint.min(minValue));
+        }
+
+        // Try max pattern: "max(20)"
+        Matcher maxMatcher = MAX_PATTERN.matcher(resolved);
+        if (maxMatcher.matches()) {
+            int maxValue = Integer.parseInt(maxMatcher.group(1));
+            return Optional.of(Constraint.max(maxValue));
+        }
+
+        // Try ratio pattern: "1/3"
+        Matcher ratioMatcher = RATIO_PATTERN.matcher(resolved);
+        if (ratioMatcher.matches()) {
+            int numerator = Integer.parseInt(ratioMatcher.group(1));
+            int denominator = Integer.parseInt(ratioMatcher.group(2));
+            return Optional.of(Constraint.ratio(numerator, denominator));
+        }
+
+        // Try plain number (length): "10"
+        if (LENGTH_PATTERN.matcher(resolved).matches()) {
+            int length = Integer.parseInt(resolved);
+            return Optional.of(Constraint.length(length));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/property/DirectionConverter.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/DirectionConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Direction;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Converts CSS direction values to Direction enum.
+ * <p>
+ * Supports the following values:
+ * <ul>
+ *   <li>{@code "horizontal"} or {@code "row"} - horizontal layout</li>
+ *   <li>{@code "vertical"} or {@code "column"} - vertical layout</li>
+ * </ul>
+ */
+public final class DirectionConverter implements PropertyConverter<Direction> {
+
+    @Override
+    public Optional<Direction> convert(String value, Map<String, String> variables) {
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        String resolved = PropertyConverter.resolveVariables(value.trim(), variables).toLowerCase();
+
+        switch (resolved) {
+            case "horizontal":
+            case "row":
+                return Optional.of(Direction.HORIZONTAL);
+            case "vertical":
+            case "column":
+                return Optional.of(Direction.VERTICAL);
+            default:
+                return Optional.empty();
+        }
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/property/FlexConverter.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/FlexConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Flex;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Converts CSS flex values to Flex enum.
+ * <p>
+ * Supports the following values:
+ * <ul>
+ *   <li>{@code "start"} - items aligned at start</li>
+ *   <li>{@code "center"} - items centered</li>
+ *   <li>{@code "end"} - items aligned at end</li>
+ *   <li>{@code "space-between"} - items distributed with space between</li>
+ *   <li>{@code "space-around"} - items distributed with space around</li>
+ *   <li>{@code "space-evenly"} - items distributed with equal space</li>
+ * </ul>
+ */
+public final class FlexConverter implements PropertyConverter<Flex> {
+
+    @Override
+    public Optional<Flex> convert(String value, Map<String, String> variables) {
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        String resolved = PropertyConverter.resolveVariables(value.trim(), variables).toLowerCase();
+
+        switch (resolved) {
+            case "start":
+                return Optional.of(Flex.START);
+            case "center":
+                return Optional.of(Flex.CENTER);
+            case "end":
+                return Optional.of(Flex.END);
+            case "space-between":
+                return Optional.of(Flex.SPACE_BETWEEN);
+            case "space-around":
+                return Optional.of(Flex.SPACE_AROUND);
+            case "space-evenly":
+                return Optional.of(Flex.SPACE_EVENLY);
+            default:
+                return Optional.empty();
+        }
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/property/IntegerConverter.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/IntegerConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Converts CSS integer values.
+ * <p>
+ * Supports plain integer values like "0", "5", "10".
+ */
+public final class IntegerConverter implements PropertyConverter<Integer> {
+
+    @Override
+    public Optional<Integer> convert(String value, Map<String, String> variables) {
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        String resolved = PropertyConverter.resolveVariables(value.trim(), variables);
+
+        try {
+            return Optional.of(Integer.parseInt(resolved));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/property/MarginConverter.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/MarginConverter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Margin;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Converts CSS margin values to Margin objects.
+ * <p>
+ * Supports the following formats:
+ * <ul>
+ *   <li>{@code "1"} - uniform margin on all sides</li>
+ *   <li>{@code "1 2"} - vertical (top/bottom) and horizontal (left/right)</li>
+ *   <li>{@code "1 2 3 4"} - top, right, bottom, left (CSS order)</li>
+ * </ul>
+ */
+public final class MarginConverter implements PropertyConverter<Margin> {
+
+    @Override
+    public Optional<Margin> convert(String value, Map<String, String> variables) {
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        String resolved = PropertyConverter.resolveVariables(value.trim(), variables);
+        String[] parts = resolved.split("\\s+");
+
+        try {
+            switch (parts.length) {
+                case 1: {
+                    int all = Integer.parseInt(parts[0]);
+                    return Optional.of(Margin.uniform(all));
+                }
+                case 2: {
+                    int vertical = Integer.parseInt(parts[0]);
+                    int horizontal = Integer.parseInt(parts[1]);
+                    return Optional.of(Margin.symmetric(vertical, horizontal));
+                }
+                case 4: {
+                    int top = Integer.parseInt(parts[0]);
+                    int right = Integer.parseInt(parts[1]);
+                    int bottom = Integer.parseInt(parts[2]);
+                    int left = Integer.parseInt(parts[3]);
+                    return Optional.of(new Margin(top, right, bottom, left));
+                }
+                default:
+                    return Optional.empty();
+            }
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/property/PropertyRegistry.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/property/PropertyRegistry.java
@@ -5,6 +5,10 @@
 package dev.tamboui.css.property;
 
 import dev.tamboui.layout.Alignment;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Direction;
+import dev.tamboui.layout.Flex;
+import dev.tamboui.layout.Margin;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Width;
@@ -31,6 +35,11 @@ public final class PropertyRegistry {
     private final AlignmentConverter alignmentConverter;
     private final BorderTypeConverter borderTypeConverter;
     private final WidthConverter widthConverter;
+    private final FlexConverter flexConverter;
+    private final DirectionConverter directionConverter;
+    private final MarginConverter marginConverter;
+    private final IntegerConverter integerConverter;
+    private final ConstraintConverter constraintConverter;
 
     private PropertyRegistry() {
         this.converters = new HashMap<>();
@@ -40,6 +49,11 @@ public final class PropertyRegistry {
         this.alignmentConverter = new AlignmentConverter();
         this.borderTypeConverter = new BorderTypeConverter();
         this.widthConverter = new WidthConverter();
+        this.flexConverter = new FlexConverter();
+        this.directionConverter = new DirectionConverter();
+        this.marginConverter = new MarginConverter();
+        this.integerConverter = new IntegerConverter();
+        this.constraintConverter = new ConstraintConverter();
 
         // Register default converters - create adapter for core color converter
         PropertyConverter<Color> colorAdapter = (value, variables) -> {
@@ -54,7 +68,12 @@ public final class PropertyRegistry {
         converters.put("padding", spacingConverter);
         converters.put("text-align", alignmentConverter);
         converters.put("border-type", borderTypeConverter);
-        converters.put("width", widthConverter);
+        converters.put("width", constraintConverter);
+        converters.put("flex", flexConverter);
+        converters.put("direction", directionConverter);
+        converters.put("margin", marginConverter);
+        converters.put("spacing", integerConverter);
+        converters.put("height", constraintConverter);
     }
 
     /**
@@ -131,6 +150,61 @@ public final class PropertyRegistry {
      */
     public Optional<Width> convertWidth(String value, Map<String, String> variables) {
         return widthConverter.convert(value, variables);
+    }
+
+    /**
+     * Converts CSS flex value.
+     *
+     * @param value     the CSS value
+     * @param variables the CSS variables
+     * @return the converted flex, or empty if conversion fails
+     */
+    public Optional<Flex> convertFlex(String value, Map<String, String> variables) {
+        return flexConverter.convert(value, variables);
+    }
+
+    /**
+     * Converts CSS direction value.
+     *
+     * @param value     the CSS value
+     * @param variables the CSS variables
+     * @return the converted direction, or empty if conversion fails
+     */
+    public Optional<Direction> convertDirection(String value, Map<String, String> variables) {
+        return directionConverter.convert(value, variables);
+    }
+
+    /**
+     * Converts CSS margin value.
+     *
+     * @param value     the CSS value
+     * @param variables the CSS variables
+     * @return the converted margin, or empty if conversion fails
+     */
+    public Optional<Margin> convertMargin(String value, Map<String, String> variables) {
+        return marginConverter.convert(value, variables);
+    }
+
+    /**
+     * Converts CSS spacing (integer) value.
+     *
+     * @param value     the CSS value
+     * @param variables the CSS variables
+     * @return the converted spacing, or empty if conversion fails
+     */
+    public Optional<Integer> convertSpacing(String value, Map<String, String> variables) {
+        return integerConverter.convert(value, variables);
+    }
+
+    /**
+     * Converts CSS height (constraint) value.
+     *
+     * @param value     the CSS value
+     * @param variables the CSS variables
+     * @return the converted constraint, or empty if conversion fails
+     */
+    public Optional<Constraint> convertConstraint(String value, Map<String, String> variables) {
+        return constraintConverter.convert(value, variables);
     }
 
     /**

--- a/tamboui-css/src/test/java/dev/tamboui/css/property/ConstraintConverterTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/property/ConstraintConverterTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Constraint;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConstraintConverterTest {
+
+    private final ConstraintConverter converter = new ConstraintConverter();
+
+    @Test
+    void convertsFit() {
+        Optional<Constraint> result = converter.convert("fit", Collections.emptyMap());
+        assertThat(result).contains(Constraint.fit());
+    }
+
+    @Test
+    void convertsFillWithDefaultWeight() {
+        Optional<Constraint> result = converter.convert("fill", Collections.emptyMap());
+        assertThat(result).contains(Constraint.fill());
+    }
+
+    @Test
+    void convertsFillWithCustomWeight() {
+        Optional<Constraint> result = converter.convert("fill(3)", Collections.emptyMap());
+        assertThat(result).contains(Constraint.fill(3));
+    }
+
+    @Test
+    void convertsFixedLength() {
+        Optional<Constraint> result = converter.convert("10", Collections.emptyMap());
+        assertThat(result).contains(Constraint.length(10));
+    }
+
+    @Test
+    void convertsPercentage() {
+        Optional<Constraint> result = converter.convert("50%", Collections.emptyMap());
+        assertThat(result).contains(Constraint.percentage(50));
+    }
+
+    @Test
+    void convertsMin() {
+        Optional<Constraint> result = converter.convert("min(5)", Collections.emptyMap());
+        assertThat(result).contains(Constraint.min(5));
+    }
+
+    @Test
+    void convertsMax() {
+        Optional<Constraint> result = converter.convert("max(100)", Collections.emptyMap());
+        assertThat(result).contains(Constraint.max(100));
+    }
+
+    @Test
+    void convertsRatio() {
+        Optional<Constraint> result = converter.convert("1/3", Collections.emptyMap());
+        assertThat(result).contains(Constraint.ratio(1, 3));
+    }
+
+    @Test
+    void handlesWhitespace() {
+        Optional<Constraint> result = converter.convert("  fill  ", Collections.emptyMap());
+        assertThat(result).contains(Constraint.fill());
+    }
+
+    @Test
+    void returnsEmptyForNull() {
+        Optional<Constraint> result = converter.convert(null, Collections.emptyMap());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyForEmptyString() {
+        Optional<Constraint> result = converter.convert("", Collections.emptyMap());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyForInvalidValue() {
+        Optional<Constraint> result = converter.convert("invalid", Collections.emptyMap());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resolvesVariables() {
+        Map<String, String> vars = Collections.singletonMap("card-height", "5");
+        Optional<Constraint> result = converter.convert("$card-height", vars);
+        assertThat(result).contains(Constraint.length(5));
+    }
+
+    @Test
+    void caseInsensitive() {
+        Optional<Constraint> result = converter.convert("FILL", Collections.emptyMap());
+        assertThat(result).contains(Constraint.fill());
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/property/DirectionConverterTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/property/DirectionConverterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Direction;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DirectionConverterTest {
+
+    private final DirectionConverter converter = new DirectionConverter();
+
+    @Test
+    void convertsHorizontal() {
+        assertThat(converter.convert("horizontal", Collections.emptyMap()))
+            .hasValue(Direction.HORIZONTAL);
+    }
+
+    @Test
+    void convertsRow() {
+        assertThat(converter.convert("row", Collections.emptyMap()))
+            .hasValue(Direction.HORIZONTAL);
+    }
+
+    @Test
+    void convertsVertical() {
+        assertThat(converter.convert("vertical", Collections.emptyMap()))
+            .hasValue(Direction.VERTICAL);
+    }
+
+    @Test
+    void convertsColumn() {
+        assertThat(converter.convert("column", Collections.emptyMap()))
+            .hasValue(Direction.VERTICAL);
+    }
+
+    @Test
+    void caseInsensitive() {
+        assertThat(converter.convert("HORIZONTAL", Collections.emptyMap()))
+            .hasValue(Direction.HORIZONTAL);
+        assertThat(converter.convert("Vertical", Collections.emptyMap()))
+            .hasValue(Direction.VERTICAL);
+        assertThat(converter.convert("ROW", Collections.emptyMap()))
+            .hasValue(Direction.HORIZONTAL);
+    }
+
+    @Test
+    void handlesWhitespace() {
+        assertThat(converter.convert("  vertical  ", Collections.emptyMap()))
+            .hasValue(Direction.VERTICAL);
+    }
+
+    @Test
+    void resolvesVariableReference() {
+        Map<String, String> variables = new HashMap<>();
+        variables.put("layout-dir", "horizontal");
+
+        assertThat(converter.convert("$layout-dir", variables))
+            .hasValue(Direction.HORIZONTAL);
+    }
+
+    @Test
+    void returnsEmptyForInvalidValue() {
+        assertThat(converter.convert("invalid", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert(null, Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("diagonal", Collections.emptyMap())).isEmpty();
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/property/FlexConverterTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/property/FlexConverterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Flex;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FlexConverterTest {
+
+    private final FlexConverter converter = new FlexConverter();
+
+    @Test
+    void convertsStart() {
+        assertThat(converter.convert("start", Collections.emptyMap()))
+            .hasValue(Flex.START);
+    }
+
+    @Test
+    void convertsCenter() {
+        assertThat(converter.convert("center", Collections.emptyMap()))
+            .hasValue(Flex.CENTER);
+    }
+
+    @Test
+    void convertsEnd() {
+        assertThat(converter.convert("end", Collections.emptyMap()))
+            .hasValue(Flex.END);
+    }
+
+    @Test
+    void convertsSpaceBetween() {
+        assertThat(converter.convert("space-between", Collections.emptyMap()))
+            .hasValue(Flex.SPACE_BETWEEN);
+    }
+
+    @Test
+    void convertsSpaceAround() {
+        assertThat(converter.convert("space-around", Collections.emptyMap()))
+            .hasValue(Flex.SPACE_AROUND);
+    }
+
+    @Test
+    void convertsSpaceEvenly() {
+        assertThat(converter.convert("space-evenly", Collections.emptyMap()))
+            .hasValue(Flex.SPACE_EVENLY);
+    }
+
+    @Test
+    void caseInsensitive() {
+        assertThat(converter.convert("START", Collections.emptyMap()))
+            .hasValue(Flex.START);
+        assertThat(converter.convert("Space-Between", Collections.emptyMap()))
+            .hasValue(Flex.SPACE_BETWEEN);
+    }
+
+    @Test
+    void handlesWhitespace() {
+        assertThat(converter.convert("  center  ", Collections.emptyMap()))
+            .hasValue(Flex.CENTER);
+    }
+
+    @Test
+    void resolvesVariableReference() {
+        Map<String, String> variables = new HashMap<>();
+        variables.put("flex-mode", "space-evenly");
+
+        assertThat(converter.convert("$flex-mode", variables))
+            .hasValue(Flex.SPACE_EVENLY);
+    }
+
+    @Test
+    void returnsEmptyForInvalidValue() {
+        assertThat(converter.convert("invalid", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert(null, Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("stretch", Collections.emptyMap())).isEmpty();
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/property/IntegerConverterTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/property/IntegerConverterTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IntegerConverterTest {
+
+    private final IntegerConverter converter = new IntegerConverter();
+
+    @Test
+    void convertsPositiveInteger() {
+        assertThat(converter.convert("5", Collections.emptyMap()))
+            .hasValue(5);
+    }
+
+    @Test
+    void convertsZero() {
+        assertThat(converter.convert("0", Collections.emptyMap()))
+            .hasValue(0);
+    }
+
+    @Test
+    void convertsNegativeInteger() {
+        assertThat(converter.convert("-3", Collections.emptyMap()))
+            .hasValue(-3);
+    }
+
+    @Test
+    void handlesWhitespace() {
+        assertThat(converter.convert("  10  ", Collections.emptyMap()))
+            .hasValue(10);
+    }
+
+    @Test
+    void resolvesVariableReference() {
+        Map<String, String> variables = new HashMap<>();
+        variables.put("gap", "2");
+
+        assertThat(converter.convert("$gap", variables))
+            .hasValue(2);
+    }
+
+    @Test
+    void returnsEmptyForInvalidValue() {
+        assertThat(converter.convert("invalid", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert(null, Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("1.5", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("10px", Collections.emptyMap())).isEmpty();
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/property/MarginConverterTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/property/MarginConverterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.property;
+
+import dev.tamboui.layout.Margin;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MarginConverterTest {
+
+    private final MarginConverter converter = new MarginConverter();
+
+    @Test
+    void convertsUniformMargin() {
+        assertThat(converter.convert("5", Collections.emptyMap()))
+            .hasValue(Margin.uniform(5));
+    }
+
+    @Test
+    void convertsSymmetricMargin() {
+        assertThat(converter.convert("2 4", Collections.emptyMap()))
+            .hasValue(Margin.symmetric(2, 4));
+    }
+
+    @Test
+    void convertsFourValueMargin() {
+        assertThat(converter.convert("1 2 3 4", Collections.emptyMap()))
+            .hasValue(new Margin(1, 2, 3, 4));
+    }
+
+    @Test
+    void handlesWhitespace() {
+        assertThat(converter.convert("  5  ", Collections.emptyMap()))
+            .hasValue(Margin.uniform(5));
+        assertThat(converter.convert("  1   2   3   4  ", Collections.emptyMap()))
+            .hasValue(new Margin(1, 2, 3, 4));
+    }
+
+    @Test
+    void resolvesVariableReference() {
+        Map<String, String> variables = new HashMap<>();
+        variables.put("margin-size", "3");
+
+        assertThat(converter.convert("$margin-size", variables))
+            .hasValue(Margin.uniform(3));
+    }
+
+    @Test
+    void returnsEmptyForInvalidValue() {
+        assertThat(converter.convert("invalid", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("", Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert(null, Collections.emptyMap())).isEmpty();
+        assertThat(converter.convert("1 2 3", Collections.emptyMap())).isEmpty(); // 3 values not supported
+        assertThat(converter.convert("1 2 3 4 5", Collections.emptyMap())).isEmpty(); // 5 values not supported
+    }
+}

--- a/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java
+++ b/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java
@@ -44,13 +44,20 @@ import static dev.tamboui.toolkit.Toolkit.*;
  */
 public class CustomComponentDemo implements Element {
 
+    private boolean showHelp = false;
+
     private static final String DEFAULT_CSS = """
         /* Edit this CSS to style the cards! */
+
+        /* ══════════════════════════════════════════
+           ProgressCard Styles
+           ══════════════════════════════════════════ */
 
         ProgressCard {
             background: #1a1a1a;
             border-color: #666666;
             border-type: rounded;
+            height: 5;
         }
 
         ProgressCard:focus {
@@ -86,6 +93,100 @@ public class CustomComponentDemo implements Element {
 
         .progress-in-progress {
             color: yellow;
+        }
+
+        /* ══════════════════════════════════════════
+           Panel Styles
+           ══════════════════════════════════════════ */
+
+        .header-panel {
+            border-type: rounded;
+            height: 3;
+        }
+
+        .status-panel {
+            border-type: rounded;
+            height: 3;
+        }
+
+        #info-panel {
+            border-type: rounded;
+            spacing: 0;
+            height: 3;
+        }
+
+        .footer-panel {
+            border-type: rounded;
+            height: 3;
+        }
+
+        #css-editor {
+            border-type: rounded;
+            height: fill;
+        }
+
+        .editor-column {
+            height: 50%;
+        }
+
+        .preview-column {
+            height: fill;
+        }
+
+        .main-row {
+            height: fill;
+        }
+
+        /* ══════════════════════════════════════════
+           Text Styles
+           ══════════════════════════════════════════ */
+
+        .title {
+            color: cyan;
+            text-style: bold;
+        }
+
+        .dim {
+            text-style: dim;
+        }
+
+        .highlight {
+            color: yellow;
+        }
+
+        .success {
+            color: green;
+        }
+
+        .error {
+            color: red;
+        }
+
+        /* ══════════════════════════════════════════
+           Flex Layout Properties
+           ══════════════════════════════════════════ */
+
+        .cards-container {
+            spacing: 1;
+            flex: start;
+            height: fill;
+        }
+
+        .header-row {
+            flex: space-between;
+        }
+
+        .footer-row {
+            flex: center;
+        }
+
+        /* Footer text uses 'fit' to size to content, enabling flex */
+        .footer-row .title {
+            width: fit;
+        }
+
+        .footer-row .dim {
+            width: fit;
         }
         """;
 
@@ -167,14 +268,15 @@ public class CustomComponentDemo implements Element {
         }
 
         column(
-            // Header
+            // Header - styling via CSS (.header-panel, .header-row, .title, .dim)
             panel(() -> row(
-                text(" Live CSS Editor Demo ").bold().cyan(),
+                text(" Live CSS Editor Demo ").addClass("title"),
                 spacer(),
-                text(" [Tab] Focus ").dim(),
-                text(" [+/-] Progress ").dim(),
-                text(" [q] Quit ").dim()
-            )).rounded().length(3),
+                text(" [Tab] Focus ").addClass("dim"),
+                text(" [+/-] Progress ").addClass("dim"),
+                text(" [h] Help ").addClass("dim"),
+                text(" [q] Quit ").addClass("dim")
+            ).addClass("header-row")).addClass("header-panel"),
 
             // Main content
             row(
@@ -183,53 +285,70 @@ public class CustomComponentDemo implements Element {
                     textArea(cssEditorState)
                         .title("CSS Editor - Edit to see live changes")
                         .showLineNumbers()
-                        .rounded()
-                        .id("css-editor")
-                        .fill(),
+                        .id("css-editor"),
 
-                    // Error/status display
+                    // Error/status display - styling via CSS (.status-panel, .error, .success)
                     panel(() -> {
                         if (parseError != null) {
-                            return text(parseError).red();
+                            return text(parseError).addClass("error");
                         } else {
-                            return text("CSS Valid").green();
+                            return text("CSS Valid").addClass("success");
                         }
-                    }).title("Status").rounded().length(3)
-                ).percent(50),
+                    }).title("Status").addClass("status-panel")
+                ).addClass("editor-column"),
 
-                // Right side - Preview
+                // Right side - Preview with cards container using CSS flex
                 column(
-                    panel(() -> column(
-                        text("Preview").bold().cyan(),
-                        spacer(1),
-                        text("Edit the CSS on the left to"),
-                        text("see changes applied live!"),
-                        spacer(1),
-                        text("Properties:").yellow(),
-                        text("  border-type: rounded|double|thick").dim(),
-                        text("  border-color: <color>").dim(),
-                        text("  background: <color>").dim()
-                    )).id("info-panel").rounded().length(12),
+                    // Compact info panel with hint
+                    panel(() -> row(
+                        text("Edit CSS to style the cards").addClass("dim"),
+                        spacer(),
+                        text("[h] Help").addClass("highlight")
+                    )).title("Preview").id("info-panel"),
 
-                    // The cards
-                    renderCard(0),
-                    renderCard(1),
-                    renderCard(2)
-                ).fill()
-            ).fill(),
+                    // The cards in a container - styling via CSS (.cards-container)
+                    column(
+                        renderCard(0),
+                        renderCard(1),
+                        renderCard(2)
+                    ).addClass("cards-container")
+                ).addClass("preview-column")
+            ).addClass("main-row"),
 
-            // Footer
+            // Footer - styling via CSS (.footer-panel, .footer-row)
+            // Text widths set via CSS width: fit, flex controls positioning
             panel(() -> row(
-                text("Edit CSS ").bold(),
-                text("to style ").dim(),
-                text("ProgressCard ").cyan(),
-                text("components in real-time").dim()
-            )).rounded().length(3)
+                text("Edit CSS ").addClass("title"),
+                text("to style ").addClass("dim"),
+                text("ProgressCard ").addClass("title"),
+                text("in real-time").addClass("dim")
+            ).addClass("footer-row")).addClass("footer-panel")
         ).render(frame, area, context);
+
+        // Show help dialog if requested
+        if (showHelp) {
+            dialog("CSS Properties Help",
+                text("Style Properties:").addClass("highlight"),
+                text("  border-type: plain|rounded|double|thick"),
+                text("  border-color: <color>"),
+                text("  background: <color>"),
+                text("  color: <color>"),
+                text("  text-style: bold|dim|italic|underline"),
+                spacer(1),
+                text("Layout Properties:").addClass("highlight"),
+                text("  height: fill | <number> | <percent>%"),
+                text("  width: fill | <number> | <percent>%"),
+                text("  flex: start|center|end|space-between"),
+                text("  spacing: <number>"),
+                spacer(1),
+                text("[Esc] Close").addClass("dim")
+            ).width(50).height(17).onCancel(() -> showHelp = false)
+             .render(frame, area, context);
+        }
     }
 
     private Element renderCard(int index) {
-        return cards.get(index).length(5);
+        return cards.get(index);
     }
 
     private void applyUserCss(String css) {
@@ -252,6 +371,21 @@ public class CustomComponentDemo implements Element {
 
     @Override
     public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
+        // Handle dialog events when shown
+        if (showHelp) {
+            if (event.isCancel()) {
+                showHelp = false;
+                return EventResult.HANDLED;
+            }
+            // Dialog is modal - consume all events
+            return EventResult.HANDLED;
+        }
+
+        // Handle 'h' to show help dialog
+        if (event.isChar('h')) {
+            showHelp = true;
+            return EventResult.HANDLED;
+        }
         // Tab and +/- are handled by the framework and individual components
         return EventResult.UNHANDLED;
     }

--- a/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/ProgressCard.java
+++ b/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/ProgressCard.java
@@ -4,10 +4,9 @@
  */
 package dev.tamboui.demo;
 
-import dev.tamboui.style.Color;
+import dev.tamboui.annotations.bindings.OnAction;
 import dev.tamboui.toolkit.component.Component;
 import dev.tamboui.toolkit.element.Element;
-import dev.tamboui.annotations.bindings.OnAction;
 import dev.tamboui.tui.event.Event;
 
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -113,22 +112,23 @@ public final class ProgressCard extends Component<ProgressCard> {
 
     @Override
     protected Element render() {
-        var focused = isFocused();
-
-        // Use double border + cyan when focused for clear visual feedback
+        // All styling is via CSS classes - no programmatic styling here
+        // Constraints (length, fill) are kept programmatic as they have no CSS equivalent
         var panel = panel(() -> column(
-                // Title with CSS class
-                text(title).bold().addClass("card-title"),
-                // Description with CSS class
-                text(description).addClass("card-description"),
-                // Progress bar with status-based CSS class
+                // Title - styling via CSS (.card-title)
+                text(title).addClass("card-title").length(1),
+                // Description - styling via CSS (.card-description)
+                text(description).addClass("card-description").length(1),
+                // Progress bar - styling via CSS (.progress-complete, .progress-in-progress)
                 gauge(progress)
                         .label(String.format("%.0f%%", progress * 100))
                         .addClass("progress-" + status.cssClass())
+                        .fill()
         ))
                 .title(status.name())
-                .addClass(status.cssClass());
-        
+                .addClass(status.cssClass())
+                .cssParent(this);
+
         return panel.fill();
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/DefaultRenderContext.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/DefaultRenderContext.java
@@ -266,11 +266,20 @@ public final class DefaultRenderContext implements RenderContext {
 
     private List<Styleable> buildAncestorChain(Styleable element) {
         List<Styleable> ancestors = new ArrayList<>();
+
+        // First, try explicit cssParent chain (takes precedence)
         Optional<Styleable> parent = element.cssParent();
         while (parent.isPresent()) {
             ancestors.add(0, parent.get());
             parent = parent.get().cssParent();
         }
+
+        // If no explicit parent, use the element stack (runtime render hierarchy)
+        // This enables descendant selectors for dynamically created elements
+        if (ancestors.isEmpty() && !elementStack.isEmpty()) {
+            ancestors.addAll(elementStack);
+        }
+
         return ancestors;
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/Element.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/Element.java
@@ -43,6 +43,26 @@ public interface Element {
     }
 
     /**
+     * Returns the preferred width of this element in cells.
+     * Used when the element has a {@link Constraint.Fit} constraint.
+     *
+     * @return the preferred width, or 0 if not applicable
+     */
+    default int preferredWidth() {
+        return 0;
+    }
+
+    /**
+     * Returns the preferred height of this element in cells.
+     * Used when the element has a {@link Constraint.Fit} constraint.
+     *
+     * @return the preferred height, or 0 if not applicable
+     */
+    default int preferredHeight() {
+        return 0;
+    }
+
+    /**
      * Returns whether this element can receive focus.
      *
      * @return true if focusable, false otherwise

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -4,12 +4,15 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.css.Styleable;
+import dev.tamboui.css.cascade.CssStyleResolver;
 import dev.tamboui.toolkit.element.ContainerElement;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
@@ -20,16 +23,26 @@ import java.util.List;
 
 /**
  * A vertical layout container that arranges children in a column.
- *
- * <p>Supports flex modes for distributing remaining space:
+ * <p>
+ * Layout properties can be set via CSS or programmatically:
+ * <ul>
+ *   <li>{@code flex} - Flex positioning mode: "start", "center", "end", "space-between", "space-around", "space-evenly"</li>
+ *   <li>{@code spacing} - Gap between children in cells</li>
+ *   <li>{@code margin} - Margin around the column</li>
+ * </ul>
+ * <p>
+ * Programmatic values override CSS values when both are set.
+ * <p>
+ * Example usage:
  * <pre>
  * column(child1, child2, child3).flex(Flex.CENTER).spacing(1)
  * </pre>
  */
 public final class Column extends ContainerElement<Column> {
 
-    private int spacing = 0;
-    private Flex flex = Flex.START;
+    private Integer spacing;
+    private Flex flex;
+    private Margin margin;
 
     public Column() {
     }
@@ -40,6 +53,8 @@ public final class Column extends ContainerElement<Column> {
 
     /**
      * Sets the spacing between children.
+     * <p>
+     * Can also be set via CSS {@code spacing} property.
      *
      * @param spacing spacing in cells between adjacent children
      * @return this column for method chaining
@@ -51,13 +66,39 @@ public final class Column extends ContainerElement<Column> {
 
     /**
      * Sets how remaining space is distributed among children.
+     * <p>
+     * Can also be set via CSS {@code flex} property.
      *
      * @param flex the flex mode for space distribution
      * @return this column for method chaining
      * @see Flex
      */
     public Column flex(Flex flex) {
-        this.flex = flex != null ? flex : Flex.START;
+        this.flex = flex;
+        return this;
+    }
+
+    /**
+     * Sets the margin around the column.
+     * <p>
+     * Can also be set via CSS {@code margin} property.
+     *
+     * @param margin the margin
+     * @return this column for method chaining
+     */
+    public Column margin(Margin margin) {
+        this.margin = margin;
+        return this;
+    }
+
+    /**
+     * Sets uniform margin around the column.
+     *
+     * @param value the margin value for all sides
+     * @return this column for method chaining
+     */
+    public Column margin(int value) {
+        this.margin = Margin.uniform(value);
         return this;
     }
 
@@ -67,10 +108,40 @@ public final class Column extends ContainerElement<Column> {
             return;
         }
 
+        // Get CSS resolver for property resolution
+        CssStyleResolver cssResolver = context.resolveStyle(this).orElse(null);
+
+        // Resolve margin: programmatic > CSS > none
+        Margin effectiveMargin = this.margin;
+        if (effectiveMargin == null && cssResolver != null) {
+            effectiveMargin = cssResolver.margin().orElse(null);
+        }
+
+        // Apply margin to get the effective render area
+        Rect effectiveArea = area;
+        if (effectiveMargin != null) {
+            effectiveArea = effectiveMargin.inner(area);
+            if (effectiveArea.isEmpty()) {
+                return;
+            }
+        }
+
         // Fill background with current style
         Style effectiveStyle = context.currentStyle();
         if (effectiveStyle.bg().isPresent()) {
-            frame.buffer().setStyle(area, effectiveStyle);
+            frame.buffer().setStyle(effectiveArea, effectiveStyle);
+        }
+
+        // Resolve spacing: programmatic > CSS > 0
+        int effectiveSpacing = this.spacing != null ? this.spacing : 0;
+        if (this.spacing == null && cssResolver != null) {
+            effectiveSpacing = cssResolver.spacing().orElse(0);
+        }
+
+        // Resolve flex: programmatic > CSS > null (don't apply if not set)
+        Flex effectiveFlex = this.flex;
+        if (effectiveFlex == null && cssResolver != null) {
+            effectiveFlex = cssResolver.flex().orElse(null);
         }
 
         // Build constraints, accounting for spacing
@@ -78,6 +149,18 @@ public final class Column extends ContainerElement<Column> {
         for (int i = 0; i < children.size(); i++) {
             Element child = children.get(i);
             Constraint c = child.constraint();
+            // Check CSS height constraint if programmatic is null (Column uses height)
+            if (c == null && child instanceof Styleable) {
+                CssStyleResolver childCss = context.resolveStyle((Styleable) child).orElse(null);
+                if (childCss != null) {
+                    c = childCss.heightConstraint().orElse(null);
+                }
+            }
+            // Handle Fit constraint by querying preferred height
+            if (c instanceof Constraint.Fit) {
+                int preferred = child.preferredHeight();
+                c = preferred > 0 ? Constraint.length(preferred) : null;
+            }
             if (c == null) {
                 // For text elements without explicit constraint, calculate height from content
                 c = calculateDefaultConstraint(child);
@@ -85,21 +168,25 @@ public final class Column extends ContainerElement<Column> {
             constraints.add(c != null ? c : Constraint.fill());
 
             // Add spacing constraint between children
-            if (spacing > 0 && i < children.size() - 1) {
-                constraints.add(Constraint.length(spacing));
+            if (effectiveSpacing > 0 && i < children.size() - 1) {
+                constraints.add(Constraint.length(effectiveSpacing));
             }
         }
 
-        List<Rect> areas = Layout.vertical()
-            .constraints(constraints.toArray(new Constraint[0]))
-            .flex(flex)
-            .split(area);
+        // Build layout - only apply flex if explicitly set
+        Layout layout = Layout.vertical()
+            .constraints(constraints.toArray(new Constraint[0]));
+
+        if (effectiveFlex != null) {
+            layout = layout.flex(effectiveFlex);
+        }
+
+        List<Rect> areas = layout.split(effectiveArea);
 
         // Render children (skipping spacing areas)
-        // Children self-register for events in their own render() if needed
         int childIndex = 0;
         for (int i = 0; i < areas.size() && childIndex < children.size(); i++) {
-            if (spacing > 0 && i % 2 == 1) {
+            if (effectiveSpacing > 0 && i % 2 == 1) {
                 // Skip spacing area
                 continue;
             }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextElement.java
@@ -173,6 +173,27 @@ public final class TextElement extends StyledElement<TextElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // For multi-line text, return the longest line
+        int maxWidth = 0;
+        int currentWidth = 0;
+        for (int i = 0; i < content.length(); i++) {
+            if (content.charAt(i) == '\n') {
+                maxWidth = Math.max(maxWidth, currentWidth);
+                currentWidth = 0;
+            } else {
+                currentWidth++;
+            }
+        }
+        return Math.max(maxWidth, currentWidth);
+    }
+
+    @Override
+    public int preferredHeight() {
+        return countLines();
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (content.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static dev.tamboui.assertj.BufferAssertions.assertThat;
+import static dev.tamboui.toolkit.Toolkit.*;
+
+/**
+ * Tests that Row and Column correctly consume CSS constraint properties.
+ */
+class ConstraintCssTest {
+
+    private StyleEngine styleEngine;
+    private DefaultRenderContext context;
+    private Buffer buffer;
+    private Frame frame;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        styleEngine = StyleEngine.create();
+        styleEngine.loadStylesheet("constraint-test", "/themes/constraint-test.tcss");
+        styleEngine.setActiveStylesheet("constraint-test");
+
+        context = DefaultRenderContext.createEmpty();
+        context.setStyleEngine(styleEngine);
+    }
+
+    private void setupBuffer(int width, int height) {
+        Rect area = new Rect(0, 0, width, height);
+        buffer = Buffer.empty(area);
+        frame = Frame.forTesting(buffer);
+    }
+
+    @Nested
+    @DisplayName("Column height constraints from CSS")
+    class ColumnHeightTests {
+
+        @Test
+        @DisplayName("CSS height: <number> sets fixed height")
+        void cssHeightFixed() {
+            setupBuffer(20, 10);
+
+            column(
+                text("A").addClass("height-fixed"),  // height: 3
+                text("B")
+            ).render(frame, new Rect(0, 0, 20, 10), context);
+
+            // A should be at row 0
+            assertThat(buffer).hasSymbolAt(0, 0, "A");
+            // B should be at row 3 (after A's 3 rows)
+            assertThat(buffer).hasSymbolAt(0, 3, "B");
+        }
+
+        @Test
+        @DisplayName("CSS height: fit sizes to content")
+        void cssHeightFit() {
+            setupBuffer(20, 10);
+
+            column(
+                text("Line1\nLine2").addClass("height-fit"),  // Should be 2 rows
+                text("After")
+            ).render(frame, new Rect(0, 0, 20, 10), context);
+
+            // First text at row 0
+            assertThat(buffer).hasSymbolAt(0, 0, "L");
+            // "After" should be at row 2 (after 2 lines of content)
+            assertThat(buffer).hasSymbolAt(0, 2, "A");
+        }
+    }
+
+    @Nested
+    @DisplayName("Row width constraints from CSS")
+    class RowWidthTests {
+
+        @Test
+        @DisplayName("CSS width: <number> sets fixed width")
+        void cssWidthFixed() {
+            setupBuffer(30, 1);
+
+            row(
+                text("A").addClass("width-fixed"),  // width: 10
+                text("B")
+            ).render(frame, new Rect(0, 0, 30, 1), context);
+
+            // A at column 0
+            assertThat(buffer).hasSymbolAt(0, 0, "A");
+            // B should be at column 10 (after A's 10 columns)
+            assertThat(buffer).hasSymbolAt(10, 0, "B");
+        }
+
+        @Test
+        @DisplayName("CSS width: fit sizes to content")
+        void cssWidthFit() {
+            setupBuffer(30, 1);
+
+            row(
+                text("Hello").addClass("width-fit"),  // Should be 5 columns
+                text("World")
+            ).render(frame, new Rect(0, 0, 30, 1), context);
+
+            // "Hello" at column 0
+            assertThat(buffer).hasSymbolAt(0, 0, "H");
+            // "World" should start at column 5
+            assertThat(buffer).hasSymbolAt(5, 0, "W");
+        }
+
+        @Test
+        @DisplayName("CSS width: percent uses percentage of available width")
+        void cssWidthPercent() {
+            setupBuffer(40, 1);
+
+            row(
+                text("A").addClass("width-percent"),  // width: 25% = 10 columns
+                text("B")
+            ).render(frame, new Rect(0, 0, 40, 1), context);
+
+            // A at column 0
+            assertThat(buffer).hasSymbolAt(0, 0, "A");
+            // B should be at column 10 (25% of 40)
+            assertThat(buffer).hasSymbolAt(10, 0, "B");
+        }
+    }
+
+    @Nested
+    @DisplayName("Descendant selector constraints")
+    class DescendantSelectorTests {
+
+        @Test
+        @DisplayName("Descendant selector .parent .child applies constraints")
+        void descendantSelectorAppliesWidthConstraint() {
+            setupBuffer(40, 1);
+
+            // .parent-row .child-text { width: fit; }
+            row(
+                text("Short").addClass("child-text"),
+                text("Rest")
+            ).addClass("parent-row")
+             .render(frame, new Rect(0, 0, 40, 1), context);
+
+            // With width: fit, "Short" takes only 5 columns
+            assertThat(buffer).hasSymbolAt(0, 0, "S");
+            // With flex: center on parent-row, rest of space is distributed
+            // So "Rest" won't be immediately after "Short"
+        }
+    }
+
+    @Nested
+    @DisplayName("Programmatic constraints override CSS")
+    class ProgrammaticOverrideTests {
+
+        @Test
+        @DisplayName("Programmatic constraint overrides CSS height")
+        void programmaticOverridesCssHeight() {
+            setupBuffer(20, 10);
+
+            column(
+                text("A").addClass("height-fixed").length(5),  // CSS: 3, programmatic: 5
+                text("B")
+            ).render(frame, new Rect(0, 0, 20, 10), context);
+
+            // A should be at row 0
+            assertThat(buffer).hasSymbolAt(0, 0, "A");
+            // B should be at row 5 (programmatic 5 overrides CSS 3)
+            assertThat(buffer).hasSymbolAt(0, 5, "B");
+        }
+
+        @Test
+        @DisplayName("Programmatic constraint overrides CSS width")
+        void programmaticOverridesCssWidth() {
+            setupBuffer(30, 1);
+
+            row(
+                text("A").addClass("width-fixed").length(15),  // CSS: 10, programmatic: 15
+                text("B")
+            ).render(frame, new Rect(0, 0, 30, 1), context);
+
+            // A at column 0
+            assertThat(buffer).hasSymbolAt(0, 0, "A");
+            // B should be at column 15 (programmatic overrides CSS)
+            assertThat(buffer).hasSymbolAt(15, 0, "B");
+        }
+    }
+}

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelFlexCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelFlexCssTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Direction;
+import dev.tamboui.layout.Flex;
+import dev.tamboui.layout.Margin;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Panel consumes CSS flex layout properties.
+ */
+class PanelFlexCssTest {
+
+    private StyleEngine styleEngine;
+    private DefaultRenderContext context;
+    private Buffer buffer;
+    private Frame frame;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        styleEngine = StyleEngine.create();
+        styleEngine.loadStylesheet("flex-test", "/themes/flex-test.tcss");
+        styleEngine.setActiveStylesheet("flex-test");
+
+        context = DefaultRenderContext.createEmpty();
+        context.setStyleEngine(styleEngine);
+
+        Rect area = new Rect(0, 0, 80, 24);
+        buffer = Buffer.empty(area);
+        frame = Frame.forTesting(buffer);
+    }
+
+    @Test
+    void panel_programmaticDirection_overridesCss() {
+        Panel panel = new Panel(
+            new TextElement("A").length(5),
+            new TextElement("B").length(5)
+        );
+        panel.addClass("horizontal-panel");
+        panel.vertical(); // Programmatic override
+        Rect area = new Rect(0, 0, 40, 10);
+
+        panel.render(frame, area, context);
+
+        // Children should be laid out vertically (programmatic overrides CSS)
+        // Text A at row 1 (inside border)
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo("A");
+        // In vertical layout, B should be on a different row than A
+        // Find where B is rendered
+        int bRow = -1;
+        for (int y = 1; y < 9; y++) {
+            if ("B".equals(buffer.get(1, y).symbol())) {
+                bRow = y;
+                break;
+            }
+        }
+        assertThat(bRow).as("B should be found in vertical layout").isGreaterThan(1);
+        assertThat(bRow).as("B should be below A (vertical layout)").isGreaterThan(1);
+    }
+
+    @Test
+    void panel_cssDirection_appliesWhenNoProgrammatic() {
+        Panel panel = new Panel(
+            new TextElement("A").length(5),
+            new TextElement("B").length(5)
+        );
+        panel.addClass("horizontal-panel");
+        // No programmatic direction - CSS should apply
+        Rect area = new Rect(0, 0, 40, 5);
+
+        panel.render(frame, area, context);
+
+        // Children should be laid out horizontally (from CSS)
+        // Both texts should be on the same row (row 1, inside border)
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo("A");
+        // In horizontal layout with spacing=2, B would be to the right
+        // Check that B is on the same row
+        boolean foundB = false;
+        for (int x = 2; x < 38; x++) {
+            if ("B".equals(buffer.get(x, 1).symbol())) {
+                foundB = true;
+                break;
+            }
+        }
+        assertThat(foundB).as("Text B should be on same row as A (horizontal layout from CSS)").isTrue();
+    }
+
+    @Test
+    void panel_cssMargin_appliesWhenNoProgrammatic() {
+        Panel panel = new Panel(new TextElement("X"));
+        panel.addClass("margined-panel");
+        Rect area = new Rect(0, 0, 20, 10);
+
+        panel.render(frame, area, context);
+
+        // With margin: 2, the panel border should start at (2, 2) not (0, 0)
+        // At (0,0) should be empty (no border)
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo(" ");
+        // Border should start at (2, 2)
+        String borderChar = buffer.get(2, 2).symbol();
+        assertThat(borderChar).isNotEqualTo(" ");
+    }
+
+    @Test
+    void panel_programmaticMargin_overridesCss() {
+        Panel panel = new Panel(new TextElement("X"));
+        panel.addClass("margined-panel"); // CSS margin: 2
+        panel.margin(0); // Programmatic override: no margin
+        Rect area = new Rect(0, 0, 20, 10);
+
+        panel.render(frame, area, context);
+
+        // With margin override to 0, the panel border should start at (0, 0)
+        String borderChar = buffer.get(0, 0).symbol();
+        assertThat(borderChar).isNotEqualTo(" ");
+    }
+
+    @Test
+    void panel_programmaticFlex_overridesCss() {
+        Panel panel = new Panel(
+            new TextElement("A").length(2),
+            new TextElement("B").length(2)
+        );
+        panel.addClass("centered-panel"); // CSS flex: center
+        panel.flex(Flex.START); // Programmatic override
+        Rect area = new Rect(0, 0, 20, 10);
+
+        panel.render(frame, area, context);
+
+        // With Flex.START, content should be at top
+        // Text A should be at row 1 (just below top border)
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo("A");
+    }
+
+    @Test
+    void panel_programmaticSpacing_overridesCss() {
+        Panel panel = new Panel(
+            new TextElement("A").length(2),
+            new TextElement("B").length(2)
+        );
+        panel.addClass("horizontal-panel"); // CSS spacing: 2
+        panel.horizontal();
+        panel.spacing(0); // Programmatic override
+        Rect area = new Rect(0, 0, 20, 5);
+
+        panel.render(frame, area, context);
+
+        // With spacing=0, B should be close to A
+        // Both A and B should be on the same row (row 1, inside border)
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo("A");
+        // Find where B is rendered - should be on same row
+        int bCol = -1;
+        for (int x = 1; x < 18; x++) {
+            if ("B".equals(buffer.get(x, 1).symbol())) {
+                bCol = x;
+                break;
+            }
+        }
+        assertThat(bCol).as("B should be found on same row (horizontal layout)").isGreaterThan(1);
+        // With spacing=0, B should be closer than with spacing=2
+        // The first child gets 2 cells width, so B should start around col 3
+        assertThat(bCol).as("B should be close to A with spacing=0").isLessThanOrEqualTo(5);
+    }
+
+    @Test
+    void panel_allFlexProperties_fromCss() {
+        Panel panel = new Panel(
+            new TextElement("L").fill(),
+            new TextElement("R").fill()
+        );
+        panel.addClass("full-flex-panel");
+        // full-flex-panel has: direction: horizontal, flex: space-between, spacing: 1, margin: 1 2 1 2
+        Rect area = new Rect(0, 0, 30, 6);
+
+        panel.render(frame, area, context);
+
+        // With margin 1 2 1 2 (top right bottom left), border starts at (2, 1)
+        // At (0,0) and (1,0) should be empty (margin)
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo(" ");
+        // Border at (2, 1) should not be empty
+        String borderChar = buffer.get(2, 1).symbol();
+        assertThat(borderChar).isNotEqualTo(" ");
+    }
+}

--- a/tamboui-toolkit/src/test/resources/themes/constraint-test.tcss
+++ b/tamboui-toolkit/src/test/resources/themes/constraint-test.tcss
@@ -1,0 +1,48 @@
+/* Constraint CSS Test Theme */
+
+/* Height constraints for Column children */
+.height-fill {
+    height: fill;
+}
+
+.height-fixed {
+    height: 3;
+}
+
+.height-percent {
+    height: 50%;
+}
+
+.height-fit {
+    height: fit;
+}
+
+/* Width constraints for Row children */
+.width-fill {
+    width: fill;
+}
+
+.width-fixed {
+    width: 10;
+}
+
+.width-percent {
+    width: 25%;
+}
+
+.width-fit {
+    width: fit;
+}
+
+/* Descendant selector test */
+.parent-row {
+    flex: center;
+}
+
+.parent-row .child-text {
+    width: fit;
+}
+
+.parent-column .child-text {
+    height: fit;
+}

--- a/tamboui-toolkit/src/test/resources/themes/flex-test.tcss
+++ b/tamboui-toolkit/src/test/resources/themes/flex-test.tcss
@@ -1,0 +1,31 @@
+/* Flex Layout Test Theme */
+
+/* Horizontal panel with spacing */
+.horizontal-panel {
+    direction: horizontal;
+    spacing: 2;
+}
+
+/* Vertical panel with flex center */
+.centered-panel {
+    direction: vertical;
+    flex: center;
+}
+
+/* Panel with margin */
+.margined-panel {
+    margin: 2;
+}
+
+/* Panel with symmetric margin */
+.symmetric-margin-panel {
+    margin: 1 3;
+}
+
+/* Panel with all layout properties */
+.full-flex-panel {
+    direction: horizontal;
+    flex: space-between;
+    spacing: 1;
+    margin: 1 2 1 2;
+}


### PR DESCRIPTION
With the new flex layout, it became evident that we needed to support more properties in CSS, the full constraints: width, height, filling, flex, ...

This is what this PR is doing. The custom component demo, which shows a CSS editor, is the perfect playground for this. It shows that we can completely get rid of programmatic constraint setup, only use CSS classes, then update live.