### PR TITLE
feat: Graceful error management

### DIFF
--- a/demos/error-handling-demo/build.gradle.kts
+++ b/demos/error-handling-demo/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Demo showcasing error handling and fault-tolerant rendering"
+
+dependencies {
+    implementation(projects.tambouiToolkit)
+    runtimeOnly(projects.tambouiJline)
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.errorhandling.ErrorHandlingDemo")
+}
+
+demo {
+    displayName = "Error Handling Demo"
+    tags = setOf("toolkit", "error-handling", "fault-tolerant", "exceptions")
+}

--- a/demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java
+++ b/demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java
@@ -1,0 +1,125 @@
+//DEPS dev.tamboui:tamboui-toolkit:LATEST
+//DEPS dev.tamboui:tamboui-jline:LATEST
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.errorhandling;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.app.ToolkitRunner;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.event.KeyEvent;
+
+import java.time.Duration;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+/**
+ * Demo application showcasing TamboUI's error handling features.
+ * <p>
+ * This demo demonstrates fault-tolerant rendering where individual
+ * widgets that fail to render are replaced with error placeholders
+ * while the rest of the UI continues to work normally.
+ */
+public class ErrorHandlingDemo {
+
+    private static boolean faultyPanelEnabled = false;
+
+    public static void main(String[] args) throws Exception {
+        TuiConfig config = TuiConfig.builder()
+                .tickRate(Duration.ofMillis(100))
+                .build();
+
+        try (ToolkitRunner runner = ToolkitRunner.builder()
+                .config(config)
+                .faultTolerant(true)
+                .build()) {
+
+            runner.run(() -> column(
+                    // Header panel
+                    panel(() -> row(
+                            text(" Error Handling Demo ").bold().cyan(),
+                            spacer(),
+                            text(" [Fault-Tolerant Mode] ").green(),
+                            text(" [q] Quit ").dim()
+                    )).rounded().borderColor(Color.DARK_GRAY).length(3),
+
+                    // Main content - two panels side by side
+                    row(
+                            // Left panel - Info (always works)
+                            panel(() -> column(
+                                    text("About This Demo").bold().yellow(),
+                                    text(""),
+                                    text("In fault-tolerant mode, when a"),
+                                    text("widget fails to render, it is"),
+                                    text("replaced with an error placeholder."),
+                                    text(""),
+                                    text("The rest of the UI continues to"),
+                                    text("work normally."),
+                                    text(""),
+                                    text("Press [e] to toggle the faulty"),
+                                    text("panel on the right.")
+                            )).title("Info").rounded().borderColor(Color.BLUE).fill(),
+
+                            // Right panel - may be faulty
+                            faultyPanelEnabled
+                                    ? faultyPanel()
+                                    : panel(() -> column(
+                                            text("Normal Panel").bold().green(),
+                                            text(""),
+                                            text("This panel renders correctly."),
+                                            text(""),
+                                            text("Press [e] to make this panel"),
+                                            text("throw an exception during render.")
+                                    )).title("Controls").rounded().borderColor(Color.GREEN).fill()
+                    ).fill(),
+
+                    // Footer
+                    panel(() -> row(
+                            text(" Status: ").dim(),
+                            faultyPanelEnabled
+                                    ? text("Faulty panel ENABLED - see error placeholder above").red()
+                                    : text("Normal operation").green(),
+                            spacer(),
+                            text(" [e] Toggle faulty panel ").yellow()
+                    )).rounded().borderColor(Color.DARK_GRAY).length(3)
+            ).id("root").focusable().onKeyEvent(ErrorHandlingDemo::handleKeyEvent));
+        }
+    }
+
+    private static EventResult handleKeyEvent(KeyEvent event) {
+        char c = event.character();
+
+        if (c == 'e' || c == 'E') {
+            faultyPanelEnabled = !faultyPanelEnabled;
+            return EventResult.HANDLED;
+        }
+
+        return EventResult.UNHANDLED;
+    }
+
+    /**
+     * Creates a panel that throws an exception during rendering.
+     */
+    private static Element faultyPanel() {
+        return new Element() {
+            @Override
+            public void render(Frame frame, Rect area, RenderContext context) {
+                throw new NullPointerException(
+                        "Cannot render: data is null"
+                );
+            }
+
+            @Override
+            public String id() {
+                return "faulty-panel";
+            }
+        };
+    }
+}

--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -214,6 +214,70 @@ try (var tui = TuiRunner.create(config)) {
 
 Tick events fire at the configured rate - useful for animations, clocks, or any periodic updates.
 
+=== Error Handling
+
+When exceptions occur during rendering, TuiRunner catches them and displays an error screen with the stack trace.
+By default, errors are shown in-app with options to scroll and dismiss:
+
+[source,java]
+----
+// Default: errors display in UI, press 'q' to quit
+try (var tui = TuiRunner.create()) {
+    tui.run(handler, renderer);
+}
+----
+
+Configure error handling behavior via `TuiConfig`:
+
+[source,java]
+----
+import dev.tamboui.tui.error.RenderErrorHandlers;
+
+// Log errors to a file and quit immediately
+var config = TuiConfig.builder()
+    .errorHandler(RenderErrorHandlers.logAndQuit(new PrintStream("/tmp/tui-errors.log")))
+    .build();
+
+// Write error details to a file, then show in-app error display
+var config = TuiConfig.builder()
+    .errorHandler(RenderErrorHandlers.writeToFile(Path.of("/tmp/crash.log")))
+    .build();
+----
+
+Available error handlers:
+
+[cols="1,2",options="header"]
+|===
+|Handler |Behavior
+
+|`displayAndQuit()` (default)
+|Shows full-screen error display with scrollable stack trace, quit on 'q'
+
+|`logAndQuit(PrintStream)`
+|Logs error to stream, then exits immediately
+
+|`writeToFile(Path)`
+|Writes error to file, then shows in-app display
+
+|`suppress()`
+|Logs warning and continues (use with caution)
+|===
+
+Custom error handlers implement `RenderErrorHandler`:
+
+[source,java]
+----
+var config = TuiConfig.builder()
+    .errorHandler((error, context) -> {
+        // Log error details
+        context.errorOutput().println("Error: " + error.message());
+        error.cause().printStackTrace(context.errorOutput());
+        // Return the action to take
+        return ErrorAction.QUIT_IMMEDIATELY;
+    })
+    .build();
+----
+
 === Semantic Key Checks
 
 `KeyEvent` provides semantic methods that respect the configured bindings:
@@ -515,6 +579,32 @@ try (var runner = ToolkitRunner.create(config)) {
     runner.run(() -> panel("App", content()));
 }
 ----
+
+=== Fault-Tolerant Rendering
+
+When enabled, fault-tolerant mode catches exceptions from individual elements and displays error placeholders instead of crashing the entire application.
+The rest of the UI continues to render normally.
+
+[source,java]
+----
+try (var runner = ToolkitRunner.builder()
+        .faultTolerant(true)
+        .build()) {
+    runner.run(() -> render());
+}
+----
+
+With fault-tolerant mode:
+
+* If an element throws during `render()`, an error placeholder is displayed in its area
+* The error placeholder shows a red border with the exception type and message
+* Other elements continue to render normally
+* Useful for dashboards where one failing widget shouldn't break the entire UI
+
+Without fault-tolerant mode (default):
+
+* Exceptions propagate to `TuiRunner`, which displays a full-screen error
+* This is the safer default for most applications
 
 === Example: Todo List
 

--- a/docs/video/error-handling-demo.tape
+++ b/docs/video/error-handling-demo.tape
@@ -1,0 +1,26 @@
+Source shared_.tape
+
+# Setup
+Hide
+Type jbang error-handling-demo
+Enter
+Sleep 2
+Show
+
+# Recording
+Sleep 1
+# Toggle faulty widget on
+Type "f"
+Sleep 1.5
+# Toggle faulty widget off
+Type "f"
+Sleep 1.5
+# Toggle back on
+Type "f"
+Sleep 1
+# Trigger fatal error
+Type "e"
+Sleep 2
+# Quit
+Type "q"
+

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -4,6 +4,9 @@
       "script-ref": ".jbang/tambouiDemos.java",
       "description": "Run TamboUI demos interactively"
     },
+    "error-handling-demo": {
+      "script-ref": "demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java"
+    },
     "fakodex-demo": {
       "script-ref": "demos/fakodex-demo/src/main/java/dev/tamboui/demo/coding/CodingAssistantDemo.java"
     },

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/RenderContext.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/RenderContext.java
@@ -6,8 +6,10 @@ package dev.tamboui.toolkit.element;
 
 import dev.tamboui.css.Styleable;
 import dev.tamboui.css.cascade.CssStyleResolver;
+import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
 
 import java.util.Optional;
 
@@ -171,6 +173,21 @@ public interface RenderContext {
      */
     default Style childStyle(String childName, ChildPosition position, dev.tamboui.css.cascade.PseudoClassState state) {
         return currentStyle();  // fallback when no CSS engine
+    }
+
+    /**
+     * Renders a child element within the given area.
+     * <p>
+     * Container elements should use this method instead of calling
+     * {@code child.render()} directly. This allows the infrastructure
+     * to handle errors gracefully when fault-tolerant mode is enabled.
+     *
+     * @param child the child element to render
+     * @param frame the frame to render into
+     * @param area the area allocated for the child
+     */
+    default void renderChild(Element child, Frame frame, Rect area) {
+        child.render(frame, area, this);
     }
 
     /**

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -211,7 +211,7 @@ public final class Column extends ContainerElement<Column> {
             }
             Element child = children.get(childIndex);
             Rect childArea = areas.get(i);
-            child.render(frame, childArea, context);
+            context.renderChild(child, frame, childArea);
             childIndex++;
         }
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ErrorPlaceholder.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ErrorPlaceholder.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
+
+/**
+ * An element that displays an error placeholder when another element fails to render.
+ * <p>
+ * Used by fault-tolerant rendering to show a visual indication that an element
+ * encountered an error during rendering, while allowing the rest of the UI to continue.
+ *
+ * <pre>{@code
+ * // Typically created automatically during fault-tolerant rendering
+ * ErrorPlaceholder placeholder = ErrorPlaceholder.from(
+ *     new RuntimeException("Widget failed"),
+ *     "my-widget"
+ * );
+ * }</pre>
+ */
+public final class ErrorPlaceholder implements Element {
+
+    private final Throwable cause;
+    private final String elementId;
+
+    private ErrorPlaceholder(Throwable cause, String elementId) {
+        this.cause = cause;
+        this.elementId = elementId;
+    }
+
+    /**
+     * Creates an ErrorPlaceholder for the given exception.
+     *
+     * @param cause the exception that occurred
+     * @param elementId the ID of the element that failed, may be null
+     * @return a new ErrorPlaceholder
+     */
+    public static ErrorPlaceholder from(Throwable cause, String elementId) {
+        return new ErrorPlaceholder(cause, elementId);
+    }
+
+    /**
+     * Creates an ErrorPlaceholder for the given exception.
+     *
+     * @param cause the exception that occurred
+     * @return a new ErrorPlaceholder
+     */
+    public static ErrorPlaceholder from(Throwable cause) {
+        return from(cause, null);
+    }
+
+    @Override
+    public void render(Frame frame, Rect area, RenderContext context) {
+        if (area.isEmpty()) {
+            return;
+        }
+
+        Buffer buffer = frame.buffer();
+
+        // Build title with element ID if available
+        String title = elementId != null ? " Error: " + elementId + " " : " Error ";
+
+        // Truncate error message to fit
+        String message = cause.getClass().getSimpleName();
+        if (cause.getMessage() != null) {
+            String shortMessage = cause.getMessage();
+            if (shortMessage.length() > 30) {
+                shortMessage = shortMessage.substring(0, 27) + "...";
+            }
+            message = message + ": " + shortMessage;
+        }
+
+        // Create a minimal block with the error info
+        Block block = Block.builder()
+                .title(title)
+                .borders(Borders.ALL)
+                .borderType(BorderType.PLAIN)
+                .borderColor(Color.RED)
+                .build();
+
+        block.render(area, buffer);
+        Rect inner = block.inner(area);
+
+        if (!inner.isEmpty()) {
+            // Show error icon and message
+            Style errorStyle = Style.EMPTY.fg(Color.RED);
+            Line errorLine = Line.from(new Span("!", errorStyle.bold()), Span.raw(" " + message));
+
+            // Truncate if needed
+            if (inner.width() > 0) {
+                buffer.setLine(inner.left(), inner.top(), errorLine);
+            }
+        }
+    }
+
+    /**
+     * Returns the exception that caused this placeholder.
+     *
+     * @return the cause
+     */
+    public Throwable cause() {
+        return cause;
+    }
+
+    /**
+     * Returns the ID of the element that failed, if available.
+     *
+     * @return the element ID, or null
+     */
+    public String elementId() {
+        return elementId;
+    }
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -508,7 +508,7 @@ public final class Panel extends ContainerElement<Panel> {
         for (int i = 0; i < children.size() && i < areas.size(); i++) {
             Element child = children.get(i);
             Rect childArea = areas.get(i);
-            child.render(frame, childArea, context);
+            context.renderChild(child, frame, childArea);
         }
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
@@ -207,7 +207,7 @@ public final class Row extends ContainerElement<Row> {
             }
             Element child = children.get(childIndex);
             Rect childArea = areas.get(i);
-            child.render(frame, childArea, context);
+            context.renderChild(child, frame, childArea);
             childIndex++;
         }
     }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.element;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.event.EventRouter;
+import dev.tamboui.toolkit.focus.FocusManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests for fault-tolerant rendering in DefaultRenderContext.
+ */
+class FaultTolerantRenderingTest {
+
+    private DefaultRenderContext context;
+    private Frame frame;
+    private Rect area;
+
+    @BeforeEach
+    void setUp() {
+        FocusManager focusManager = new FocusManager();
+        context = new DefaultRenderContext(focusManager, new EventRouter(focusManager));
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 40, 10));
+        frame = Frame.forTesting(buffer);
+        area = new Rect(0, 0, 40, 10);
+    }
+
+    @Nested
+    @DisplayName("When fault-tolerant mode is disabled")
+    class FaultTolerantDisabled {
+
+        @BeforeEach
+        void setUp() {
+            context.setFaultTolerant(false);
+        }
+
+        @Test
+        @DisplayName("exceptions propagate from renderChild")
+        void exceptionsPropagateFromRenderChild() {
+            Element faultyElement = createFaultyElement();
+
+            assertThatThrownBy(() -> context.renderChild(faultyElement, frame, area))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessage("Intentional render failure");
+        }
+
+        @Test
+        @DisplayName("successful renders work normally")
+        void successfulRendersWorkNormally() {
+            AtomicBoolean rendered = new AtomicBoolean(false);
+            Element element = createSuccessfulElement(rendered);
+
+            context.renderChild(element, frame, area);
+
+            assertThat(rendered.get()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("When fault-tolerant mode is enabled")
+    class FaultTolerantEnabled {
+
+        @BeforeEach
+        void setUp() {
+            context.setFaultTolerant(true);
+        }
+
+        @Test
+        @DisplayName("exceptions are caught and don't propagate")
+        void exceptionsAreCaughtAndDontPropagate() {
+            Element faultyElement = createFaultyElement();
+
+            // Should not throw
+            assertThatCode(() -> context.renderChild(faultyElement, frame, area))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("error placeholder is rendered for faulty elements")
+        void errorPlaceholderIsRenderedForFaultyElements() {
+            Element faultyElement = createFaultyElement();
+
+            context.renderChild(faultyElement, frame, area);
+
+            // Check that something was rendered (error placeholder renders a border)
+            Buffer buffer = frame.buffer();
+            // The error placeholder should have rendered something
+            // Check for the "Error" title or border characters
+            String topLeft = buffer.get(0, 0).symbol();
+            assertThat(topLeft).isIn("┌", "╭", "+", "─");
+        }
+
+        @Test
+        @DisplayName("successful renders work normally")
+        void successfulRendersWorkNormally() {
+            AtomicBoolean rendered = new AtomicBoolean(false);
+            Element element = createSuccessfulElement(rendered);
+
+            context.renderChild(element, frame, area);
+
+            assertThat(rendered.get()).isTrue();
+        }
+
+        @Test
+        @DisplayName("isFaultTolerant returns true")
+        void isFaultTolerantReturnsTrue() {
+            assertThat(context.isFaultTolerant()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("Default behavior")
+    class DefaultBehavior {
+
+        @Test
+        @DisplayName("fault-tolerant is disabled by default")
+        void faultTolerantDisabledByDefault() {
+            FocusManager fm = new FocusManager();
+            DefaultRenderContext newContext = new DefaultRenderContext(fm, new EventRouter(fm));
+
+            assertThat(newContext.isFaultTolerant()).isFalse();
+        }
+    }
+
+    private Element createFaultyElement() {
+        return new Element() {
+            @Override
+            public void render(Frame frame, Rect area, RenderContext context) {
+                throw new RuntimeException("Intentional render failure");
+            }
+
+            @Override
+            public String id() {
+                return "faulty-element";
+            }
+        };
+    }
+
+    private Element createSuccessfulElement(AtomicBoolean rendered) {
+        return new Element() {
+            @Override
+            public void render(Frame frame, Rect area, RenderContext context) {
+                rendered.set(true);
+            }
+
+            @Override
+            public String id() {
+                return "successful-element";
+            }
+        };
+    }
+}

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests for ErrorPlaceholder element.
+ */
+class ErrorPlaceholderTest {
+
+    @Test
+    @DisplayName("from(Throwable, String) creates placeholder with element ID")
+    void fromWithElementId() {
+        RuntimeException cause = new RuntimeException("Test error");
+
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(cause, "my-widget");
+
+        assertThat(placeholder.cause()).isSameAs(cause);
+        assertThat(placeholder.elementId()).isEqualTo("my-widget");
+    }
+
+    @Test
+    @DisplayName("from(Throwable) creates placeholder without element ID")
+    void fromWithoutElementId() {
+        RuntimeException cause = new RuntimeException("Test error");
+
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(cause);
+
+        assertThat(placeholder.cause()).isSameAs(cause);
+        assertThat(placeholder.elementId()).isNull();
+    }
+
+    @Test
+    @DisplayName("render() draws error placeholder in the area")
+    void renderDrawsPlaceholder() {
+        Rect area = new Rect(0, 0, 30, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        RenderContext context = RenderContext.empty();
+
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(
+                new RuntimeException("Widget failed"),
+                "test-widget"
+        );
+
+        placeholder.render(frame, area, context);
+
+        // Check that border was rendered (top-left corner)
+        String topLeft = buffer.get(0, 0).symbol();
+        assertThat(topLeft).isIn("┌", "╭", "+");
+
+        // Check that something was written inside (error indicator)
+        String firstContent = buffer.get(1, 1).symbol();
+        assertThat(firstContent).isNotEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("render() handles empty area gracefully")
+    void renderHandlesEmptyArea() {
+        Rect emptyArea = new Rect(0, 0, 0, 0);
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 10));
+        Frame frame = Frame.forTesting(buffer);
+        RenderContext context = RenderContext.empty();
+
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(new RuntimeException("Error"));
+
+        // Should not throw
+        assertThatCode(() -> placeholder.render(frame, emptyArea, context))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("render() handles small area gracefully")
+    void renderHandlesSmallArea() {
+        Rect smallArea = new Rect(0, 0, 3, 3);
+        Buffer buffer = Buffer.empty(smallArea);
+        Frame frame = Frame.forTesting(buffer);
+        RenderContext context = RenderContext.empty();
+
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(new RuntimeException("Error"));
+
+        // Should not throw
+        assertThatCode(() -> placeholder.render(frame, smallArea, context))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("id() returns null (placeholder has no ID)")
+    void idReturnsNull() {
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(new RuntimeException("Error"));
+
+        assertThat(placeholder.id()).isNull();
+    }
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/error/ErrorAction.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/error/ErrorAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+/**
+ * Defines the actions that can be taken when a render error occurs.
+ * <p>
+ * When a rendering exception is caught, the error handler returns one of these
+ * actions to indicate how the TuiRunner should proceed.
+ *
+ * @see RenderErrorHandler
+ */
+public enum ErrorAction {
+
+    /**
+     * Display the error in the UI, wait for user dismissal, then quit.
+     * <p>
+     * This is the default behavior. The error display shows the exception type,
+     * message, and a scrollable stack trace. Users can press 'q' to quit or
+     * use arrow keys to scroll through the stack trace.
+     */
+    DISPLAY_AND_QUIT,
+
+    /**
+     * Clean up the terminal and quit immediately without displaying the error.
+     * <p>
+     * Use this when you want to log the error elsewhere (e.g., to a file) and
+     * exit cleanly without user interaction.
+     */
+    QUIT_IMMEDIATELY,
+
+    /**
+     * Suppress the error and attempt to continue rendering.
+     * <p>
+     * <strong>Warning:</strong> This is dangerous and should only be used by
+     * advanced users who understand the implications. Continuing after a render
+     * error may leave the UI in an inconsistent state.
+     */
+    SUPPRESS
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/error/ErrorContext.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/error/ErrorContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+import java.io.PrintStream;
+
+/**
+ * Context provided to error handlers when a render error occurs.
+ * <p>
+ * Provides access to error output streams and control over the runner.
+ */
+public interface ErrorContext {
+
+    /**
+     * Returns the output stream for logging fatal errors.
+     * <p>
+     * This stream is configured via {@code TuiConfig.errorOutput()} and defaults
+     * to {@code System.err} (captured at config creation time). When the TUI has
+     * captured standard streams, this provides a way to log errors to an external
+     * destination.
+     *
+     * @return the error output stream
+     */
+    PrintStream errorOutput();
+
+    /**
+     * Signals the runner to stop.
+     * <p>
+     * Call this when the error handler determines the application should quit.
+     * The runner will perform cleanup and exit the main loop.
+     */
+    void quit();
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/error/RenderError.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/error/RenderError.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Objects;
+
+/**
+ * Immutable container for render error information.
+ * <p>
+ * Captures the exception that occurred during rendering along with a timestamp
+ * and a pre-formatted stack trace for display.
+ */
+public final class RenderError {
+
+    private final Throwable cause;
+    private final long timestamp;
+    private final String formattedStackTrace;
+
+    private RenderError(Throwable cause, long timestamp, String formattedStackTrace) {
+        this.cause = cause;
+        this.timestamp = timestamp;
+        this.formattedStackTrace = formattedStackTrace;
+    }
+
+    /**
+     * Creates a RenderError from the given exception.
+     *
+     * @param cause the exception that occurred
+     * @return a new RenderError
+     * @throws NullPointerException if cause is null
+     */
+    public static RenderError from(Throwable cause) {
+        Objects.requireNonNull(cause, "cause");
+        return new RenderError(
+                cause,
+                System.currentTimeMillis(),
+                formatStackTrace(cause)
+        );
+    }
+
+    /**
+     * Returns the original exception that caused the error.
+     *
+     * @return the cause
+     */
+    public Throwable cause() {
+        return cause;
+    }
+
+    /**
+     * Returns the timestamp when the error was captured.
+     *
+     * @return the timestamp in milliseconds since epoch
+     */
+    public long timestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Returns a pre-formatted stack trace suitable for display.
+     *
+     * @return the formatted stack trace
+     */
+    public String formattedStackTrace() {
+        return formattedStackTrace;
+    }
+
+    /**
+     * Returns the error message from the cause, or the class name if no message.
+     *
+     * @return the error message
+     */
+    public String message() {
+        String msg = cause.getMessage();
+        return msg != null ? msg : cause.getClass().getName();
+    }
+
+    /**
+     * Returns the simple class name of the exception.
+     *
+     * @return the exception type name
+     */
+    public String exceptionType() {
+        return cause.getClass().getSimpleName();
+    }
+
+    /**
+     * Returns the full class name of the exception.
+     *
+     * @return the full exception class name
+     */
+    public String fullExceptionType() {
+        return cause.getClass().getName();
+    }
+
+    private static String formatStackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        t.printStackTrace(pw);
+        pw.flush();
+        return sw.toString();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RenderError[%s: %s at %d]",
+                exceptionType(), message(), timestamp);
+    }
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/error/RenderErrorHandler.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/error/RenderErrorHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+/**
+ * Handler for render errors.
+ * <p>
+ * Implementations decide what action to take when a rendering exception occurs.
+ * The handler receives the error details and a context for interacting with the
+ * runner, and returns an action indicating how to proceed.
+ *
+ * <pre>{@code
+ * // Custom handler that logs and quits immediately
+ * RenderErrorHandler handler = (error, context) -> {
+ *     error.cause().printStackTrace(context.errorOutput());
+ *     return ErrorAction.QUIT_IMMEDIATELY;
+ * };
+ * }</pre>
+ *
+ * @see RenderErrorHandlers
+ * @see ErrorAction
+ */
+@FunctionalInterface
+public interface RenderErrorHandler {
+
+    /**
+     * Handles a render error.
+     *
+     * @param error   the error information
+     * @param context the error context providing output streams and runner control
+     * @return the action to take
+     */
+    ErrorAction handle(RenderError error, ErrorContext context);
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/error/RenderErrorHandlers.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/error/RenderErrorHandlers.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+/**
+ * Factory methods for common error handler implementations.
+ * <p>
+ * Provides pre-built handlers for common error handling scenarios:
+ * <ul>
+ *   <li>{@link #displayAndQuit()} - Default: show error in UI, wait for dismissal</li>
+ *   <li>{@link #logAndQuit(PrintStream)} - Log to stream and quit immediately</li>
+ *   <li>{@link #writeToFile(Path)} - Write to file then display in UI</li>
+ * </ul>
+ */
+public final class RenderErrorHandlers {
+
+    private RenderErrorHandlers() {
+        // Factory class - no instantiation
+    }
+
+    /**
+     * Returns the default handler that displays the error in the UI.
+     * <p>
+     * The error display shows the exception type, message, and a scrollable
+     * stack trace. Users can press 'q' to quit or use arrow keys to scroll.
+     *
+     * @return the default display-and-quit handler
+     */
+    public static RenderErrorHandler displayAndQuit() {
+        return DisplayAndQuitHandler.INSTANCE;
+    }
+
+    /**
+     * Returns a handler that logs the error to a stream and quits immediately.
+     * <p>
+     * The full stack trace is printed to the provided stream before the runner
+     * quits. The terminal is cleaned up before printing.
+     *
+     * @param output the output stream to log to
+     * @return a log-and-quit handler
+     */
+    public static RenderErrorHandler logAndQuit(PrintStream output) {
+        return new LogAndQuitHandler(output);
+    }
+
+    /**
+     * Returns a handler that writes the error to a file, then displays in the UI.
+     * <p>
+     * This is useful when you want both a log file for debugging and immediate
+     * user feedback. If the file cannot be written, the handler falls back to
+     * just displaying in the UI.
+     *
+     * @param logFile the path to write the error log
+     * @return a write-to-file-then-display handler
+     */
+    public static RenderErrorHandler writeToFile(Path logFile) {
+        return new WriteToFileHandler(logFile);
+    }
+
+    /**
+     * Returns a handler that suppresses errors and continues.
+     * <p>
+     * <strong>Warning:</strong> This is dangerous and should only be used in
+     * specific scenarios where you understand the implications. Errors are
+     * logged to the error output but rendering continues.
+     *
+     * @return a suppress handler
+     */
+    public static RenderErrorHandler suppress() {
+        return SuppressHandler.INSTANCE;
+    }
+
+    // Default handler - displays in UI
+    private static final class DisplayAndQuitHandler implements RenderErrorHandler {
+        static final DisplayAndQuitHandler INSTANCE = new DisplayAndQuitHandler();
+
+        @Override
+        public ErrorAction handle(RenderError error, ErrorContext context) {
+            return ErrorAction.DISPLAY_AND_QUIT;
+        }
+    }
+
+    // Handler that logs to a stream and quits
+    private static final class LogAndQuitHandler implements RenderErrorHandler {
+        private final PrintStream output;
+
+        LogAndQuitHandler(PrintStream output) {
+            this.output = output;
+        }
+
+        @Override
+        public ErrorAction handle(RenderError error, ErrorContext context) {
+            output.println("=== TamboUI Render Error ===");
+            output.println("Type: " + error.fullExceptionType());
+            output.println("Message: " + error.message());
+            output.println("Timestamp: " + error.timestamp());
+            output.println();
+            output.println(error.formattedStackTrace());
+            output.flush();
+            return ErrorAction.QUIT_IMMEDIATELY;
+        }
+    }
+
+    // Handler that writes to file then displays
+    private static final class WriteToFileHandler implements RenderErrorHandler {
+        private final Path logFile;
+
+        WriteToFileHandler(Path logFile) {
+            this.logFile = logFile;
+        }
+
+        @Override
+        public ErrorAction handle(RenderError error, ErrorContext context) {
+            try {
+                PrintStream fileOut = new PrintStream(new FileOutputStream(logFile.toFile(), true));
+                try {
+                    fileOut.println("=== TamboUI Render Error ===");
+                    fileOut.println("Type: " + error.fullExceptionType());
+                    fileOut.println("Message: " + error.message());
+                    fileOut.println("Timestamp: " + error.timestamp());
+                    fileOut.println();
+                    fileOut.println(error.formattedStackTrace());
+                    fileOut.println();
+                    fileOut.flush();
+                } finally {
+                    fileOut.close();
+                }
+            } catch (IOException e) {
+                // Failed to write to file - log to error output
+                context.errorOutput().println("Warning: Could not write error to " + logFile + ": " + e.getMessage());
+            }
+            return ErrorAction.DISPLAY_AND_QUIT;
+        }
+    }
+
+    // Handler that suppresses errors (dangerous)
+    private static final class SuppressHandler implements RenderErrorHandler {
+        static final SuppressHandler INSTANCE = new SuppressHandler();
+
+        @Override
+        public ErrorAction handle(RenderError error, ErrorContext context) {
+            context.errorOutput().println("Warning: Suppressed render error: " + error.message());
+            return ErrorAction.SUPPRESS;
+        }
+    }
+}

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
@@ -4,9 +4,13 @@
  */
 package dev.tamboui.tui;
 
+import dev.tamboui.tui.error.ErrorAction;
+import dev.tamboui.tui.error.RenderErrorHandlers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.*;
@@ -111,5 +115,76 @@ class TuiConfigTest {
     void builderDefaultsShutdownHookToTrue() {
         TuiConfig config = TuiConfig.builder().build();
         assertThat(config.shutdownHook()).isTrue();
+    }
+
+    @Test
+    @DisplayName("defaults() sets errorHandler to displayAndQuit")
+    void defaultsSetErrorHandlerToDisplayAndQuit() {
+        TuiConfig config = TuiConfig.defaults();
+
+        assertThat(config.errorHandler()).isNotNull();
+        // Verify it's the display-and-quit handler by checking its behavior
+        ErrorAction action = config.errorHandler().handle(
+                dev.tamboui.tui.error.RenderError.from(new RuntimeException("test")),
+                new dev.tamboui.tui.error.ErrorContext() {
+                    @Override
+                    public PrintStream errorOutput() {
+                        return System.err;
+                    }
+
+                    @Override
+                    public void quit() {
+                    }
+                }
+        );
+        assertThat(action).isEqualTo(ErrorAction.DISPLAY_AND_QUIT);
+    }
+
+    @Test
+    @DisplayName("defaults() sets errorOutput to System.err")
+    void defaultsSetErrorOutputToSystemErr() {
+        TuiConfig config = TuiConfig.defaults();
+        assertThat(config.errorOutput()).isSameAs(System.err);
+    }
+
+    @Test
+    @DisplayName("builder allows custom errorHandler")
+    void builderAllowsCustomErrorHandler() {
+        TuiConfig config = TuiConfig.builder()
+                .errorHandler(RenderErrorHandlers.suppress())
+                .build();
+
+        assertThat(config.errorHandler()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("builder allows custom errorOutput")
+    void builderAllowsCustomErrorOutput() {
+        PrintStream customOutput = new PrintStream(new ByteArrayOutputStream());
+        TuiConfig config = TuiConfig.builder()
+                .errorOutput(customOutput)
+                .build();
+
+        assertThat(config.errorOutput()).isSameAs(customOutput);
+    }
+
+    @Test
+    @DisplayName("builder defaults errorHandler when null is passed")
+    void builderDefaultsErrorHandlerWhenNull() {
+        TuiConfig config = TuiConfig.builder()
+                .errorHandler(null)
+                .build();
+
+        assertThat(config.errorHandler()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("builder defaults errorOutput when null is passed")
+    void builderDefaultsErrorOutputWhenNull() {
+        TuiConfig config = TuiConfig.builder()
+                .errorOutput(null)
+                .build();
+
+        assertThat(config.errorOutput()).isSameAs(System.err);
     }
 }

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/error/RenderErrorHandlersTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/error/RenderErrorHandlersTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.*;
+
+class RenderErrorHandlersTest {
+
+    @Test
+    @DisplayName("displayAndQuit() returns DISPLAY_AND_QUIT action")
+    void displayAndQuitReturnsDisplayAction() {
+        RenderErrorHandler handler = RenderErrorHandlers.displayAndQuit();
+        RenderError error = RenderError.from(new RuntimeException("test"));
+        ErrorContext context = createMockContext();
+
+        ErrorAction action = handler.handle(error, context);
+
+        assertThat(action).isEqualTo(ErrorAction.DISPLAY_AND_QUIT);
+    }
+
+    @Test
+    @DisplayName("logAndQuit() logs to output and returns QUIT_IMMEDIATELY")
+    void logAndQuitLogsAndReturnsQuitAction() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(output);
+        RenderErrorHandler handler = RenderErrorHandlers.logAndQuit(printStream);
+        RenderError error = RenderError.from(new RuntimeException("Test error message"));
+        ErrorContext context = createMockContext();
+
+        ErrorAction action = handler.handle(error, context);
+
+        assertThat(action).isEqualTo(ErrorAction.QUIT_IMMEDIATELY);
+        String logged = output.toString();
+        assertThat(logged)
+                .contains("TamboUI Render Error")
+                .contains("RuntimeException")
+                .contains("Test error message");
+    }
+
+    @Test
+    @DisplayName("writeToFile() writes error to file and returns DISPLAY_AND_QUIT")
+    void writeToFileWritesAndReturnsDisplayAction(@TempDir Path tempDir) throws Exception {
+        Path logFile = tempDir.resolve("error.log");
+        RenderErrorHandler handler = RenderErrorHandlers.writeToFile(logFile);
+        RenderError error = RenderError.from(new RuntimeException("File test error"));
+        ErrorContext context = createMockContext();
+
+        ErrorAction action = handler.handle(error, context);
+
+        assertThat(action).isEqualTo(ErrorAction.DISPLAY_AND_QUIT);
+        assertThat(logFile).exists();
+        String content = new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8);
+        assertThat(content)
+                .contains("TamboUI Render Error")
+                .contains("RuntimeException")
+                .contains("File test error");
+    }
+
+    @Test
+    @DisplayName("writeToFile() falls back gracefully on write failure")
+    void writeToFileFallsBackOnFailure() {
+        // Use an invalid path that will fail
+        Path invalidPath = Paths.get("/nonexistent/directory/error.log");
+        RenderErrorHandler handler = RenderErrorHandlers.writeToFile(invalidPath);
+        RenderError error = RenderError.from(new RuntimeException("test"));
+        ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
+        ErrorContext context = createMockContext(new PrintStream(errorOutput));
+
+        ErrorAction action = handler.handle(error, context);
+
+        // Should still return DISPLAY_AND_QUIT even on file write failure
+        assertThat(action).isEqualTo(ErrorAction.DISPLAY_AND_QUIT);
+        assertThat(errorOutput.toString()).contains("Warning");
+    }
+
+    @Test
+    @DisplayName("suppress() returns SUPPRESS action")
+    void suppressReturnsSuppressAction() {
+        RenderErrorHandler handler = RenderErrorHandlers.suppress();
+        RenderError error = RenderError.from(new RuntimeException("test"));
+        ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
+        ErrorContext context = createMockContext(new PrintStream(errorOutput));
+
+        ErrorAction action = handler.handle(error, context);
+
+        assertThat(action).isEqualTo(ErrorAction.SUPPRESS);
+        assertThat(errorOutput.toString()).contains("Suppressed render error");
+    }
+
+    private ErrorContext createMockContext() {
+        return createMockContext(new PrintStream(new ByteArrayOutputStream()));
+    }
+
+    private ErrorContext createMockContext(PrintStream errorOutput) {
+        return new ErrorContext() {
+            @Override
+            public PrintStream errorOutput() {
+                return errorOutput;
+            }
+
+            @Override
+            public void quit() {
+                // No-op for testing
+            }
+        };
+    }
+}

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/error/RenderErrorTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/error/RenderErrorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.error;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.assertj.core.api.Assertions.*;
+
+class RenderErrorTest {
+
+    @Test
+    @DisplayName("from() creates RenderError with cause")
+    void fromCreateRenderErrorWithCause() {
+        RuntimeException cause = new RuntimeException("Test error");
+
+        RenderError error = RenderError.from(cause);
+
+        assertThat(error.cause()).isSameAs(cause);
+    }
+
+    @Test
+    @DisplayName("from() captures timestamp")
+    void fromCapturesTimestamp() {
+        long before = System.currentTimeMillis();
+        RenderError error = RenderError.from(new RuntimeException("Test"));
+        long after = System.currentTimeMillis();
+
+        assertThat(error.timestamp()).isBetween(before, after);
+    }
+
+    @Test
+    @DisplayName("from() formats stack trace")
+    void fromFormatsStackTrace() {
+        RuntimeException cause = new RuntimeException("Test error");
+
+        RenderError error = RenderError.from(cause);
+
+        assertThat(error.formattedStackTrace())
+                .contains("RuntimeException")
+                .contains("Test error")
+                .contains("at ");
+    }
+
+    @Test
+    @DisplayName("message() returns exception message")
+    void messageReturnsExceptionMessage() {
+        RenderError error = RenderError.from(new RuntimeException("Custom message"));
+
+        assertThat(error.message()).isEqualTo("Custom message");
+    }
+
+    @Test
+    @DisplayName("message() returns class name when no message")
+    void messageReturnsClassNameWhenNoMessage() {
+        RenderError error = RenderError.from(new NullPointerException());
+
+        assertThat(error.message()).isEqualTo("java.lang.NullPointerException");
+    }
+
+    @Test
+    @DisplayName("exceptionType() returns simple class name")
+    void exceptionTypeReturnsSimpleClassName() {
+        RenderError error = RenderError.from(new IllegalStateException("test"));
+
+        assertThat(error.exceptionType()).isEqualTo("IllegalStateException");
+    }
+
+    @Test
+    @DisplayName("fullExceptionType() returns full class name")
+    void fullExceptionTypeReturnsFullClassName() {
+        RenderError error = RenderError.from(new IllegalArgumentException("test"));
+
+        assertThat(error.fullExceptionType()).isEqualTo("java.lang.IllegalArgumentException");
+    }
+
+    @Test
+    @DisplayName("from() throws NullPointerException for null cause")
+    void fromThrowsForNullCause() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> RenderError.from(null));
+    }
+
+    @Test
+    @DisplayName("toString() includes type, message and timestamp")
+    void toStringIncludesRelevantInfo() {
+        RenderError error = RenderError.from(new RuntimeException("Test"));
+
+        assertThat(error.toString())
+                .contains("RenderError")
+                .contains("RuntimeException")
+                .contains("Test");
+    }
+}

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/error/ErrorDisplay.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/error/ErrorDisplay.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.widgets.error;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.widget.Widget;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A widget that displays error information with a stack trace.
+ * <p>
+ * Used to show exceptions that occur during rendering. The widget displays:
+ * <ul>
+ *   <li>Exception type in red</li>
+ *   <li>Error message</li>
+ *   <li>Scrollable stack trace</li>
+ *   <li>Footer with instructions</li>
+ * </ul>
+ *
+ * <pre>{@code
+ * ErrorDisplay display = ErrorDisplay.builder()
+ *     .error(exception)
+ *     .scroll(scrollOffset)
+ *     .title(" ERROR ")
+ *     .footer(" Press 'q' to quit, arrows to scroll ")
+ *     .build();
+ *
+ * display.render(area, buffer);
+ * }</pre>
+ */
+public final class ErrorDisplay implements Widget {
+
+    private final Throwable error;
+    private final String title;
+    private final String footer;
+    private final int scroll;
+    private final Color borderColor;
+
+    private ErrorDisplay(Builder builder) {
+        this.error = builder.error;
+        this.title = builder.title;
+        this.footer = builder.footer;
+        this.scroll = builder.scroll;
+        this.borderColor = builder.borderColor;
+    }
+
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Creates an ErrorDisplay for the given exception with default settings.
+     *
+     * @param error the exception to display
+     * @return a new ErrorDisplay
+     */
+    public static ErrorDisplay from(Throwable error) {
+        return builder().error(error).build();
+    }
+
+    @Override
+    public void render(Rect area, Buffer buffer) {
+        if (area.isEmpty() || error == null) {
+            return;
+        }
+
+        // Build content lines
+        List<Line> lines = buildContentLines();
+
+        // Create the block with border
+        Block block = Block.builder()
+                .title(title)
+                .titleBottom(footer)
+                .borders(Borders.ALL)
+                .borderType(BorderType.ROUNDED)
+                .borderColor(borderColor)
+                .build();
+
+        // Render the block
+        block.render(area, buffer);
+        Rect inner = block.inner(area);
+
+        if (inner.isEmpty()) {
+            return;
+        }
+
+        // Calculate visible lines based on scroll
+        int visibleHeight = inner.height();
+        int maxScroll = Math.max(0, lines.size() - visibleHeight);
+        int actualScroll = Math.min(scroll, maxScroll);
+
+        // Render visible lines
+        for (int i = 0; i < visibleHeight && (actualScroll + i) < lines.size(); i++) {
+            Line line = lines.get(actualScroll + i);
+            buffer.setLine(inner.left(), inner.top() + i, line);
+        }
+    }
+
+    private List<Line> buildContentLines() {
+        List<Line> lines = new ArrayList<Line>();
+
+        // Exception type
+        lines.add(Line.from(new Span(error.getClass().getName(), Style.EMPTY.fg(Color.RED).bold())));
+        lines.add(Line.from(Span.raw("")));
+
+        // Message
+        String message = error.getMessage();
+        if (message != null && !message.isEmpty()) {
+            lines.add(Line.from(new Span("Message: ", Style.EMPTY.bold()), Span.raw(message)));
+            lines.add(Line.from(Span.raw("")));
+        }
+
+        // Stack trace
+        lines.add(Line.from(new Span("Stack trace:", Style.EMPTY.bold())));
+
+        String stackTrace = formatStackTrace(error);
+        String[] stackLines = stackTrace.split("\n");
+        for (String stackLine : stackLines) {
+            lines.add(Line.from(Span.raw(stackLine)));
+        }
+
+        return lines;
+    }
+
+    private static String formatStackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        t.printStackTrace(pw);
+        pw.flush();
+        return sw.toString();
+    }
+
+    /**
+     * Returns the total number of content lines.
+     * <p>
+     * Useful for calculating scroll bounds.
+     *
+     * @return the number of lines
+     */
+    public int lineCount() {
+        return buildContentLines().size();
+    }
+
+    /**
+     * Builder for {@link ErrorDisplay}.
+     */
+    public static final class Builder {
+        private Throwable error;
+        private String title = " ERROR ";
+        private String footer = " Press 'q' to quit, arrows to scroll ";
+        private int scroll = 0;
+        private Color borderColor = Color.RED;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the error to display.
+         *
+         * @param error the exception
+         * @return this builder
+         */
+        public Builder error(Throwable error) {
+            this.error = error;
+            return this;
+        }
+
+        /**
+         * Sets the title shown at the top of the border.
+         *
+         * @param title the title
+         * @return this builder
+         */
+        public Builder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        /**
+         * Sets the footer shown at the bottom of the border.
+         *
+         * @param footer the footer
+         * @return this builder
+         */
+        public Builder footer(String footer) {
+            this.footer = footer;
+            return this;
+        }
+
+        /**
+         * Sets the scroll offset.
+         *
+         * @param scroll the number of lines to scroll
+         * @return this builder
+         */
+        public Builder scroll(int scroll) {
+            this.scroll = Math.max(0, scroll);
+            return this;
+        }
+
+        /**
+         * Sets the border color.
+         *
+         * @param color the border color
+         * @return this builder
+         */
+        public Builder borderColor(Color color) {
+            this.borderColor = color;
+            return this;
+        }
+
+        /**
+         * Builds the ErrorDisplay.
+         *
+         * @return a new ErrorDisplay
+         */
+        public ErrorDisplay build() {
+            return new ErrorDisplay(this);
+        }
+    }
+}


### PR DESCRIPTION
The rationale for this change is simple: at the moment, if, for some reason, an error happens during UI rendering (for example a widget throws an exception), the whole application crashes. This can be even more problematic in setups where the TUI needs to capture the standard output and error streams, to avoid UI trashing, because in that case, no exception would ever be shown to the user, with an application that could have its UI die without error.

To fix this, this PR introduces error management at the TuiRunner level. An error handler can be set, which allows different strategies, like displaying a standard error panel instead, logging to a file, etc.

On top of that, the Toolkit runner provides a failsafe mode for Element rendering, where a failing Element area can be replaced completely, allowing the _rest_ of the UI to work properly. To illustrate this, a demo has been added.