### PR TITLE
fix: Use solid cursor for text input

### DIFF
--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
@@ -244,10 +244,9 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
             int cursorX = textArea.left() + relativeCol;
             int cursorY = textArea.top() + relativeRow;
 
-            // Set cursor style at cursor position
+            // Render cursor as styled cell in buffer (avoids terminal cursor blink issues)
             Cell currentCell = buffer.get(cursorX, cursorY);
             buffer.set(cursorX, cursorY, currentCell.patchStyle(cursorStyle));
-            frame.setCursorPosition(new Position(cursorX, cursorY));
         }
     }
 

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextInput.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextInput.java
@@ -155,11 +155,10 @@ public final class TextInput implements StatefulWidget<TextInputState> {
         int cursorX = inputArea.left() + (cursorPos - scrollOffset);
         int cursorY = inputArea.top();
 
-        // Set cursor style at cursor position
+        // Render cursor as styled cell in buffer (avoids terminal cursor blink issues)
         if (inputArea.contains(cursorX, cursorY)) {
             Cell currentCell = buffer.get(cursorX, cursorY);
             buffer.set(cursorX, cursorY, currentCell.patchStyle(cursorStyle));
-            frame.setCursorPosition(new Position(cursorX, cursorY));
         }
     }
 


### PR DESCRIPTION
This is because the default blinking behavior of some terminals make it extremely confusing with redraws: typically this resets the OS timeout for blinking, so if you type a bit fast, the cursor simply disappears then reappears after the tick timeout. To avoid this, we now render a fixed cursor, which is what other TUIs do usually anyway.
