### PR TITLE
fix: Fix wrapping of text in ListElement

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/layout/cassowary/Expression.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/cassowary/Expression.java
@@ -6,7 +6,7 @@ package dev.tamboui.layout.cassowary;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -119,7 +119,7 @@ public final class Expression {
      * @return a new expression representing the sum
      */
     public Expression plus(Expression other) {
-        Map<Variable, Double> coefficients = new HashMap<>();
+        Map<Variable, Double> coefficients = new LinkedHashMap<>();
 
         for (Term term : this.terms) {
             coefficients.merge(term.variable(), term.coefficient(), Double::sum);

--- a/tamboui-core/src/test/java/dev/tamboui/layout/LayoutTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/layout/LayoutTest.java
@@ -147,4 +147,33 @@ class LayoutTest {
         assertThat(rects.get(0).height()).isEqualTo(33);
         assertThat(rects.get(1).height()).isEqualTo(66);
     }
+
+    @Test
+    @DisplayName("Horizontal layout with 4 fill constraints does not exceed bounds")
+    void fourFillConstraintsDoNotExceedBounds() {
+        // Simulates Row in Panel: inner area (1, 1, 18, 1), 4 children with fill()
+        Rect area = new Rect(1, 1, 18, 1);
+        Layout layout = Layout.horizontal()
+            .constraints(
+                Constraint.fill(),
+                Constraint.fill(),
+                Constraint.fill(),
+                Constraint.fill()
+            );
+
+        List<Rect> rects = layout.split(area);
+
+        assertThat(rects).hasSize(4);
+
+        // Total width should equal input width (18)
+        int totalWidth = rects.stream().mapToInt(Rect::width).sum();
+        assertThat(totalWidth).as("total width").isEqualTo(area.width());
+
+        // All rects should be within the input area bounds
+        for (int i = 0; i < rects.size(); i++) {
+            Rect rect = rects.get(i);
+            assertThat(rect.left()).as("rect[" + i + "] left").isGreaterThanOrEqualTo(area.left());
+            assertThat(rect.right()).as("rect[" + i + "] right").isLessThanOrEqualTo(area.right());
+        }
+    }
 }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/Element.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/Element.java
@@ -63,6 +63,23 @@ public interface Element {
     }
 
     /**
+     * Returns the preferred height of this element given an available width and render context.
+     * <p>
+     * This is useful for elements that may wrap content (like text) where the
+     * height depends on the available width. The render context allows CSS-aware
+     * height calculation where properties like {@code text-overflow} may be set via CSS.
+     * <p>
+     * When context is null, implementations should use programmatic property values only.
+     *
+     * @param availableWidth the available width in cells
+     * @param context the render context for CSS resolution, may be null
+     * @return the preferred height given the available width
+     */
+    default int preferredHeight(int availableWidth, RenderContext context) {
+        return preferredHeight();
+    }
+
+    /**
      * Returns whether this element can receive focus.
      *
      * @return true if focusable, false otherwise

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -103,6 +103,25 @@ public final class Column extends ContainerElement<Column> {
     }
 
     @Override
+    public int preferredHeight(int availableWidth, RenderContext context) {
+        if (children.isEmpty() || availableWidth <= 0) {
+            return 0;
+        }
+
+        // Calculate effective spacing
+        int effectiveSpacing = this.spacing != null ? this.spacing : 0;
+        int totalSpacing = effectiveSpacing * Math.max(0, children.size() - 1);
+
+        // Sum heights of all children (Column is vertical, so all children get full width)
+        int totalHeight = 0;
+        for (Element child : children) {
+            totalHeight += child.preferredHeight(availableWidth, context);
+        }
+
+        return totalHeight + totalSpacing;
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (children.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -302,6 +302,53 @@ public final class Panel extends ContainerElement<Panel> {
         return layoutConstraint;
     }
 
+    @Override
+    public int preferredHeight(int availableWidth, RenderContext context) {
+        if (availableWidth <= 0) {
+            return 2; // Just borders
+        }
+
+        // Border overhead: 2 rows for top and bottom
+        int height = 2;
+
+        // Padding overhead
+        if (padding != null) {
+            height += padding.verticalTotal();
+        }
+
+        // Content width after borders and padding
+        int paddingHorizontal = padding != null ? padding.horizontalTotal() : 0;
+        int contentWidth = Math.max(1, availableWidth - 2 - paddingHorizontal);
+
+        if (children.isEmpty()) {
+            return height;
+        }
+
+        // Determine layout direction (default vertical)
+        Direction effectiveDirection = this.direction != null ? this.direction : Direction.VERTICAL;
+        int effectiveSpacing = this.spacing != null ? this.spacing : 0;
+
+        if (effectiveDirection == Direction.VERTICAL) {
+            // Sum of children heights + spacing
+            int totalSpacing = effectiveSpacing * Math.max(0, children.size() - 1);
+            for (Element child : children) {
+                height += child.preferredHeight(contentWidth, context);
+            }
+            height += totalSpacing;
+        } else {
+            // Horizontal: max height of children with equal width distribution
+            int totalSpacing = effectiveSpacing * Math.max(0, children.size() - 1);
+            int childWidth = Math.max(1, (contentWidth - totalSpacing) / children.size());
+            int maxChildHeight = 1;
+            for (Element child : children) {
+                maxChildHeight = Math.max(maxChildHeight, child.preferredHeight(childWidth, context));
+            }
+            height += maxChildHeight;
+        }
+
+        return height;
+    }
+
     /**
      * Computes the total height required to fit the panel's content.
      *

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
@@ -103,6 +103,27 @@ public final class Row extends ContainerElement<Row> {
     }
 
     @Override
+    public int preferredHeight(int availableWidth, RenderContext context) {
+        if (children.isEmpty() || availableWidth <= 0) {
+            return 1;
+        }
+
+        // For a row, calculate max height of children
+        // Give each child an equal share of width as a reasonable approximation
+        int effectiveSpacing = this.spacing != null ? this.spacing : 0;
+        int totalSpacing = effectiveSpacing * Math.max(0, children.size() - 1);
+        int contentWidth = Math.max(1, availableWidth - totalSpacing);
+        int childWidth = Math.max(1, contentWidth / children.size());
+
+        int maxHeight = 1;
+        for (Element child : children) {
+            maxHeight = Math.max(maxHeight, child.preferredHeight(childWidth, context));
+        }
+
+        return maxHeight;
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (children.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LayoutElementsTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LayoutElementsTest.java
@@ -4,12 +4,16 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
-import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.DefaultRenderContext;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.widgets.text.Overflow;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -309,6 +313,116 @@ class LayoutElementsTest {
     }
 
     @Nested
+    @DisplayName("Width-aware preferred height")
+    class PreferredHeightWithWidthTests {
+
+        @Test
+        @DisplayName("Row.preferredHeight(width) returns max child height")
+        void rowMaxChildHeight() {
+            Row r = row(
+                text("Short"),
+                text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER)
+            );
+            // At width 20, each child gets 10 chars (20/2)
+            // "12345678901234567890" = 20 chars at width 10 = 2 lines
+            assertThat(r.preferredHeight(20, null)).isEqualTo(2);
+
+            // At width 10, each child gets 5 chars (10/2)
+            // "12345678901234567890" = 20 chars at width 5 = 4 lines
+            assertThat(r.preferredHeight(10, null)).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("Row.preferredHeight(width) accounts for spacing")
+        void rowWithSpacing() {
+            Row r = row(
+                text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER),
+                text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER)
+            ).spacing(2);
+            // Width 22: 2 spacing + 20 content = 10 per child, each wraps to 2 lines
+            assertThat(r.preferredHeight(22, null)).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("Column.preferredHeight(width) returns sum of child heights")
+        void columnSumChildHeights() {
+            Column c = column(
+                text("Short"),
+                text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER)
+            );
+            // At width 20, first child = 1, second child = 1 (no wrapping)
+            assertThat(c.preferredHeight(20, null)).isEqualTo(2);
+
+            // At width 10, first child = 1, second child = 2 (wraps)
+            assertThat(c.preferredHeight(10, null)).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("Column.preferredHeight(width) accounts for spacing")
+        void columnWithSpacing() {
+            Column c = column(
+                text("A"),
+                text("B"),
+                text("C")
+            ).spacing(1);
+            // 3 children + 2 spacing = 5
+            assertThat(c.preferredHeight(20, null)).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("Panel.preferredHeight(width) includes borders")
+        void panelIncludesBorders() {
+            Panel p = panel(text("Content"));
+            // 2 for borders + 1 for content
+            assertThat(p.preferredHeight(20, null)).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("Panel.preferredHeight(width) includes padding")
+        void panelIncludesPadding() {
+            Panel p = panel(text("Content")).padding(1);
+            // 2 for borders + 2 for padding + 1 for content
+            assertThat(p.preferredHeight(20, null)).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("Panel.preferredHeight(width) calculates wrapped content height")
+        void panelWithWrappedContent() {
+            Panel p = panel(
+                text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER)
+            );
+            // At width 22: 2 borders, content width = 20, text fits in 1 line
+            assertThat(p.preferredHeight(22, null)).isEqualTo(3);
+
+            // At width 12: 2 borders, content width = 10, text wraps to 2 lines
+            assertThat(p.preferredHeight(12, null)).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("Nested row in column calculates height correctly")
+        void nestedRowInColumn() {
+            Column c = column(
+                text("Header"),
+                row(
+                    text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER),
+                    text("Short")
+                )
+            );
+            // At width 20: header = 1, row max = 1 (20 chars / 2 = 10 per child, wraps to 2)
+            // Actually: 20 chars at width 10 = 2 lines
+            assertThat(c.preferredHeight(20, null)).isEqualTo(3); // 1 + 2
+        }
+
+        @Test
+        @DisplayName("Empty containers return sensible defaults")
+        void emptyContainers() {
+            assertThat(row().preferredHeight(20, null)).isEqualTo(1);
+            assertThat(column().preferredHeight(20, null)).isEqualTo(0);
+            assertThat(panel().preferredHeight(20, null)).isEqualTo(2); // Just borders
+        }
+    }
+
+    @Nested
     @DisplayName("Nested layout tests")
     class NestedLayoutTests {
 
@@ -362,6 +476,210 @@ class LayoutElementsTest {
 
             // Should render without error
             assertThat(buffer).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Row with many text elements clips each to its area")
+        void rowWithManyTextElementsClips() {
+            // Simulate the stats row: 10 text elements in a 40-cell wide row
+            // Each element should get ~4 cells and be clipped
+            Rect area = new Rect(0, 0, 40, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            row(
+                text("A 4"), text("passed"),
+                text("B 3"), text("failed"),
+                text("C 0"), text("skipped"),
+                text("D 0"), text("running"),
+                text("E 0"), text("pending")
+            ).render(frame, area, RenderContext.empty());
+
+            // Check that text doesn't extend beyond the row's area
+            // The last cell (x=39) should be within bounds
+            // If overflow occurred, we'd see content from later elements bleeding over
+
+            // Print buffer for debugging
+            StringBuilder row0 = new StringBuilder();
+            for (int x = 0; x < 40; x++) {
+                row0.append(buffer.get(x, 0).symbol());
+            }
+            System.out.println("Row content: [" + row0 + "]");
+
+            // Each element should be clipped to ~4 cells
+            // With 10 elements in 40 cells, each gets 4 cells
+            // "passed" (6 chars) should be clipped to "pass"
+            // Verify no text appears outside bounds
+            assertThat(buffer.get(39, 0).symbol()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Row text elements are clipped to assigned area - not overflow")
+        void rowTextElementsDoNotOverflow() {
+            // A narrower test case: 2 text elements in 10-cell row
+            // Each should get 5 cells
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            row(
+                text("AAAAAAAAAA"), // 10 chars, should be clipped to 5
+                text("BBBBBBBBBB")  // 10 chars, should be clipped to 5
+            ).render(frame, area, RenderContext.empty());
+
+            // Print buffer for debugging
+            StringBuilder row0 = new StringBuilder();
+            for (int x = 0; x < 10; x++) {
+                row0.append(buffer.get(x, 0).symbol());
+            }
+            System.out.println("Row content: [" + row0 + "]");
+
+            // First 5 chars should be "AAAAA"
+            // Next 5 chars should be "BBBBB"
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+            assertThat(buffer.get(4, 0).symbol()).isEqualTo("A");
+            assertThat(buffer.get(5, 0).symbol()).isEqualTo("B");
+            assertThat(buffer.get(9, 0).symbol()).isEqualTo("B");
+        }
+
+        @Test
+        @DisplayName("Row with flex:start still clips text elements")
+        void rowWithFlexStartClipsText() {
+            // Test with flex(START) like the user's CSS
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            row(
+                text("AAAAAAAAAA"), // 10 chars
+                text("BBBBBBBBBB")  // 10 chars
+            ).flex(dev.tamboui.layout.Flex.START)
+             .render(frame, area, RenderContext.empty());
+
+            // Print buffer for debugging
+            StringBuilder row0 = new StringBuilder();
+            for (int x = 0; x < 10; x++) {
+                row0.append(buffer.get(x, 0).symbol());
+            }
+            System.out.println("Row with flex:start content: [" + row0 + "]");
+
+            // With flex:start, elements should still be clipped
+            // Each gets 5 cells, remaining space goes at end
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+            assertThat(buffer.get(5, 0).symbol()).isEqualTo("B");
+        }
+
+        @Test
+        @DisplayName("Panel with row inside clips correctly")
+        void panelWithRowClipsCorrectly() {
+            // Test the full structure: Panel > Column > Row > TextElements
+            Rect area = new Rect(0, 0, 20, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            panel("Test",
+                column(
+                    row(
+                        text("AAAAAAAAAA"),
+                        text("BBBBBBBBBB")
+                    )
+                )
+            ).render(frame, area, RenderContext.empty());
+
+            // Print row 1 (inside the panel, after border)
+            StringBuilder row1 = new StringBuilder();
+            for (int x = 0; x < 20; x++) {
+                row1.append(buffer.get(x, 1).symbol());
+            }
+            System.out.println("Panel row 1: [" + row1 + "]");
+
+            // The row should be inside the panel (border at x=0, x=19)
+            // Inner width = 18, so each text gets 9 chars
+            // Content should be clipped and not overflow the panel border
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo("│"); // left border
+            assertThat(buffer.get(19, 1).symbol()).isEqualTo("│"); // right border
+        }
+
+        @Test
+        @DisplayName("Stats row with CSS does not overflow panel - reproduces user issue")
+        void statsRowWithCssDoesNotOverflowPanel() {
+            // Reproduce the user's issue: Panel > Column > Row with many text elements
+            // CSS has text-overflow: wrap-character on .stats-row
+            // Text should NOT overflow the panel borders
+
+            StyleEngine styleEngine = StyleEngine.create();
+            styleEngine.addStylesheet(
+                ".stats-row { text-overflow: wrap-character; height: 1; flex: start; }\n" +
+                ".success { color: green; }\n" +
+                ".error { color: red; }\n" +
+                ".warning { color: yellow; }\n" +
+                ".info { color: cyan; }\n" +
+                ".dim { color: gray; }"
+            );
+
+            DefaultRenderContext context = DefaultRenderContext.createEmpty();
+            context.setStyleEngine(styleEngine);
+
+            // Panel width 50, simulating user's Tests panel
+            Rect area = new Rect(0, 0, 50, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // Create structure matching user's code
+            panel("Tests",
+                column(
+                    row(
+                        text("Header")
+                    ),
+                    row(
+                        text("+ 4").addClass("success"), text("passed"),
+                        text("x 3").addClass("error"), text("failed"),
+                        text("> 0").addClass("warning"), text("skipped"),
+                        text("~ 0").addClass("info"), text("running"),
+                        text("? 0").addClass("dim"), text("pending")
+                    ).addClass("stats-row")
+                )
+            ).render(frame, area, context);
+
+            // The panel borders must be intact - text must NOT overflow
+            // Row 0: top border (┌Tests...┐)
+            // Row 1: Header row with borders
+            // Row 2: Empty row due to column expansion
+            // Row 3: Stats row - THIS IS WHERE THE BUG IS (right border missing)
+            // Row 4: bottom border (└...┘)
+            BufferAssertions.assertThat(buffer)
+                .hasSymbolAt(0, 1, "│")   // left border row 1
+                .hasSymbolAt(49, 1, "│")  // right border row 1
+                .hasSymbolAt(0, 2, "│")   // left border row 2
+                .hasSymbolAt(49, 2, "│")  // right border row 2
+                .hasSymbolAt(0, 3, "│")   // left border row 3 (stats row)
+                .hasSymbolAt(49, 3, "│"); // right border row 3 (stats row) - BUG: this fails!
+        }
+
+        @Test
+        @DisplayName("Simple row in panel does not overflow - minimal reproduction")
+        void simpleRowInPanelDoesNotOverflow() {
+            // Minimal test: Panel > Row with text that exceeds available width
+            // Without any CSS, just pure layout
+            Rect area = new Rect(0, 0, 20, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // Inner area should be 18 wide (20 - 2 borders)
+            // Row with 4 text elements, each ~4.5 chars
+            panel("T",
+                row(
+                    text("AAAA"),
+                    text("BBBB"),
+                    text("CCCC"),
+                    text("DDDD")
+                )
+            ).render(frame, area, RenderContext.empty());
+
+            // Right border must be intact at position 19
+            BufferAssertions.assertThat(buffer)
+                .hasSymbolAt(0, 1, "│")   // left border
+                .hasSymbolAt(19, 1, "│"); // right border - must NOT be overwritten
         }
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ListElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ListElementTest.java
@@ -9,7 +9,9 @@ import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.widgets.text.Overflow;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -161,5 +163,129 @@ class ListElementTest {
             .selected(0);
         element.selectNext(3);
         assertThat(element.selected()).isEqualTo(1);
+    }
+
+    @Nested
+    @DisplayName("Text wrapping in list items")
+    class TextWrappingTests {
+
+        @Test
+        @DisplayName("List with wrapping text items renders correctly")
+        void listWithWrappingTextItems() {
+            // Area: 20 wide, 10 tall
+            // With displayOnly (no highlight symbol), content width = 20
+            Rect area = new Rect(0, 0, 20, 10);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // "This is a longer item that should wrap to multiple lines" = 56 chars
+            // At width 20, wraps to 3 lines:
+            //   "This is a longer ite" (20)
+            //   "m that should wrap t" (20)
+            //   "o multiple lines" (16)
+            list()
+                .add(text("Short item"))
+                .add(text("This is a longer item that should wrap to multiple lines").overflow(Overflow.WRAP_CHARACTER))
+                .add(text("Another short"))
+                .displayOnly()
+                .render(frame, area, RenderContext.empty());
+
+            // Line 0: "Short item"
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("S");
+            assertThat(buffer.get(5, 0).symbol()).isEqualTo(" ");
+            assertThat(buffer.get(6, 0).symbol()).isEqualTo("i");
+
+            // Line 1: "This is a longer ite" (first line of wrapped text)
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo("T");
+            assertThat(buffer.get(19, 1).symbol()).isEqualTo("e");
+
+            // Line 2: "m that should wrap t" (second line of wrapped text)
+            assertThat(buffer.get(0, 2).symbol()).isEqualTo("m");
+
+            // Line 3: "o multiple lines" (third line of wrapped text)
+            assertThat(buffer.get(0, 3).symbol()).isEqualTo("o");
+
+            // Line 4: "Another short" (third item, after wrapped text)
+            // A=0, n=1, o=2, t=3, h=4, e=5, r=6, (space)=7, s=8
+            assertThat(buffer.get(0, 4).symbol()).isEqualTo("A");
+            assertThat(buffer.get(8, 4).symbol()).isEqualTo("s");
+        }
+
+        @Test
+        @DisplayName("List calculates correct total height for scrollbar with wrapped items")
+        void scrollbarHeightWithWrappedItems() {
+            Rect area = new Rect(0, 0, 10, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // With width 10 and scrollbar (width 9 for content), "12345678901234567890" wraps to 3 lines
+            list()
+                .add(text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER))
+                .add(text("Short"))
+                .displayOnly()
+                .scrollbar()
+                .render(frame, area, RenderContext.empty());
+
+            // Should render without errors - the scrollbar should account for wrapped height
+            assertThat(buffer).isNotNull();
+        }
+
+        @Test
+        @DisplayName("Mixed fixed-height and wrapped items render correctly")
+        void mixedHeightItems() {
+            Rect area = new Rect(0, 0, 15, 10);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            list()
+                .add(text("Fixed").length(1))  // Explicit 1-line constraint
+                .add(text("This text will wrap at width").overflow(Overflow.WRAP_CHARACTER))
+                .add(text("Also fixed").length(1))
+                .displayOnly()
+                .render(frame, area, RenderContext.empty());
+
+            // First item "Fixed" at line 0
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("F");
+
+            // Wrapped text starts at line 1
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo("T");
+        }
+
+        @Test
+        @DisplayName("Element.preferredHeight(width) is used for item height calculation")
+        void preferredHeightWithWidthIsUsed() {
+            // Create a custom element that returns different heights based on width
+            TextElement wrappingText = text("12345678901234567890").overflow(Overflow.WRAP_CHARACTER);
+
+            // At width 10, should be 2 lines
+            assertThat(wrappingText.preferredHeight(10, null)).isEqualTo(2);
+
+            // At width 20, should be 1 line
+            assertThat(wrappingText.preferredHeight(20, null)).isEqualTo(1);
+
+            // At width 5, should be 4 lines
+            assertThat(wrappingText.preferredHeight(5, null)).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("Auto-scroll to end works with wrapped items")
+        void autoScrollToEndWithWrappedItems() {
+            Rect area = new Rect(0, 0, 10, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // First item wraps to 3 lines, second is 1 line
+            // With viewport height 3, scrollToEnd should show the last item
+            list()
+                .add(text("12345678901234567890123456789").overflow(Overflow.WRAP_CHARACTER))
+                .add(text("Last"))
+                .displayOnly()
+                .scrollToEnd()
+                .render(frame, area, RenderContext.empty());
+
+            // "Last" should be visible somewhere in the viewport
+            // The exact position depends on scroll calculation
+            assertThat(buffer).isNotNull();
+        }
     }
 }

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
@@ -148,8 +148,6 @@ public final class Paragraph implements Widget {
         }
 
         switch (overflow) {
-            case CLIP:
-                return clipLines(lines, maxWidth);
             case WRAP_CHARACTER:
             case WRAP_WORD:
                 return wrapLines(lines, maxWidth);
@@ -159,8 +157,10 @@ public final class Paragraph implements Widget {
                 return truncateWithEllipsis(lines, maxWidth, EllipsisPosition.START);
             case ELLIPSIS_MIDDLE:
                 return truncateWithEllipsis(lines, maxWidth, EllipsisPosition.MIDDLE);
+            case CLIP:
             default:
-                return lines;
+                // Always clip as safety measure to prevent rendering outside bounds
+                return clipLines(lines, maxWidth);
         }
     }
 


### PR DESCRIPTION
Technically speaking, this commit does a bit more, since there was a more general problem. I noticed that when adding a text() element into a ListElement, then the overflow policy wasn't respected.

This commit fixes it, making sure that all containers provide their expected height.

(another issue found implementing a real app ;))