### PR TITLE
fix: Consistent CSS styling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,69 @@ class MyApp extends ToolkitApp {
 - keep each .tape short and focus. 
 - Try cover all demo features, but be aware they should not be too long as then the `.svg` renderings gets too big.
 
+## CSS-Compatible Elements
+
+When writing new Elements or modifying existing ones, follow these guidelines to ensure consistent CSS support:
+
+### The `resolveEffectiveStyle` Helper
+
+Use `StyledElement.resolveEffectiveStyle()` for sub-component styling with the priority order: **explicit > CSS > default**.
+
+```java
+// Simple case (no pseudo-class):
+Style effectiveCursorStyle = resolveEffectiveStyle(context, "cursor", cursorStyle, DEFAULT_CURSOR_STYLE);
+
+// With pseudo-class state (e.g., :selected):
+Style effectiveHighlightStyle = resolveEffectiveStyle(
+    context, "item", PseudoClassState.ofSelected(),
+    highlightStyle, DEFAULT_HIGHLIGHT_STYLE);
+```
+
+### Pattern for CSS-Compatible Fields
+
+1. **Make style fields nullable** (null = "use CSS or default"):
+   ```java
+   private Style cursorStyle;  // null, not Style.EMPTY
+   ```
+
+2. **Add default style constants**:
+   ```java
+   private static final Style DEFAULT_CURSOR_STYLE = Style.EMPTY.reversed();
+   private static final Style DEFAULT_PLACEHOLDER_STYLE = Style.EMPTY.dim();
+   ```
+
+3. **Use resolveEffectiveStyle in renderContent()**:
+   ```java
+   Style effectiveStyle = resolveEffectiveStyle(context, "child-name", explicitStyle, DEFAULT_STYLE);
+   ```
+
+### Documenting CSS Selectors
+
+Add a JavaDoc section to each Element class documenting its CSS child selectors:
+
+```java
+/**
+ * <h2>CSS Child Selectors</h2>
+ * <ul>
+ *   <li>{@code ElementName-cursor} - The cursor style (default: reversed)</li>
+ *   <li>{@code ElementName-placeholder} - The placeholder text style (default: dim)</li>
+ * </ul>
+ */
+```
+
+### Available CSS Child Selectors
+
+| Element | Child Selectors |
+|---------|-----------------|
+| TextInputElement | `-cursor`, `-placeholder` |
+| TextAreaElement | `-cursor`, `-placeholder`, `-line-number` |
+| GaugeElement | `-filled` |
+| LineGaugeElement | `-filled`, `-unfilled` |
+| ScrollbarElement | `-thumb`, `-track`, `-begin`, `-end` |
+| ListElement | `-item`, `-scrollbar-thumb`, `-scrollbar-track` |
+| TableElement | `-row`, `-header` |
+| TabsElement | `-tab`, `-divider` |
+
 ## PR Guidelines
 
 - Use `git add` for new files to include them in the commit

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GaugeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GaugeElement.java
@@ -26,12 +26,29 @@ import dev.tamboui.widgets.gauge.Gauge;
  *     .gaugeColor(Color.GREEN)
  *     .title("Progress")
  * }</pre>
+ *
+ * <h2>CSS Child Selectors</h2>
+ * <p>
+ * The following child selectors can be used to style sub-components:
+ * <ul>
+ *   <li>{@code GaugeElement-filled} - The filled portion of the gauge</li>
+ * </ul>
+ * <p>
+ * Example CSS:
+ * <pre>{@code
+ * GaugeElement-filled { color: green; }
+ * }</pre>
+ * <p>
+ * Note: Programmatic styles set via {@link #gaugeStyle(Style)} or {@link #gaugeColor(Color)}
+ * take precedence over CSS styles.
  */
 public final class GaugeElement extends StyledElement<GaugeElement> {
 
+    private static final Style DEFAULT_FILLED_STYLE = Style.EMPTY;
+
     private double ratio = 0.0;
     private String label;
-    private Style gaugeStyle = Style.EMPTY;
+    private Style gaugeStyle;
     private boolean useUnicode = true;
     private String title;
     private BorderType borderType;
@@ -128,11 +145,8 @@ public final class GaugeElement extends StyledElement<GaugeElement> {
 
         Style effectiveStyle = context.currentStyle();
 
-        // Use gaugeStyle if explicitly set, otherwise use the foreground color from CSS
-        Style effectiveGaugeStyle = gaugeStyle;
-        if (effectiveGaugeStyle.equals(Style.EMPTY) && effectiveStyle.fg().isPresent()) {
-            effectiveGaugeStyle = Style.EMPTY.fg(effectiveStyle.fg().get());
-        }
+        // Resolve filled style with priority: explicit > CSS > default
+        Style effectiveGaugeStyle = resolveEffectiveStyle(context, "filled", gaugeStyle, DEFAULT_FILLED_STYLE);
 
         Gauge.Builder builder = Gauge.builder()
             .ratio(ratio)

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/LineGaugeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/LineGaugeElement.java
@@ -21,13 +21,33 @@ import dev.tamboui.widgets.gauge.LineGauge;
  *     .label("Progress: ")
  *     .filledColor(Color.GREEN)
  * }</pre>
+ *
+ * <h2>CSS Child Selectors</h2>
+ * <p>
+ * The following child selectors can be used to style sub-components:
+ * <ul>
+ *   <li>{@code LineGaugeElement-filled} - The filled portion of the gauge</li>
+ *   <li>{@code LineGaugeElement-unfilled} - The unfilled portion of the gauge</li>
+ * </ul>
+ * <p>
+ * Example CSS:
+ * <pre>{@code
+ * LineGaugeElement-filled { color: green; }
+ * LineGaugeElement-unfilled { color: gray; }
+ * }</pre>
+ * <p>
+ * Note: Programmatic styles set via {@link #filledStyle(Style)} or {@link #unfilledStyle(Style)}
+ * take precedence over CSS styles.
  */
 public final class LineGaugeElement extends StyledElement<LineGaugeElement> {
 
+    private static final Style DEFAULT_FILLED_STYLE = Style.EMPTY;
+    private static final Style DEFAULT_UNFILLED_STYLE = Style.EMPTY;
+
     private double ratio = 0.0;
     private String label;
-    private Style filledStyle = Style.EMPTY;
-    private Style unfilledStyle = Style.EMPTY;
+    private Style filledStyle;
+    private Style unfilledStyle;
     private LineGauge.LineSet lineSet = LineGauge.NORMAL;
 
     public LineGaugeElement() {
@@ -127,11 +147,15 @@ public final class LineGaugeElement extends StyledElement<LineGaugeElement> {
             return;
         }
 
+        // Resolve styles with priority: explicit > CSS > default
+        Style effectiveFilledStyle = resolveEffectiveStyle(context, "filled", filledStyle, DEFAULT_FILLED_STYLE);
+        Style effectiveUnfilledStyle = resolveEffectiveStyle(context, "unfilled", unfilledStyle, DEFAULT_UNFILLED_STYLE);
+
         LineGauge.Builder builder = LineGauge.builder()
             .ratio(ratio)
             .style(context.currentStyle())
-            .filledStyle(filledStyle)
-            .unfilledStyle(unfilledStyle)
+            .filledStyle(effectiveFilledStyle)
+            .unfilledStyle(effectiveUnfilledStyle)
             .lineSet(lineSet);
 
         if (label != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ListElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ListElement.java
@@ -535,13 +535,9 @@ public final class ListElement<T> extends StyledElement<ListElement<T>> {
         this.lastViewportHeight = visibleHeight;
 
         // Resolve highlight style: explicit > CSS > default
-        Style effectiveHighlightStyle = highlightStyle;
-        if (effectiveHighlightStyle == null) {
-            Style cssStyle = context.childStyle("item", PseudoClassState.ofSelected());
-            effectiveHighlightStyle = cssStyle.equals(context.currentStyle())
-                ? DEFAULT_HIGHLIGHT_STYLE
-                : cssStyle;
-        }
+        Style effectiveHighlightStyle = resolveEffectiveStyle(
+            context, "item", PseudoClassState.ofSelected(),
+            highlightStyle, DEFAULT_HIGHLIGHT_STYLE);
 
         // Resolve highlight symbol
         String effectiveHighlightSymbol = highlightSymbol != null ? highlightSymbol : DEFAULT_HIGHLIGHT_SYMBOL;
@@ -688,32 +684,18 @@ public final class ListElement<T> extends StyledElement<ListElement<T>> {
                 .viewportContentLength(visibleHeight)
                 .position(scrollOffset);
 
-            // Resolve scrollbar styles
-            Style thumbStyle = null;
-            Style trackStyle = null;
-
-            Style cssThumbStyle = context.childStyle("scrollbar-thumb");
-            if (!cssThumbStyle.equals(context.currentStyle())) {
-                thumbStyle = cssThumbStyle;
-            }
-            if (scrollbarThumbColor != null) {
-                thumbStyle = Style.EMPTY.fg(scrollbarThumbColor);
-            }
-
-            Style cssTrackStyle = context.childStyle("scrollbar-track");
-            if (!cssTrackStyle.equals(context.currentStyle())) {
-                trackStyle = cssTrackStyle;
-            }
-            if (scrollbarTrackColor != null) {
-                trackStyle = Style.EMPTY.fg(scrollbarTrackColor);
-            }
+            // Resolve scrollbar styles: explicit > CSS > default
+            Style explicitThumbStyle = scrollbarThumbColor != null ? Style.EMPTY.fg(scrollbarThumbColor) : null;
+            Style explicitTrackStyle = scrollbarTrackColor != null ? Style.EMPTY.fg(scrollbarTrackColor) : null;
+            Style thumbStyle = resolveEffectiveStyle(context, "scrollbar-thumb", explicitThumbStyle, Style.EMPTY);
+            Style trackStyle = resolveEffectiveStyle(context, "scrollbar-track", explicitTrackStyle, Style.EMPTY);
 
             Scrollbar.Builder scrollbarBuilder = Scrollbar.builder()
                 .orientation(ScrollbarOrientation.VERTICAL_RIGHT);
-            if (thumbStyle != null) {
+            if (!thumbStyle.equals(Style.EMPTY)) {
                 scrollbarBuilder.thumbStyle(thumbStyle);
             }
-            if (trackStyle != null) {
+            if (!trackStyle.equals(Style.EMPTY)) {
                 scrollbarBuilder.trackStyle(trackStyle);
             }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollbarElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollbarElement.java
@@ -24,8 +24,33 @@ import dev.tamboui.widgets.scrollbar.ScrollbarState;
  *     .state(scrollbarState)
  *     .thumbColor(Color.YELLOW)
  * }</pre>
+ *
+ * <h2>CSS Child Selectors</h2>
+ * <p>
+ * The following child selectors can be used to style sub-components:
+ * <ul>
+ *   <li>{@code ScrollbarElement-thumb} - The thumb/handle of the scrollbar</li>
+ *   <li>{@code ScrollbarElement-track} - The track/background of the scrollbar</li>
+ *   <li>{@code ScrollbarElement-begin} - The begin marker (up/left arrow)</li>
+ *   <li>{@code ScrollbarElement-end} - The end marker (down/right arrow)</li>
+ * </ul>
+ * <p>
+ * Example CSS:
+ * <pre>{@code
+ * ScrollbarElement-thumb { color: yellow; }
+ * ScrollbarElement-track { color: gray; }
+ * ScrollbarElement-begin { color: white; }
+ * ScrollbarElement-end { color: white; }
+ * }</pre>
+ * <p>
+ * Note: Programmatic styles set via the corresponding setter methods take precedence over CSS styles.
  */
 public final class ScrollbarElement extends StyledElement<ScrollbarElement> {
+
+    private static final Style DEFAULT_THUMB_STYLE = Style.EMPTY;
+    private static final Style DEFAULT_TRACK_STYLE = Style.EMPTY;
+    private static final Style DEFAULT_BEGIN_STYLE = Style.EMPTY;
+    private static final Style DEFAULT_END_STYLE = Style.EMPTY;
 
     private ScrollbarOrientation orientation = ScrollbarOrientation.VERTICAL_RIGHT;
     private ScrollbarState state;
@@ -214,6 +239,12 @@ public final class ScrollbarElement extends StyledElement<ScrollbarElement> {
             return;
         }
 
+        // Resolve styles with priority: explicit > CSS > default
+        Style effectiveThumbStyle = resolveEffectiveStyle(context, "thumb", thumbStyle, DEFAULT_THUMB_STYLE);
+        Style effectiveTrackStyle = resolveEffectiveStyle(context, "track", trackStyle, DEFAULT_TRACK_STYLE);
+        Style effectiveBeginStyle = resolveEffectiveStyle(context, "begin", beginStyle, DEFAULT_BEGIN_STYLE);
+        Style effectiveEndStyle = resolveEffectiveStyle(context, "end", endStyle, DEFAULT_END_STYLE);
+
         Scrollbar.Builder builder = Scrollbar.builder()
             .orientation(orientation)
             .style(context.currentStyle());
@@ -238,20 +269,21 @@ public final class ScrollbarElement extends StyledElement<ScrollbarElement> {
             builder.endSymbol(endSymbol);
         }
 
-        if (thumbStyle != null) {
-            builder.thumbStyle(thumbStyle);
+        // Apply resolved styles (only if they have styling, not just EMPTY)
+        if (!effectiveThumbStyle.equals(Style.EMPTY)) {
+            builder.thumbStyle(effectiveThumbStyle);
         }
 
-        if (trackStyle != null) {
-            builder.trackStyle(trackStyle);
+        if (!effectiveTrackStyle.equals(Style.EMPTY)) {
+            builder.trackStyle(effectiveTrackStyle);
         }
 
-        if (beginStyle != null) {
-            builder.beginStyle(beginStyle);
+        if (!effectiveBeginStyle.equals(Style.EMPTY)) {
+            builder.beginStyle(effectiveBeginStyle);
         }
 
-        if (endStyle != null) {
-            builder.endStyle(endStyle);
+        if (!effectiveEndStyle.equals(Style.EMPTY)) {
+            builder.endStyle(effectiveEndStyle);
         }
 
         Scrollbar widget = builder.build();

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TableElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TableElement.java
@@ -216,13 +216,9 @@ public final class TableElement extends StyledElement<TableElement> {
         }
 
         // Resolve highlight style: explicit > CSS > default
-        Style effectiveHighlightStyle = highlightStyle;
-        if (effectiveHighlightStyle == null) {
-            Style cssStyle = context.childStyle("row", PseudoClassState.ofSelected());
-            effectiveHighlightStyle = cssStyle.equals(context.currentStyle())
-                ? DEFAULT_HIGHLIGHT_STYLE
-                : cssStyle;
-        }
+        Style effectiveHighlightStyle = resolveEffectiveStyle(
+            context, "row", PseudoClassState.ofSelected(),
+            highlightStyle, DEFAULT_HIGHLIGHT_STYLE);
 
         // Resolve highlight symbol: explicit > default
         String effectiveHighlightSymbol = highlightSymbol != null ? highlightSymbol : DEFAULT_HIGHLIGHT_SYMBOL;
@@ -230,12 +226,9 @@ public final class TableElement extends StyledElement<TableElement> {
         // Resolve header style from CSS
         Row effectiveHeader = header;
         if (effectiveHeader != null && effectiveHeader.style().equals(Style.EMPTY)) {
-            Style headerStyle = context.childStyle("header");
-            if (!headerStyle.equals(context.currentStyle())) {
-                effectiveHeader = effectiveHeader.style(headerStyle);
-            } else {
-                effectiveHeader = effectiveHeader.style(DEFAULT_HEADER_STYLE);
-            }
+            // Header row has no explicit style, resolve from CSS or default
+            Style headerStyle = resolveEffectiveStyle(context, "header", null, DEFAULT_HEADER_STYLE);
+            effectiveHeader = effectiveHeader.style(headerStyle);
         }
 
         Table.Builder builder = Table.builder()

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TabsElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TabsElement.java
@@ -171,13 +171,9 @@ public final class TabsElement extends StyledElement<TabsElement> {
             : context.currentStyle().patch(baseTabStyle);
 
         // Resolve highlight style: explicit > CSS > default
-        Style effectiveHighlightStyle = highlightStyle;
-        if (effectiveHighlightStyle == null) {
-            Style cssStyle = context.childStyle("tab", PseudoClassState.ofSelected());
-            effectiveHighlightStyle = cssStyle.equals(context.currentStyle())
-                ? DEFAULT_HIGHLIGHT_STYLE
-                : cssStyle;
-        }
+        Style effectiveHighlightStyle = resolveEffectiveStyle(
+            context, "tab", PseudoClassState.ofSelected(),
+            highlightStyle, DEFAULT_HIGHLIGHT_STYLE);
 
         // Resolve divider style from CSS
         Style dividerCssStyle = context.childStyle("divider");

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -30,20 +30,42 @@ import dev.tamboui.widgets.input.TextAreaState;
  *     .showLineNumbers()
  *     .rounded()
  * }</pre>
+ *
+ * <h2>CSS Child Selectors</h2>
+ * <p>
+ * The following child selectors can be used to style sub-components:
+ * <ul>
+ *   <li>{@code TextAreaElement-cursor} - The cursor style (default: reversed)</li>
+ *   <li>{@code TextAreaElement-placeholder} - The placeholder text style (default: dim)</li>
+ *   <li>{@code TextAreaElement-line-number} - The line number style (default: dim)</li>
+ * </ul>
+ * <p>
+ * Example CSS:
+ * <pre>{@code
+ * TextAreaElement-cursor { text-style: reversed; background: cyan; }
+ * TextAreaElement-placeholder { color: gray; text-style: italic; }
+ * TextAreaElement-line-number { color: #666666; }
+ * }</pre>
+ * <p>
+ * Note: Programmatic styles set via the corresponding setter methods take precedence over CSS styles.
  */
 public final class TextAreaElement extends StyledElement<TextAreaElement> {
 
+    private static final Style DEFAULT_CURSOR_STYLE = Style.EMPTY.reversed();
+    private static final Style DEFAULT_PLACEHOLDER_STYLE = Style.EMPTY.dim();
+    private static final Style DEFAULT_LINE_NUMBER_STYLE = Style.EMPTY.dim();
+
     private TextAreaState state;
-    private Style cursorStyle = Style.EMPTY.reversed();
+    private Style cursorStyle;
     private String placeholder = "";
-    private Style placeholderStyle = Style.EMPTY.dim();
+    private Style placeholderStyle;
     private String title;
     private BorderType borderType;
     private Color borderColor;
     private Color focusedBorderColor;
     private boolean showCursor = true;
     private boolean showLineNumbers = false;
-    private Style lineNumberStyle = Style.EMPTY.dim();
+    private Style lineNumberStyle;
     private TextChangeListener changeListener;
 
     public TextAreaElement() {
@@ -261,13 +283,18 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
 
         boolean isFocused = elementId != null && context.isFocused(elementId);
 
+        // Resolve styles with priority: explicit > CSS > default
+        Style effectiveCursorStyle = resolveEffectiveStyle(context, "cursor", cursorStyle, DEFAULT_CURSOR_STYLE);
+        Style effectivePlaceholderStyle = resolveEffectiveStyle(context, "placeholder", placeholderStyle, DEFAULT_PLACEHOLDER_STYLE);
+        Style effectiveLineNumberStyle = resolveEffectiveStyle(context, "line-number", lineNumberStyle, DEFAULT_LINE_NUMBER_STYLE);
+
         TextArea.Builder builder = TextArea.builder()
             .style(context.currentStyle())
-            .cursorStyle(cursorStyle)
+            .cursorStyle(effectiveCursorStyle)
             .placeholder(placeholder)
-            .placeholderStyle(placeholderStyle)
+            .placeholderStyle(effectivePlaceholderStyle)
             .showLineNumbers(showLineNumbers)
-            .lineNumberStyle(lineNumberStyle);
+            .lineNumberStyle(effectiveLineNumberStyle);
 
         Color effectiveBorderColor = isFocused && focusedBorderColor != null
                 ? focusedBorderColor

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextInputElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextInputElement.java
@@ -33,13 +33,33 @@ import static dev.tamboui.toolkit.Toolkit.handleTextInputKey;
  *     .title("Name")
  *     .rounded()
  * }</pre>
+ *
+ * <h2>CSS Child Selectors</h2>
+ * <p>
+ * The following child selectors can be used to style sub-components:
+ * <ul>
+ *   <li>{@code TextInputElement-cursor} - The cursor style (default: reversed)</li>
+ *   <li>{@code TextInputElement-placeholder} - The placeholder text style (default: dim)</li>
+ * </ul>
+ * <p>
+ * Example CSS:
+ * <pre>{@code
+ * TextInputElement-cursor { text-style: reversed; background: yellow; }
+ * TextInputElement-placeholder { color: gray; text-style: italic; }
+ * }</pre>
+ * <p>
+ * Note: Programmatic styles set via {@link #cursorStyle(Style)} or {@link #placeholderStyle(Style)}
+ * take precedence over CSS styles.
  */
 public final class TextInputElement extends StyledElement<TextInputElement> {
 
+    private static final Style DEFAULT_CURSOR_STYLE = Style.EMPTY.reversed();
+    private static final Style DEFAULT_PLACEHOLDER_STYLE = Style.EMPTY.dim();
+
     private TextInputState state;
-    private Style cursorStyle = Style.EMPTY.reversed();
+    private Style cursorStyle;
     private String placeholder = "";
-    private Style placeholderStyle = Style.EMPTY.dim();
+    private Style placeholderStyle;
     private String title;
     private BorderType borderType;
     private Color borderColor;
@@ -177,11 +197,15 @@ public final class TextInputElement extends StyledElement<TextInputElement> {
             return;
         }
 
+        // Resolve styles with priority: explicit > CSS > default
+        Style effectiveCursorStyle = resolveEffectiveStyle(context, "cursor", cursorStyle, DEFAULT_CURSOR_STYLE);
+        Style effectivePlaceholderStyle = resolveEffectiveStyle(context, "placeholder", placeholderStyle, DEFAULT_PLACEHOLDER_STYLE);
+
         TextInput.Builder builder = TextInput.builder()
             .style(context.currentStyle())
-            .cursorStyle(cursorStyle)
+            .cursorStyle(effectiveCursorStyle)
             .placeholder(placeholder)
-            .placeholderStyle(placeholderStyle);
+            .placeholderStyle(effectivePlaceholderStyle);
 
         if (title != null || borderType != null) {
             Block.Builder blockBuilder = Block.builder().borders(Borders.ALL);

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ElementChildStyleCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ElementChildStyleCssTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Modifier;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.DefaultRenderContext;
+import dev.tamboui.widgets.input.TextInputState;
+import dev.tamboui.widgets.input.TextAreaState;
+import dev.tamboui.widgets.scrollbar.ScrollbarState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests CSS child styling for various elements.
+ * <p>
+ * These tests verify the "explicit > CSS > default" priority pattern
+ * implemented via {@link dev.tamboui.toolkit.element.StyledElement#resolveEffectiveStyle}.
+ */
+class ElementChildStyleCssTest {
+
+    private DefaultRenderContext context;
+    private StyleEngine styleEngine;
+
+    @BeforeEach
+    void setUp() {
+        context = DefaultRenderContext.createEmpty();
+        styleEngine = StyleEngine.create();
+        context.setStyleEngine(styleEngine);
+    }
+
+    @Nested
+    @DisplayName("TextInputElement CSS child styling")
+    class TextInputElementCssTests {
+
+        @Test
+        @DisplayName("explicit cursor style overrides CSS")
+        void explicitCursorStyleOverridesCss() {
+            String css = "TextInputElement-cursor { background: blue; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 20, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // Use constructor with text - this sets cursor at end (position 5)
+            TextInputState state = new TextInputState("Hello");
+
+            // Use explicit style
+            textInput(state)
+                .cursorStyle(Style.EMPTY.bg(Color.RED))
+                .render(frame, area, context);
+
+            // Explicit style should override CSS - cursor at position 5
+            assertThat(buffer.get(5, 0).style().bg()).contains(Color.RED);
+        }
+
+        @Test
+        @DisplayName("explicit placeholder style overrides CSS")
+        void explicitPlaceholderStyleOverridesCss() {
+            String css = "TextInputElement-placeholder { color: cyan; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 20, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextInputState state = new TextInputState();
+            // Empty text shows placeholder
+
+            textInput(state)
+                .placeholder("Enter text...")
+                .placeholderStyle(Style.EMPTY.fg(Color.MAGENTA))
+                .render(frame, area, context);
+
+            // Explicit placeholder style should override CSS
+            assertThat(buffer.get(0, 0).style().fg()).contains(Color.MAGENTA);
+        }
+
+        @Test
+        @DisplayName("default cursor style used when no CSS or explicit style")
+        void defaultCursorStyleUsedWithoutCssOrExplicit() {
+            Rect area = new Rect(0, 0, 20, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // Use constructor with text - this sets cursor at end (position 2)
+            TextInputState state = new TextInputState("Hi");
+
+            textInput(state)
+                .render(frame, area, context);
+
+            // Default cursor style is reversed - cursor at position 2
+            assertThat(buffer.get(2, 0).style().effectiveModifiers())
+                .contains(Modifier.REVERSED);
+        }
+
+        @Test
+        @DisplayName("default placeholder style used when no CSS or explicit style")
+        void defaultPlaceholderStyleUsedWithoutCssOrExplicit() {
+            Rect area = new Rect(0, 0, 20, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextInputState state = new TextInputState();
+            // Empty text shows placeholder
+
+            textInput(state)
+                .placeholder("Enter text...")
+                .render(frame, area, context);
+
+            // Default placeholder style is dim
+            assertThat(buffer.get(0, 0).style().effectiveModifiers())
+                .contains(Modifier.DIM);
+        }
+    }
+
+    @Nested
+    @DisplayName("GaugeElement CSS child styling")
+    class GaugeElementCssTests {
+
+        @Test
+        @DisplayName("explicit gauge style overrides CSS")
+        void explicitGaugeStyleOverridesCss() {
+            String css = "GaugeElement-filled { color: green; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            gauge(1.0)
+                .label("")
+                .gaugeColor(Color.YELLOW)
+                .render(frame, area, context);
+
+            // Explicit style should override CSS
+            assertThat(buffer.get(0, 0).style().fg()).contains(Color.YELLOW);
+        }
+
+        @Test
+        @DisplayName("gauge renders with default style when no CSS or explicit")
+        void defaultGaugeStyleUsed() {
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            gauge(1.0)
+                .label("")
+                .render(frame, area, context);
+
+            // Gauge should render (filled character)
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("█");
+        }
+    }
+
+    @Nested
+    @DisplayName("LineGaugeElement CSS child styling")
+    class LineGaugeElementCssTests {
+
+        @Test
+        @DisplayName("explicit styles override CSS for both filled and unfilled")
+        void explicitStylesOverrideCss() {
+            String css = "LineGaugeElement-filled { color: magenta; }\n" +
+                         "LineGaugeElement-unfilled { color: gray; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            lineGauge(0.5)
+                .filledColor(Color.RED)
+                .unfilledColor(Color.BLUE)
+                .render(frame, area, context);
+
+            // Explicit styles should override CSS
+            assertThat(buffer.get(0, 0).style().fg()).contains(Color.RED);
+            assertThat(buffer.get(9, 0).style().fg()).contains(Color.BLUE);
+        }
+
+        @Test
+        @DisplayName("line gauge renders correctly without styling")
+        void lineGaugeRendersWithDefaults() {
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            lineGauge(0.5)
+                .render(frame, area, context);
+
+            // Line gauge should render its characters
+            assertThat(buffer.get(0, 0).symbol()).isNotEqualTo(" ");
+        }
+    }
+
+    @Nested
+    @DisplayName("ScrollbarElement CSS child styling")
+    class ScrollbarElementCssTests {
+
+        @Test
+        @DisplayName("explicit thumb style overrides CSS")
+        void explicitThumbStyleOverridesCss() {
+            String css = "ScrollbarElement-thumb { color: yellow; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 1, 10);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            ScrollbarState state = new ScrollbarState()
+                .contentLength(100)
+                .viewportContentLength(10)
+                .position(0);
+
+            scrollbar()
+                .vertical()
+                .state(state)
+                .thumbColor(Color.CYAN)
+                .render(frame, area, context);
+
+            // Check that the scrollbar renders without errors
+            assertThat(buffer).isNotNull();
+        }
+
+        @Test
+        @DisplayName("scrollbar renders with default symbols")
+        void scrollbarRendersWithDefaults() {
+            Rect area = new Rect(0, 0, 1, 10);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            ScrollbarState state = new ScrollbarState()
+                .contentLength(100)
+                .viewportContentLength(10)
+                .position(0);
+
+            scrollbar()
+                .vertical()
+                .state(state)
+                .render(frame, area, context);
+
+            // Scrollbar should render some non-empty content
+            boolean hasContent = false;
+            for (int y = 0; y < 10; y++) {
+                if (!" ".equals(buffer.get(0, y).symbol())) {
+                    hasContent = true;
+                    break;
+                }
+            }
+            assertThat(hasContent).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("TextAreaElement CSS child styling")
+    class TextAreaElementCssTests {
+
+        @Test
+        @DisplayName("explicit line number style overrides CSS")
+        void explicitLineNumberStyleOverridesCss() {
+            String css = "TextAreaElement-line-number { color: cyan; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 20, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState();
+            state.setText("Line 1\nLine 2");
+
+            textArea(state)
+                .showLineNumbers()
+                .lineNumberStyle(Style.EMPTY.fg(Color.RED))
+                .render(frame, area, context);
+
+            // Explicit style should override CSS
+            assertThat(buffer.get(0, 0).style().fg()).contains(Color.RED);
+        }
+
+        @Test
+        @DisplayName("explicit placeholder style overrides CSS")
+        void explicitPlaceholderStyleOverridesCss() {
+            String css = "TextAreaElement-placeholder { color: magenta; }";
+            styleEngine.addStylesheet("test", css);
+            styleEngine.setActiveStylesheet("test");
+
+            Rect area = new Rect(0, 0, 20, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState();
+            // Empty text shows placeholder
+
+            textArea(state)
+                .placeholder("Enter description...")
+                .placeholderStyle(Style.EMPTY.fg(Color.GREEN))
+                .render(frame, area, context);
+
+            // Explicit placeholder style should override CSS
+            assertThat(buffer.get(0, 0).style().fg()).contains(Color.GREEN);
+        }
+
+        @Test
+        @DisplayName("default line number style used when no CSS or explicit")
+        void defaultLineNumberStyleUsed() {
+            Rect area = new Rect(0, 0, 20, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState();
+            state.setText("Line 1\nLine 2");
+
+            textArea(state)
+                .showLineNumbers()
+                .render(frame, area, context);
+
+            // Default line number style is dim
+            assertThat(buffer.get(0, 0).style().effectiveModifiers())
+                .contains(Modifier.DIM);
+        }
+    }
+}


### PR DESCRIPTION
This commit refactors styling in Elements to make it more consistent:

- all Element implementations provide CSS properties to resolve styles
- there is a base method in `StyledElement` which performs the resolution, avoiding code duplication, with the right priority (explicit > CSS > default).
- some elements were only partially styleable using CSS, now all of them should be