### PR TITLE
feat: dark/light theme for asciinemaplayer

### DIFF
--- a/docs/src/theme/tamboui.css
+++ b/docs/src/theme/tamboui.css
@@ -957,3 +957,78 @@ body.toc2.toc-left .prev-next-nav {
     background: rgba(30, 30, 46, 0.9);
     border-top: 1px solid var(--sl-color-hairline);
 }
+
+/* Apply Solarized Dark theme in dark mode */
+[data-theme="dark"] .ap-player {
+    --term-color-foreground: #839496;
+    --term-color-background: #002b36;
+    --term-color-0: #073642;
+    --term-color-1: #dc322f;
+    --term-color-2: #859900;
+    --term-color-3: #b58900;
+    --term-color-4: #268bd2;
+    --term-color-5: #d33682;
+    --term-color-6: #2aa198;
+    --term-color-7: #eee8d5;
+    --term-color-8: #002b36;
+    --term-color-9: #cb4b16;
+    --term-color-10: #586e75;
+    --term-color-11: #657b83;
+    --term-color-12: #839496;
+    --term-color-13: #6c71c4;
+    --term-color-14: #93a1a1;
+    --term-color-15: #fdf6e3;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .ap-player {
+        --term-color-foreground: #839496;
+        --term-color-background: #002b36;
+        --term-color-0: #073642;
+        --term-color-1: #dc322f;
+        --term-color-2: #859900;
+        --term-color-3: #b58900;
+        --term-color-4: #268bd2;
+        --term-color-5: #d33682;
+        --term-color-6: #2aa198;
+        --term-color-7: #eee8d5;
+        --term-color-8: #002b36;
+        --term-color-9: #cb4b16;
+        --term-color-10: #586e75;
+        --term-color-11: #657b83;
+        --term-color-12: #839496;
+        --term-color-13: #6c71c4;
+        --term-color-14: #93a1a1;
+        --term-color-15: #fdf6e3;
+    }
+}
+
+/* Apply Solarized Light theme in light mode */
+[data-theme="light"] .ap-player {
+    --term-color-foreground: #657b83;
+    --term-color-background: #fdf6e3;
+    --term-color-0: #073642;
+    --term-color-1: #dc322f;
+    --term-color-2: #859900;
+    --term-color-3: #b58900;
+    --term-color-4: #268bd2;
+    --term-color-5: #d33682;
+    --term-color-6: #2aa198;
+    --term-color-7: #eee8d5;
+    --term-color-8: #002b36;
+    --term-color-9: #cb4b16;
+    --term-color-10: #586e75;
+    --term-color-11: #657c83;
+    --term-color-12: #839496;
+    --term-color-13: #6c71c4;
+    --term-color-14: #93a1a1;
+    --term-color-15: #fdf6e3;
+}
+
+[data-theme="light"] .ap-overlay-start .ap-play-button svg .ap-play-btn-fill {
+    fill: var(--term-color-1);
+}
+
+[data-theme="light"] .ap-overlay-start .ap-play-button svg .ap-play-btn-stroke {
+    stroke: var(--term-color-1);
+}


### PR DESCRIPTION
this toggles the theme of asciinema player using css dark/light themes.

though not sure if good - as tamboui demos look to not use ansi colors in key places so some demos sees text stay white and not visible in light mode.

we should check if that happens in lightmode in terminal too- if yes, we shuold fix/find way to handle that.