### PR TITLE
feat: add highlight using pygments

### DIFF
--- a/demos/filemanager-demo/build.gradle.kts
+++ b/demos/filemanager-demo/build.gradle.kts
@@ -12,6 +12,7 @@ demo {
 dependencies {
     implementation(projects.tambouiToolkit)
     implementation(projects.tambouiImage)
+    implementation(projects.tambouiPygments)
 }
 
 application {

--- a/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerDemo.java
+++ b/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerDemo.java
@@ -2,6 +2,7 @@
 //DEPS dev.tamboui:tamboui-jline3-backend:LATEST
 //DEPS dev.tamboui:tamboui-image:LATEST
 //DEPS dev.tamboui:tamboui-panama-backend:LATEST
+//DEPS dev.tamboui:tamboui-pygments:LATEST
 
 
 //SOURCES FileManagerController.java FileManagerView.java FileManagerKeyHandler.java DirectoryBrowserController.java

--- a/docs/video/pygments-demo.tape
+++ b/docs/video/pygments-demo.tape
@@ -1,0 +1,28 @@
+Source shared_.tape
+
+# Setup
+Hide
+Type jbang pygments-demo
+Enter
+Sleep 2
+Show
+
+# Recording
+Sleep 1s
+
+# Select a couple of samples (list on the left)
+Type "j"
+Sleep 0.6s
+Type "j"
+Sleep 0.6s
+
+# Focus code view and scroll
+Tab
+Sleep 0.4s
+Ctrl+d
+Sleep 0.6s
+
+# Quit
+Ctrl+c
+Sleep 1s
+

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -43,6 +43,9 @@
     "picocli-demo": {
       "script-ref": "tamboui-picocli/demos/picocli-demo/src/main/java/dev/tamboui/demo/PicoCLIDemo.java"
     },
+    "pygments-demo": {
+      "script-ref": "tamboui-pygments/demos/pygments-demo/src/main/java/dev/tamboui/demo/PygmentsDemo.java"
+    },
     "tfx-basic-effects-demo": {
       "script-ref": "tamboui-tfx/demos/tfx-basic-effects-demo/src/main/java/dev/tamboui/demo/BasicEffectsTFXDemo.java"
     },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "tamboui-parent"
 val modules = listOf(
     "tamboui-core",
     "tamboui-css",
+    "tamboui-pygments",
     "tamboui-widgets",
     "tamboui-image",
     "tamboui-jline3-backend",

--- a/tamboui-pygments/build.gradle.kts
+++ b/tamboui-pygments/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    id("dev.tamboui.java-library")
+    `java-test-fixtures`
+}
+
+description = "Pygments (pygmentize) CLI based syntax highlighting for TamboUI Text"
+
+dependencies {
+    api(projects.tambouiCore)
+
+    testFixturesApi(libs.assertj.core)
+}
+

--- a/tamboui-pygments/demos/pygments-demo/build.gradle.kts
+++ b/tamboui-pygments/demos/pygments-demo/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Demo showcasing pygmentize-based syntax highlighting"
+
+demo {
+    displayName = "Syntax highlighting (Pygmentize)"
+    tags = setOf("toolkit", "syntax-highlighting", "pygments", "richtext", "scrolling")
+}
+
+dependencies {
+    implementation(projects.tambouiToolkit)
+    implementation(projects.tambouiPygments)
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.PygmentsDemo")
+}
+

--- a/tamboui-pygments/demos/pygments-demo/src/main/java/dev/tamboui/demo/PygmentsDemo.java
+++ b/tamboui-pygments/demos/pygments-demo/src/main/java/dev/tamboui/demo/PygmentsDemo.java
@@ -1,0 +1,285 @@
+//DEPS dev.tamboui:tamboui-toolkit:LATEST
+//DEPS dev.tamboui:tamboui-pygments:LATEST
+//DEPS dev.tamboui:tamboui-jline3-backend:LATEST
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo;
+
+import dev.tamboui.layout.Rect;
+import static dev.tamboui.pygments.Pygments.pygments;
+import dev.tamboui.pygments.Pygments;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.style.Tags;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.toolkit.app.ToolkitRunner;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.toolkit.elements.ListElement;
+import dev.tamboui.toolkit.elements.RichTextAreaElement;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.bindings.BindingSets;
+import dev.tamboui.tui.event.KeyEvent;
+import java.time.Duration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+/**
+ * Demo showcasing {@link Pygments}.
+ */
+public final class PygmentsDemo implements Element {
+
+    private static final List<Sample> SAMPLES = Arrays.asList(
+        new Sample(
+            "Java",
+            "Hello.java",
+            ""
+                + "package dev.tamboui.demo;\n"
+                + "\n"
+                + "class Hello {\n"
+                + "  // Highlighted via the pygmentize CLI\n"
+                + "  static String greet(String name) {\n"
+                + "    return name == null ? \"Hello, world\" : \"Hello, \" + name;\n"
+                + "  }\n"
+                + "\n"
+                + "  public static void main(String[] args) {\n"
+                + "    System.out.println(greet(args.length > 0 ? args[0] : null));\n"
+                + "    int n = 42;\n"
+                + "  }\n"
+                + "}\n"
+        ),
+        new Sample(
+            "Python",
+            "hello.py",
+            ""
+                + "from dataclasses import dataclass\n"
+                + "\n"
+                + "@dataclass\n"
+                + "class User:\n"
+                + "    name: str\n"
+                + "\n"
+                + "def greet(user: User | None) -> str:\n"
+                + "    # This is a comment\n"
+                + "    return f\"Hello, {user.name if user else 'world'}\"\\\n"
+                + "        .strip()\n"
+                + "\n"
+                + "print(greet(User('Ada')))\n"
+        ),
+        new Sample(
+            "JavaScript",
+            "app.js",
+            ""
+                + "export function greet(name) {\n"
+                + "  // nullish coalescing\n"
+                + "  return `Hello, ${name ?? 'world'}`;\n"
+                + "}\n"
+                + "\n"
+                + "console.log(greet(null));\n"
+        ),
+        new Sample(
+            "Rust",
+            "main.rs",
+            ""
+                + "fn greet(name: Option<&str>) -> String {\n"
+                + "    // This is a comment\n"
+                + "    format!(\"Hello, {}\", name.unwrap_or(\"world\"))\n"
+                + "}\n"
+                + "\n"
+                + "fn main() {\n"
+                + "    println!(\"{}\", greet(None));\n"
+                + "    let n: i32 = 42;\n"
+                + "    println!(\"n={}\", n);\n"
+                + "}\n"
+        ),
+        new Sample(
+            "YAML",
+            "config.yaml",
+            ""
+                + "name: tamboui\n"
+                + "features:\n"
+                + "  - tui\n"
+                + "  - css\n"
+                + "  - syntax-highlighting\n"
+                + "meta:\n"
+                + "  version: 1\n"
+                + "  enabled: true\n"
+        ),
+        new Sample(
+            "Markdown",
+            "README.md",
+            ""
+                + "# TamboUI Demo\n"
+                + "\n"
+                + "```java\n"
+                + "// Syntax highlighting for Java:\n"
+                + "System.out.println(\"Hello, world!\");\n"
+                + "```\n"
+                + "\n"
+                + "1. Easy bullet points\n"
+                + "2. *Italic* and **bold** styles\n"
+                + "\n"
+                + "> Blockquote support!\n"
+        )
+    );
+
+    private final RichTextAreaElement codeArea;
+    private final ListElement<Sample> sampleList;
+
+    private final Text[] highlightedCache;
+    private final String[] subtitleCache;
+    private int lastSelected = -1;
+    private Text cachedText = Text.empty();
+    private String cachedSubtitle = "";
+    private String cachedTitle = "";
+
+    public PygmentsDemo() {
+        codeArea = new RichTextAreaElement()
+            .wrapCharacter()
+            .scrollbar(RichTextAreaElement.ScrollBarPolicy.AS_NEEDED)
+            .rounded()
+            .focusable()
+            .focusedBorderColor(Color.CYAN)
+            .fill();
+
+        sampleList = new ListElement<Sample>()
+            .data(SAMPLES, s -> row(
+                text(s.title).bold(),
+                spacer(),
+                text(s.filename).dim()
+            ))
+            .title("Samples")
+            .rounded()
+            .scrollbar(ListElement.ScrollBarPolicy.AS_NEEDED)
+            .highlightSymbol("› ")
+            .highlightColor(Color.CYAN)
+            .autoScroll()
+            .focusable()
+            .id("samples");
+
+        highlightedCache = new Text[SAMPLES.size()];
+        subtitleCache = new String[SAMPLES.size()];
+    }
+
+    public static void main(String[] args) throws Exception {
+        var config = TuiConfig.builder()
+            .mouseCapture(true)
+            // Enable vim-style navigation (j/k, Ctrl+u/d) in addition to arrow keys.
+            .bindings(BindingSets.vim())
+            .build();
+
+        try (var runner = ToolkitRunner.builder()
+            .config(config)
+            .bindings(BindingSets.vim())
+            .build()) {
+            var demo = new PygmentsDemo();
+            runner.run(() -> demo);
+        }
+    }
+
+
+    @Override
+    public void render(Frame frame, Rect area, RenderContext context) {
+        int selected = Math.min(Math.max(0, sampleList.selected()), SAMPLES.size() - 1);
+        if (selected != lastSelected) {
+            lastSelected = selected;
+        }
+
+        Sample sample = SAMPLES.get(selected);
+        cachedTitle = sample.title + " — " + sample.filename;
+
+        // Highlight each sample at most once (lazy cache).
+        if (highlightedCache[selected] == null) {
+            Pygments.Result result = pygments().highlightWithInfo(
+                sample.filename,
+                sample.source,
+                Duration.ofSeconds(3) // Use default style resolver
+            );
+
+            subtitleCache[selected] = result.highlighted()
+                ? "lexer=" + result.lexer().orElse("?")
+                : ("no highlighting (" + result.message().orElse("unknown") + ")");
+            highlightedCache[selected] = addLineNumbers(result.text());
+        }
+
+        cachedSubtitle = subtitleCache[selected] != null ? subtitleCache[selected] : "";
+        cachedText = highlightedCache[selected] != null ? highlightedCache[selected] : Text.raw(sample.source);
+
+        column(
+            panel(() -> row(
+                text(" Syntax highlighting (Pygmentize) ").bold(),
+                spacer(1),
+                text(" [Tab] Focus ").dim(),
+                text(" [Ctrl+C] Quit ").dim()
+            )).rounded().length(3),
+            text(cachedSubtitle).dim().length(1),
+            row(
+                sampleList.length(34),
+                spacer(1),
+                panel(() -> codeArea.text(cachedText))
+                    .title(cachedTitle)
+                    .rounded()
+                    .fill()
+            ).fill()
+        ).render(frame, area, context);
+    }
+
+    private static Text addLineNumbers(Text text) {
+        List<Line> in = text.lines();
+        if (in.isEmpty()) {
+            return text;
+        }
+
+        int digits = String.valueOf(in.size()).length();
+        Style lnStyle = Style.EMPTY
+            .fg(Color.GRAY)
+            .dim()
+            .withExtension(Tags.class, Tags.of("syntax-line-number"));
+
+        List<Line> out = new ArrayList<>(in.size());
+        for (int i = 0; i < in.size(); i++) {
+            Line line = in.get(i);
+            String ln = padLeft(String.valueOf(i + 1), digits);
+            List<Span> spans = new ArrayList<>(2 + line.spans().size());
+            spans.add(Span.styled(ln, lnStyle));
+            spans.add(Span.styled(" │ ", lnStyle));
+            spans.addAll(line.spans());
+            out.add(Line.from(spans));
+        }
+        return Text.from(out);
+    }
+
+    private static String padLeft(String s, int width) {
+        if (s.length() >= width) {
+            return s;
+        }
+        StringBuilder sb = new StringBuilder(width);
+        for (int i = s.length(); i < width; i++) {
+            sb.append(' ');
+        }
+        sb.append(s);
+        return sb.toString();
+    }
+
+    private static final class Sample {
+        final String title;
+        final String filename;
+        final String source;
+
+        Sample(String title, String filename, String source) {
+            this.title = title;
+            this.filename = filename;
+            this.source = source;
+        }
+    }
+}
+

--- a/tamboui-pygments/src/main/java/dev/tamboui/pygments/Pygments.java
+++ b/tamboui-pygments/src/main/java/dev/tamboui/pygments/Pygments.java
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.pygments;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.style.Tags;
+import dev.tamboui.text.Text;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Syntax-highlights source code by invoking the {@code pygmentize} CLI with the {@code raw} formatter.
+ * It will first try `pygmentize`, then `uvx`, then `pipx` to find a working pygmentize command.
+ * <p>
+ * The raw formatter emits one token per line in the form:
+ * {@code Token.Keyword\t'repr(token_text)'}.
+ * This class parses that output and converts it to {@link Text} by applying {@link dev.tamboui.style.Tags}
+ * on spans (e.g. {@code syntax-comment}, {@code syntax-string}, etc).
+ * 
+ */
+public final class Pygments {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(2);
+    private static final String DEFAULT_BIN = "pygmentize";
+    private static final String UVX_BIN = "uvx";
+    private static final String PIPX_BIN = "pipx";
+
+    private static volatile Pygments CACHED;
+
+    private volatile Invoker defaultInvoker;
+
+    private Pygments() {
+        // stateful utility
+    }
+
+    /**
+     * Returns a cached {@link Pygments} instance.
+     * <p>
+     * The returned instance caches which invoker is usable (direct {@code pygmentize}, {@code uvx}, or {@code pipx})
+     * the first time it needs to run Pygments.
+     */
+    public static Pygments pygments() {
+        Pygments v = CACHED;
+        if (v != null) {
+            return v;
+        }
+        synchronized (Pygments.class) {
+            if (CACHED == null) {
+                CACHED = new Pygments();
+            }
+            return CACHED;
+        }
+    }
+
+    public Text highlight(String filename, String source) {
+        return highlight(filename, source, DEFAULT_TIMEOUT, DEFAULT_STYLE_RESOLVER);
+    }
+
+    public Text highlight(String filename, String source, TokenStyleResolver resolver) {
+        return highlight(filename, source, DEFAULT_TIMEOUT, resolver);
+    }
+
+    public Text highlight(String filename, String source, Duration timeout, TokenStyleResolver resolver) {
+        Result result = highlightWithInfo(filename, source, timeout, resolver);
+        return result.text();
+    }
+
+    public Result highlightWithInfo(String filename, String source, Duration timeout) {
+        return highlightWithInfo(filename, source, timeout, DEFAULT_STYLE_RESOLVER);
+    }
+
+    public Result highlightWithInfo(String filename, String source, Duration timeout, TokenStyleResolver resolver) {
+        Objects.requireNonNull(resolver, "resolver");
+
+        if (source == null || source.isEmpty()) {
+            return new Result(Text.empty(), null, false, null);
+        }
+        if (filename == null || filename.trim().isEmpty()) {
+            return new Result(Text.raw(source), null, false, "filename is required for lexer inference");
+        }
+
+        Invoker invoker = resolveInvoker();
+        if (invoker == null) {
+            return new Result(Text.raw(source), null, false, "pygmentize not available (tried pygmentize, uvx, pipx)");
+        }
+
+        String lexer;
+        try {
+            lexer = inferLexer(filename, invoker, timeout);
+        } catch (IOException | InterruptedException e) {
+            return new Result(Text.raw(source), null, false, e.getMessage());
+        }
+
+        if (lexer == null || lexer.isEmpty()) {
+            return new Result(Text.raw(source), null, false, "no lexer inferred from filename");
+        }
+
+        String raw;
+        try {
+            raw = tokenizeToRaw(lexer, source, invoker, timeout);
+        } catch (IOException | InterruptedException e) {
+            return new Result(Text.raw(source), lexer, false, e.getMessage());
+        }
+
+        try {
+            Text text = RawTokenParser.parse(raw, resolver);
+            return new Result(text, lexer, true, null);
+        } catch (RuntimeException e) {
+            return new Result(Text.raw(source), lexer, false, "failed to parse pygmentize output: " + e.getMessage());
+        }
+    }
+
+    public boolean isAvailable() {
+        return resolveInvoker() != null;
+    }
+
+    private static String inferLexer(String filename, Invoker invoker, Duration timeout) throws IOException, InterruptedException {
+        // First try extension mapping (fast, no process call)
+        String lexer = inferLexerFromExtension(filename);
+        if (lexer != null) {
+            return lexer;
+        }
+        // Fallback to pygmentize inference (slower, but supports all file types)
+        return inferLexerFromPygmentize(filename, invoker, timeout);
+    }
+
+    private static String inferLexerFromExtension(String filename) {
+        if (filename == null || filename.isEmpty()) {
+            return null;
+        }
+        int lastDot = filename.lastIndexOf('.');
+        if (lastDot < 0 || lastDot >= filename.length() - 1) {
+            return null;
+        }
+        String extension = filename.substring(lastDot + 1).toLowerCase(Locale.ROOT);
+        return EXTENSION_TO_LEXER.get(extension);
+    }
+
+    private static String inferLexerFromPygmentize(String filename, Invoker invoker, Duration timeout) throws IOException, InterruptedException {
+        // `pygmentize -N filename` prints a lexer name (or "text" / empty)
+        ProcessResult pr = run(invoker.command("-N", filename), null, timeout, invoker.filterNotes());
+        if (pr.exitCode != 0) {
+            return null;
+        }
+        String out = pr.stdout.trim();
+        if (out.isEmpty()) {
+            return null;
+        }
+        // sometimes outputs like "text\n" or "java\n"
+        String lexer = out.toLowerCase(Locale.ROOT);
+        // Don't return "text" as it means no lexer was found
+        return "text".equals(lexer) ? null : lexer;
+    }
+
+    private static final Map<String, String> EXTENSION_TO_LEXER = createExtensionMap();
+
+    private static Map<String, String> createExtensionMap() {
+        Map<String, String> map = new HashMap<>();
+        // Common languages
+        map.put("java", "java");
+        map.put("py", "python");
+        map.put("js", "javascript");
+        map.put("jsx", "javascript");
+        map.put("ts", "typescript");
+        map.put("tsx", "typescript");
+        map.put("rs", "rust");
+        map.put("go", "go");
+        map.put("c", "c");
+        map.put("h", "c");
+        map.put("cpp", "cpp");
+        map.put("cc", "cpp");
+        map.put("cxx", "cpp");
+        map.put("hpp", "cpp");
+        map.put("cs", "csharp");
+        map.put("php", "php");
+        map.put("rb", "ruby");
+        map.put("swift", "swift");
+        map.put("kt", "kotlin");
+        map.put("scala", "scala");
+        map.put("clj", "clojure");
+        map.put("hs", "haskell");
+        map.put("ml", "ocaml");
+        map.put("fs", "fsharp");
+        map.put("erl", "erlang");
+        map.put("ex", "elixir");
+        map.put("exs", "elixir");
+        map.put("lua", "lua");
+        map.put("pl", "perl");
+        map.put("pm", "perl");
+        map.put("r", "r");
+        map.put("sh", "bash");
+        map.put("bash", "bash");
+        map.put("zsh", "bash");
+        // Data formats
+        map.put("json", "json");
+        map.put("xml", "xml");
+        map.put("html", "html");
+        map.put("htm", "html");
+        map.put("css", "css");
+        map.put("yaml", "yaml");
+        map.put("yml", "yaml");
+        map.put("toml", "toml");
+        map.put("ini", "ini");
+        map.put("properties", "properties");
+        map.put("sql", "sql");
+        // Markup
+        map.put("md", "markdown");
+        map.put("markdown", "markdown");
+        map.put("rst", "rst");
+        map.put("tex", "latex");
+        // Config/build files
+        map.put("gradle", "groovy");
+        map.put("groovy", "groovy");
+        map.put("makefile", "makefile");
+        map.put("mk", "makefile");
+        map.put("cmake", "cmake");
+        // Shell scripts
+        map.put("ps1", "powershell");
+        map.put("bat", "batch");
+        map.put("cmd", "batch");
+        return Collections.unmodifiableMap(map);
+    }
+
+    private static String tokenizeToRaw(String lexer, String source, Invoker invoker, Duration timeout) throws IOException, InterruptedException {
+        List<String> cmd = invoker.command("-l", lexer, "-f", "raw");
+
+        ProcessResult pr = run(cmd, source, timeout, invoker.filterNotes());
+        if (pr.exitCode != 0) {
+            throw new IOException("pygmentize failed: " + pr.stderr.trim());
+        }
+        return pr.stdout;
+    }
+
+    private static ProcessResult run(List<String> command, String stdin, Duration timeout, boolean filterNotes)
+        throws IOException, InterruptedException {
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        Process p = pb.start();
+
+        if (stdin != null) {
+            try (OutputStream os = p.getOutputStream()) {
+                os.write(stdin.getBytes(StandardCharsets.UTF_8));
+            }
+        } else {
+            p.getOutputStream().close();
+        }
+
+        boolean finished = p.waitFor(timeout.toMillis(), java.util.concurrent.TimeUnit.MILLISECONDS);
+        if (!finished) {
+            p.destroyForcibly();
+            throw new IOException("pygmentize timed out");
+        }
+
+        String out = readAll(p.getInputStream());
+        String err = readAll(p.getErrorStream());
+        if (filterNotes) {
+            out = stripNoteLines(out);
+            err = stripNoteLines(err);
+        }
+        return new ProcessResult(p.exitValue(), out, err);
+    }
+
+    private static String stripNoteLines(String s) {
+        if (s == null || s.isEmpty()) {
+            return "";
+        }
+        String[] lines = s.split("\n", -1);
+        StringBuilder sb = new StringBuilder(s.length());
+        for (String line : lines) {
+            if (line.startsWith("NOTE:")) {
+                continue;
+            }
+            sb.append(line).append('\n');
+        }
+        // Preserve the behavior of split(..., -1) which always leaves a trailing empty element if s ended with '\n'.
+        // Since we always append '\n' above, remove one if the original didn't end with it.
+        if (!s.endsWith("\n") && sb.length() > 0) {
+            sb.setLength(sb.length() - 1);
+        }
+        return sb.toString();
+    }
+
+    private Invoker resolveInvoker() {
+        return resolveDefaultInvoker();
+    }
+
+    private Invoker resolveDefaultInvoker() {
+        if(defaultInvoker != null) {
+            return defaultInvoker;
+        }
+        synchronized (this) {
+            Invoker detected = null;
+            // Prefer a real pygmentize first.
+            if (canRunDirect(DEFAULT_BIN, Duration.ofSeconds(2), "-V")) {
+                detected = Invoker.direct(DEFAULT_BIN);
+            } else if (canRunDirect(UVX_BIN, Duration.ofSeconds(2), "--version")) {
+                // Fallback 1: uvx --from pygments pygmentize ...
+                detected = Invoker.uvx();
+            } else if (canRunDirect(PIPX_BIN, Duration.ofSeconds(2), "--version")) {
+                // Fallback 2: pipx run --spec pygments pygmentize ...
+                detected = Invoker.pipx();
+            }
+            defaultInvoker = detected;
+            return detected;
+        }
+    }
+
+    /**
+     * can i run the command and get a success exit code?
+     * @param bin the command to run
+     * @param timeout the timeout
+     * @param args the arguments to pass to the command (--version, -V, etc.) to ensure it returns a succcess
+     * @return true if the command can be run and get a success exit code, false otherwise
+     */
+    private static boolean canRunDirect(String bin, Duration timeout,String... args) {
+        try {
+            List<String> cmd = new ArrayList<>(1 + args.length);
+            cmd.add(bin);
+            cmd.addAll(Arrays.asList(args));
+            ProcessResult pr = run(cmd, null, timeout, false);
+            if (pr.exitCode == 0) {
+                return true;
+            }
+        } catch (Exception ignored) {
+            // ignore
+        }
+        return false;
+    }
+
+    private static final class Invoker {
+        private final List<String> prefix;
+        private final boolean filterNotes;
+
+        private Invoker(List<String> prefix, boolean filterNotes) {
+            this.prefix = prefix;
+            this.filterNotes = filterNotes;
+        }
+
+        static Invoker direct(String bin) {
+            return new Invoker(Collections.singletonList(bin), false);
+        }
+
+        static Invoker uvx() {
+            return new Invoker(Arrays.asList(UVX_BIN, "--from", "pygments", "pygmentize"), false);
+        }
+
+        static Invoker pipx() {
+            // pipx may print "NOTE:" lines; strip them from stdout/stderr.
+            return new Invoker(Arrays.asList(PIPX_BIN, "run", "--spec", "pygments", "pygmentize"), true);
+        }
+
+        List<String> command(String... args) {
+            List<String> cmd = new ArrayList<>(prefix.size() + args.length);
+            cmd.addAll(prefix);
+            cmd.addAll(Arrays.asList(args));
+            return cmd;
+        }
+
+        boolean filterNotes() {
+            return filterNotes;
+        }
+    }
+
+    private static String readAll(InputStream is) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buf = new byte[8192];
+        int read;
+        while ((read = is.read(buf)) >= 0) {
+            baos.write(buf, 0, read);
+        }
+        return new String(baos.toByteArray(), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Optional mapping from token information to a style patch.
+     */
+    @FunctionalInterface
+    public interface TokenStyleResolver {
+        /**
+         * @param tokenType full Pygments token type (e.g. {@code Token.Literal.String})
+         * @return a style to use for the given token type
+         */
+        Style resolve(String tokenType);
+    }
+
+    public static final TokenStyleResolver DEFAULT_STYLE_RESOLVER = createDefaultStyleResolver();
+
+    private static TokenStyleResolver createDefaultStyleResolver() {
+        Map<String, Style> tokenStyles = new HashMap<>();
+        // Token.Comment: "$text 60%"
+        tokenStyles.put("Token.Comment", Style.EMPTY.gray().dim().withExtension(Tags.class, Tags.of("syntax-comment")));
+        // Token.Error: "$text-error on $error-muted"
+        tokenStyles.put("Token.Error", Style.EMPTY.red().bg(Color.rgb(0x2c, 0x1e, 0x1e)).withExtension(Tags.class, Tags.of("syntax-error"))); // $text-error on $error-muted
+        // Token.Generic.Strong: "bold"
+        tokenStyles.put("Token.Generic.Strong", Style.EMPTY.bold());
+        // Token.Generic.Emph: "italic"
+        tokenStyles.put("Token.Generic.Emph", Style.EMPTY.italic());
+        // Token.Generic.Error: "$text-error on $error-muted"
+        tokenStyles.put("Token.Generic.Error", Style.EMPTY.red().bg(Color.rgb(0x2c, 0x1e, 0x1e)).withExtension(Tags.class, Tags.of("syntax-error")));
+        // Token.Generic.Heading: "$text-primary underline"
+        tokenStyles.put("Token.Generic.Heading", Style.EMPTY.underlineColor(Color.WHITE).withExtension(Tags.class, Tags.of("syntax-heading")));
+        // Token.Generic.Subheading: "$text-primary"
+        tokenStyles.put("Token.Generic.Subheading", Style.EMPTY.fg(Color.WHITE).withExtension(Tags.class, Tags.of("syntax-subheading")));
+        // Token.Keyword: "$text-accent"
+        tokenStyles.put("Token.Keyword", Style.EMPTY.fg(Color.CYAN).withExtension(Tags.class, Tags.of("syntax-keyword")));
+        // Token.Keyword.Constant: "bold $text-success 80%"
+        tokenStyles.put("Token.Keyword.Constant", Style.EMPTY.bold().fg(Color.rgb(0xa9, 0xdc, 0x76)).withExtension(Tags.class, Tags.of("syntax-constant"))); // $text-success 80%
+        // Token.Keyword.Namespace: "$text-error"
+        tokenStyles.put("Token.Keyword.Namespace", Style.EMPTY.fg(Color.RED).withExtension(Tags.class, Tags.of("syntax-namespace")));
+        // Token.Keyword.Type: "bold"
+        tokenStyles.put("Token.Keyword.Type", Style.EMPTY.bold());
+        // Token.Literal.Number: "$text-warning"
+        tokenStyles.put("Token.Literal.Number", Style.EMPTY.fg(Color.YELLOW).withExtension(Tags.class, Tags.of("syntax-number")));
+        // Token.Literal.String.Backtick: "$text 60%"
+        tokenStyles.put("Token.Literal.String.Backtick", Style.EMPTY.fg(Color.GRAY).withExtension(Tags.class, Tags.of("syntax-string-backtick")));
+        // Token.Literal.String: "$text-success 90%"
+        tokenStyles.put("Token.Literal.String", Style.EMPTY.fg(Color.rgb(0x8d, 0xcf, 0x8c)).withExtension(Tags.class, Tags.of("syntax-string"))); // $text-success 90%
+        // Token.Literal.String.Doc: "$text-success 80% italic"
+        tokenStyles.put("Token.Literal.String.Doc", Style.EMPTY.fg(Color.rgb(0xa9, 0xdc, 0x76)).italic().withExtension(Tags.class, Tags.of("syntax-string-doc")));
+        // Token.Literal.String.Double: "$text-success 90%"
+        tokenStyles.put("Token.Literal.String.Double", Style.EMPTY.fg(Color.rgb(0x8d, 0xcf, 0x8c)).withExtension(Tags.class, Tags.of("syntax-string-double")));
+        // Token.Name: "$text-primary"
+        tokenStyles.put("Token.Name", Style.EMPTY.fg(Color.WHITE).withExtension(Tags.class, Tags.of("syntax-name")));
+        // Token.Name.Attribute: "$text-warning"
+        tokenStyles.put("Token.Name.Attribute", Style.EMPTY.fg(Color.YELLOW).withExtension(Tags.class, Tags.of("syntax-attribute")));
+        // Token.Name.Builtin: "$text-accent"
+        tokenStyles.put("Token.Name.Builtin", Style.EMPTY.fg(Color.CYAN).withExtension(Tags.class, Tags.of("syntax-builtin", "syntax-identifier")));
+        // Token.Name.Builtin.Pseudo: "italic"
+        tokenStyles.put("Token.Name.Builtin.Pseudo", Style.EMPTY.italic().withExtension(Tags.class, Tags.of("syntax-builtin-pseudo")));
+        // Token.Name.Class: "$text-warning bold"
+        tokenStyles.put("Token.Name.Class", Style.EMPTY.fg(Color.YELLOW).bold().withExtension(Tags.class, Tags.of("syntax-class")));
+        // Token.Name.Constant: "$text-error"
+        tokenStyles.put("Token.Name.Constant", Style.EMPTY.fg(Color.RED).withExtension(Tags.class, Tags.of("syntax-constant")));    
+        // Token.Name.Decorator: "$text-primary bold"
+        tokenStyles.put("Token.Name.Decorator", Style.EMPTY.fg(Color.WHITE).bold().withExtension(Tags.class, Tags.of("syntax-decorator")));
+        // Token.Name.Function: "$text-warning underline"
+        tokenStyles.put("Token.Name.Function", Style.EMPTY.fg(Color.YELLOW).underlineColor(Color.YELLOW).withExtension(Tags.class, Tags.of("syntax-function")));
+        // Token.Name.Function.Magic: "$text-warning underline"
+        tokenStyles.put("Token.Name.Function.Magic", Style.EMPTY.fg(Color.YELLOW).underlineColor(Color.YELLOW).withExtension(Tags.class, Tags.of("syntax-function-magic")));
+        // Token.Name.Tag: "$text-primary bold"
+        tokenStyles.put("Token.Name.Tag", Style.EMPTY.fg(Color.WHITE).bold().withExtension(Tags.class, Tags.of("syntax-tag")));
+        // Token.Name.Variable: "$text-secondary"
+        tokenStyles.put("Token.Name.Variable", Style.EMPTY.fg(Color.GRAY).withExtension(Tags.class, Tags.of("syntax-variable")));
+        // Token.Name.Namespace
+        tokenStyles.put("Token.Name.Namespace", Style.EMPTY.fg(Color.RED).withExtension(Tags.class, Tags.of("syntax-namespace")));
+        // Token.Number: "$text-warning"
+        tokenStyles.put("Token.Number", Style.EMPTY.fg(Color.YELLOW).withExtension(Tags.class, Tags.of("syntax-number")));
+        // Token.Operator: "bold"
+        tokenStyles.put("Token.Operator", Style.EMPTY.bold().withExtension(Tags.class, Tags.of("syntax-operator")));
+        // Token.Operator.Word: "bold $text-error"
+        tokenStyles.put("Token.Operator.Word", Style.EMPTY.bold().fg(Color.RED).withExtension(Tags.class, Tags.of("syntax-operator-word")));
+        // Token.String: "$text-success"
+        tokenStyles.put("Token.String", Style.EMPTY.fg(Color.GREEN).withExtension(Tags.class, Tags.of("syntax-string")));
+        // Token.Whitespace: ""
+        tokenStyles.put("Token.Text.Whitespace", Style.EMPTY.withExtension(Tags.class, Tags.of("syntax-whitespace")));
+        // Token.Whitespace: ""
+        tokenStyles.put("Token.Text.Punctuation", Style.EMPTY.withExtension(Tags.class, Tags.of("syntax-punctuation")));
+        
+        Map<String, Style> unmodifiableMap = Collections.unmodifiableMap(tokenStyles);
+        return k -> {
+            Style style = unmodifiableMap.get(k);
+            return style != null ? style : Style.EMPTY;
+        };
+    }
+
+    /**
+     * Highlight result with extra info for UIs.
+     */
+    public static final class Result {
+        private final Text text;
+        private final String lexer;
+        private final boolean highlighted;
+        private final String message;
+
+        private Result(Text text, String lexer, boolean highlighted, String message) {
+            this.text = Objects.requireNonNull(text, "text");
+            this.lexer = lexer;
+            this.highlighted = highlighted;
+            this.message = message;
+        }
+
+        public Text text() {
+            return text;
+        }
+
+        public Optional<String> lexer() {
+            return Optional.ofNullable(lexer);
+        }
+
+        public boolean highlighted() {
+            return highlighted;
+        }
+
+        public Optional<String> message() {
+            return Optional.ofNullable(message);
+        }
+    }
+
+    private static final class ProcessResult {
+        final int exitCode;
+        final String stdout;
+        final String stderr;
+
+        ProcessResult(int exitCode, String stdout, String stderr) {
+            this.exitCode = exitCode;
+            this.stdout = stdout != null ? stdout : "";
+            this.stderr = stderr != null ? stderr : "";
+        }
+    }
+}
+

--- a/tamboui-pygments/src/main/java/dev/tamboui/pygments/PythonReprString.java
+++ b/tamboui-pygments/src/main/java/dev/tamboui/pygments/PythonReprString.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.pygments;
+
+/**
+ * Decodes a Python {@code repr()} string literal as emitted by Pygments raw formatter.
+ * <p>
+ * This is a pragmatic decoder: it supports the common escape sequences used by repr()
+ * for code token streams (\n, \t, \r, \\, \', \", hex, unicode, and octal).
+ */
+final class PythonReprString {
+
+    private PythonReprString() {
+    }
+
+    static String decode(String repr) {
+        if (repr == null) {
+            return "";
+        }
+        String s = repr.trim();
+        if (s.isEmpty()) {
+            return "";
+        }
+
+        // Strip prefixes like u'', r'', b'' (and combinations).
+        int i = 0;
+        while (i < s.length()) {
+            char c = s.charAt(i);
+            if (c == 'u' || c == 'U' || c == 'r' || c == 'R' || c == 'b' || c == 'B' || c == 'f' || c == 'F') {
+                i++;
+                continue;
+            }
+            break;
+        }
+        s = s.substring(i).trim();
+        if (s.length() < 2) {
+            return "";
+        }
+
+        char quote = s.charAt(0);
+        if (quote != '\'' && quote != '"') {
+            return "";
+        }
+        if (s.charAt(s.length() - 1) != quote) {
+            return "";
+        }
+        String body = s.substring(1, s.length() - 1);
+
+        StringBuilder out = new StringBuilder(body.length());
+        for (int p = 0; p < body.length(); p++) {
+            char ch = body.charAt(p);
+            if (ch != '\\') {
+                out.append(ch);
+                continue;
+            }
+            if (p + 1 >= body.length()) {
+                out.append('\\');
+                break;
+            }
+            char e = body.charAt(++p);
+            switch (e) {
+                case 'n': out.append('\n'); break;
+                case 't': out.append('\t'); break;
+                case 'r': out.append('\r'); break;
+                case '\\': out.append('\\'); break;
+                case '\'': out.append('\''); break;
+                case '"': out.append('"'); break;
+                case 'a': out.append('\u0007'); break;
+                case 'b': out.append('\b'); break;
+                case 'f': out.append('\f'); break;
+                case 'v': out.append('\u000b'); break;
+                case 'x': {
+                    int cp = readHex(body, p + 1, 2);
+                    if (cp >= 0) {
+                        out.append((char) cp);
+                        p += 2;
+                    } else {
+                        out.append("\\x");
+                    }
+                    break;
+                }
+                case 'u': {
+                    int cp = readHex(body, p + 1, 4);
+                    if (cp >= 0) {
+                        out.append((char) cp);
+                        p += 4;
+                    } else {
+                        out.append("\\u");
+                    }
+                    break;
+                }
+                case 'U': {
+                    int cp = readHex(body, p + 1, 8);
+                    if (cp >= 0) {
+                        out.appendCodePoint(cp);
+                        p += 8;
+                    } else {
+                        out.append("\\U");
+                    }
+                    break;
+                }
+                default:
+                    // Octal escape \ooo
+                    if (e >= '0' && e <= '7') {
+                        int oct = e - '0';
+                        int consumed = 0;
+                        while (consumed < 2 && p + 1 < body.length()) {
+                            char o = body.charAt(p + 1);
+                            if (o < '0' || o > '7') {
+                                break;
+                            }
+                            oct = (oct * 8) + (o - '0');
+                            p++;
+                            consumed++;
+                        }
+                        out.append((char) oct);
+                    } else {
+                        // Unknown escape, keep the escaped char
+                        out.append(e);
+                    }
+                    break;
+            }
+        }
+        return out.toString();
+    }
+
+    private static int readHex(String s, int start, int digits) {
+        if (start + digits > s.length()) {
+            return -1;
+        }
+        int v = 0;
+        for (int i = 0; i < digits; i++) {
+            int d = Character.digit(s.charAt(start + i), 16);
+            if (d < 0) {
+                return -1;
+            }
+            v = (v << 4) | d;
+        }
+        return v;
+    }
+}
+

--- a/tamboui-pygments/src/main/java/dev/tamboui/pygments/RawTokenParser.java
+++ b/tamboui-pygments/src/main/java/dev/tamboui/pygments/RawTokenParser.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.pygments;
+
+import dev.tamboui.style.Style;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parser for Pygments RawTokenFormatter output.
+ * <p>
+ * Package-private on purpose; public API is {@link Pygments}.
+ */
+final class RawTokenParser {
+
+    private RawTokenParser() {
+    }
+
+    static Text parse(String raw, Pygments.TokenStyleResolver resolver) {
+        if (raw == null || raw.isEmpty()) {
+            return Text.empty();
+        }
+
+        List<Line> lines = new ArrayList<>();
+        List<Span> current = new ArrayList<>();
+        boolean sawNonEmptyContent = false;
+
+        int idx = 0;
+        while (idx < raw.length()) {
+            int end = raw.indexOf('\n', idx);
+            String line = end >= 0 ? raw.substring(idx, end) : raw.substring(idx);
+            idx = end >= 0 ? end + 1 : raw.length();
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            int split = firstWhitespaceIndex(line);
+            if (split < 0) {
+                continue;
+            }
+            String tokenType = line.substring(0, split).trim();
+            String rest = line.substring(split).trim();
+            if (tokenType.isEmpty() || rest.isEmpty()) {
+                continue;
+            }
+
+            String tokenText = PythonReprString.decode(rest);
+            // Defensive normalization: some environments may double-escape control characters,
+            // leaving literal "\n" in the decoded text. For whitespace tokens, treat those
+            // sequences as the intended control characters.
+            if (tokenType.startsWith("Token.Text.Whitespace") || tokenType.equals("Token.Text")) {
+                tokenText = normalizeCommonWhitespaceEscapes(tokenText);
+            }
+            if (tokenText.isEmpty()) {
+                continue;
+            }
+
+            Style style = resolver.resolve(tokenType);
+            if (!tokenText.equals("\n") && tokenText.trim().length() > 0) {
+                sawNonEmptyContent = true;
+            }
+            appendText(tokenText, style, lines, current);
+        }
+
+        if (!current.isEmpty()) {
+            lines.add(Line.from(current));
+        }
+
+        // Pygments commonly emits a final Token.Text.Whitespace '\n' for files ending with a newline.
+        // In a "text editor" mental model this should not add an extra blank *visible* line at the end,
+        // so we trim exactly one trailing empty line in that case.
+        if (sawNonEmptyContent && !lines.isEmpty() && lines.get(lines.size() - 1).isEmpty()) {
+            lines.remove(lines.size() - 1);
+        }
+
+        return Text.from(lines);
+    }
+
+    private static String normalizeCommonWhitespaceEscapes(String s) {
+        if (s == null) {
+            return "";
+        }
+        // Only handle the exact whole-token cases; do not replace inside larger strings.
+        if ("\\n".equals(s)) {
+            return "\n";
+        }
+        if ("\\r".equals(s)) {
+            return "\r";
+        }
+        if ("\\t".equals(s)) {
+            return "\t";
+        }
+        if ("\\r\\n".equals(s)) {
+            return "\r\n";
+        }
+        return s;
+    }
+
+    private static void appendText(String text, Style style, List<Line> lines, List<Span> current) {
+        int start = 0;
+        while (start < text.length()) {
+            int nl = text.indexOf('\n', start);
+            if (nl < 0) {
+                current.add(Span.styled(text.substring(start), style));
+                return;
+            }
+            String chunk = text.substring(start, nl);
+            if (!chunk.isEmpty()) {
+                current.add(Span.styled(chunk, style));
+            }
+            lines.add(Line.from(new ArrayList<>(current)));
+            current.clear();
+            start = nl + 1;
+        }
+    }
+
+    private static int firstWhitespaceIndex(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if (c == '\t' || c == ' ') {
+                return i;
+            }
+        }
+        return -1;
+    }
+}
+

--- a/tamboui-pygments/src/test/java/dev/tamboui/pygments/PygementsTest.java
+++ b/tamboui-pygments/src/test/java/dev/tamboui/pygments/PygementsTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.pygments;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static dev.tamboui.pygments.Pygments.pygments;
+
+class PygmentsTest {
+
+    @Test
+    void testPygments() {
+        Pygments.Result result = pygments().highlightWithInfo(
+            "test.java",
+            "print('Hello, World!')",
+            Duration.ofSeconds(1)
+        );
+        assertThat(result).isNotNull();
+    }
+}
+

--- a/tamboui-pygments/src/test/java/dev/tamboui/pygments/RawTokenParserTest.java
+++ b/tamboui-pygments/src/test/java/dev/tamboui/pygments/RawTokenParserTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.pygments;
+
+import dev.tamboui.style.Tags;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RawTokenParserTest {
+
+    @Test
+    void parsesRawFormatterIntoStyledText() {
+        String raw = ""
+            + "Token.Keyword\t'class'\n"
+            + "Token.Text\t' '\n"
+            + "Token.Name.Class\t'A'\n"
+            + "Token.Punctuation\t'{' \n"
+            + "Token.Comment\t'// hello'\n"
+            + "Token.Text.Whitespace\t'\\n'\n"
+            + "Token.Literal.String\t'\"x\"'\n"
+            + "Token.Text.Whitespace\t'\\n'\n"
+            + "Token.Literal.Number\t'42'\n";
+
+        Text text = RawTokenParser.parse(raw, Pygments.DEFAULT_STYLE_RESOLVER);
+        assertThat(text.rawContent()).contains("class A");
+
+        Set<String> tags = collectTags(text);
+        assertThat(tags).contains("syntax-keyword", "syntax-comment", "syntax-string", "syntax-number", "syntax-class");
+    }
+
+    @Test
+    void doesNotAddExtraTrailingBlankLineForFinalNewline() {
+        String raw = ""
+            + "Token.Name\t'a'\n"
+            + "Token.Text.Whitespace\t'\\n'\n";
+
+        Text text = RawTokenParser.parse(raw, Pygments.DEFAULT_STYLE_RESOLVER);
+        assertThat(text.lines()).hasSize(1);
+        assertThat(text.lines().get(0).rawContent()).isEqualTo("a");
+    }
+
+    @Test
+    void whitespaceTokenWithLiteralBackslashN_isTreatedAsNewline() {
+        // If a raw stream ever contains a double-escaped newline, we still want it to break lines.
+        String raw = ""
+            + "Token.Name\t'a'\n"
+            + "Token.Text.Whitespace\t'\\\\n'\n"
+            + "Token.Name\t'b'\n";
+
+        Text text = RawTokenParser.parse(raw, Pygments.DEFAULT_STYLE_RESOLVER);
+        assertThat(text.lines()).hasSize(2);
+        assertThat(text.lines().get(0).rawContent()).isEqualTo("a");
+        assertThat(text.lines().get(1).rawContent()).isEqualTo("b");
+    }
+
+    private static Set<String> collectTags(Text text) {
+        Set<String> out = new HashSet<>();
+        for (Line line : text.lines()) {
+            for (Span span : line.spans()) {
+                Tags tags = span.style().extension(Tags.class, Tags.empty());
+                out.addAll(tags.values());
+            }
+        }
+        return out;
+    }
+}
+


### PR DESCRIPTION
I wanted to have a pure java highlighter but were not able to find one I was happy with (closest is/was textmate4e which I do think is doable but its dependency chain is massive so I wanted something that was lighter).

this adds a pygments.highlight(sourcetype, source) that converts into Text() with styles and tags. 

For now only done at lower levels, added demo and hook to Filemanager. 

note: it tries pygmentize, uvx, pipx in that order ...thus first call might be slow but afterwards its "just" a external process call "cost"

Could also be a candidate to be external repo - wdyt?

* note: I have a tree-sitter spike which is probably better more long term but it supports way less languages so stil wanted a basic highlight via pygment.  