### PR TITLE
fix: Fix InlineDisplay collapsing

### DIFF
--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -1105,10 +1105,12 @@ try (var runner = InlineToolkitRunner.create(3)) {
 
 === Scopes for Dynamic Regions
 
-Use `scope()` to create collapsible regions:
+Use `scope()` from `InlineToolkit` to create collapsible regions:
 
 [source,java]
 ----
+import static dev.tamboui.toolkit.InlineToolkit.*;
+
 private boolean downloading = true;
 
 @Override

--- a/docs/video/inline-toolkit-demo.tape
+++ b/docs/video/inline-toolkit-demo.tape
@@ -18,12 +18,22 @@ Sleep 500ms
 Enter
 Sleep 1s
 
-# Watch the animated installation progress
-Sleep 12s
+# Watch npm install - details visible by default, press 'd' to collapse then expand
+Sleep 3s
+Type "d"
+Sleep 3s
+Type "d"
+Sleep 6s
 
 # Answer the "Continue with native module build?" prompt
 Type "y"
-Sleep 8s
+
+# Watch native build - collapse then expand details
+Sleep 2s
+Type "d"
+Sleep 2s
+Type "d"
+Sleep 4s
 
 # Exit when done
 Sleep 2s

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Backend.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Backend.java
@@ -195,6 +195,109 @@ public interface Backend extends AutoCloseable {
     int peek(int timeoutMs) throws IOException;
 
     /**
+     * Inserts N lines at the current cursor position, pushing existing lines down.
+     * The cursor position does not change.
+     *
+     * @param n the number of lines to insert
+     * @throws IOException if the operation fails
+     */
+    default void insertLines(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writeRaw("\u001b[" + n + "L");
+    }
+
+    /**
+     * Deletes N lines at the current cursor position, pulling lines below up.
+     * The cursor position does not change.
+     *
+     * @param n the number of lines to delete
+     * @throws IOException if the operation fails
+     */
+    default void deleteLines(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writeRaw("\u001b[" + n + "M");
+    }
+
+    /**
+     * Moves the cursor up by N lines. If the cursor is already at the top,
+     * this has no effect.
+     *
+     * @param n the number of lines to move up
+     * @throws IOException if the operation fails
+     */
+    default void moveCursorUp(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writeRaw("\u001b[" + n + "A");
+    }
+
+    /**
+     * Moves the cursor down by N lines. If the cursor is already at the bottom,
+     * this has no effect.
+     *
+     * @param n the number of lines to move down
+     * @throws IOException if the operation fails
+     */
+    default void moveCursorDown(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writeRaw("\u001b[" + n + "B");
+    }
+
+    /**
+     * Moves the cursor right by N columns. If the cursor is already at the
+     * rightmost position, this has no effect.
+     *
+     * @param n the number of columns to move right
+     * @throws IOException if the operation fails
+     */
+    default void moveCursorRight(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writeRaw("\u001b[" + n + "C");
+    }
+
+    /**
+     * Moves the cursor left by N columns. If the cursor is already at the
+     * leftmost position, this has no effect.
+     *
+     * @param n the number of columns to move left
+     * @throws IOException if the operation fails
+     */
+    default void moveCursorLeft(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writeRaw("\u001b[" + n + "D");
+    }
+
+    /**
+     * Erases from the cursor to the end of the line.
+     * The cursor position does not change.
+     *
+     * @throws IOException if the operation fails
+     */
+    default void eraseToEndOfLine() throws IOException {
+        writeRaw("\u001b[K");
+    }
+
+    /**
+     * Moves the cursor to the beginning of the current line (carriage return).
+     *
+     * @throws IOException if the operation fails
+     */
+    default void carriageReturn() throws IOException {
+        writeRaw("\r");
+    }
+
+    /**
      * Closes this backend and releases any resources.
      *
      * @throws IOException if closing fails

--- a/tamboui-core/src/test/java/dev/tamboui/inline/InlineDisplayTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/inline/InlineDisplayTest.java
@@ -245,6 +245,11 @@ class InlineDisplayTest {
         }
 
         @Override
+        public void writeRaw(byte[] data) throws IOException {
+            // Write to nowhere - just accept the output for testing
+        }
+
+        @Override
         public void onResize(Runnable handler) {
         }
 

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/BackendTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/BackendTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.terminal;
+
+import dev.tamboui.buffer.CellUpdate;
+import dev.tamboui.layout.Position;
+import dev.tamboui.layout.Size;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BackendTest {
+
+    private MinimalBackend backend;
+    private ByteArrayOutputStream output;
+
+    @BeforeEach
+    void setUp() {
+        output = new ByteArrayOutputStream();
+        backend = new MinimalBackend(output);
+    }
+
+    @Test
+    @DisplayName("insertLines generates correct ANSI sequence")
+    void insertLines() throws IOException {
+        backend.insertLines(5);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[5L");
+    }
+
+    @Test
+    @DisplayName("insertLines with n=0 does nothing")
+    void insertLinesZero() throws IOException {
+        backend.insertLines(0);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("insertLines with negative n does nothing")
+    void insertLinesNegative() throws IOException {
+        backend.insertLines(-1);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("deleteLines generates correct ANSI sequence")
+    void deleteLines() throws IOException {
+        backend.deleteLines(3);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[3M");
+    }
+
+    @Test
+    @DisplayName("deleteLines with n=0 does nothing")
+    void deleteLinesZero() throws IOException {
+        backend.deleteLines(0);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("moveCursorUp generates correct ANSI sequence")
+    void moveCursorUp() throws IOException {
+        backend.moveCursorUp(4);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[4A");
+    }
+
+    @Test
+    @DisplayName("moveCursorDown generates correct ANSI sequence")
+    void moveCursorDown() throws IOException {
+        backend.moveCursorDown(2);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[2B");
+    }
+
+    @Test
+    @DisplayName("moveCursorRight generates correct ANSI sequence")
+    void moveCursorRight() throws IOException {
+        backend.moveCursorRight(10);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[10C");
+    }
+
+    @Test
+    @DisplayName("moveCursorLeft generates correct ANSI sequence")
+    void moveCursorLeft() throws IOException {
+        backend.moveCursorLeft(7);
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[7D");
+    }
+
+    @Test
+    @DisplayName("eraseToEndOfLine generates correct ANSI sequence")
+    void eraseToEndOfLine() throws IOException {
+        backend.eraseToEndOfLine();
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\u001b[K");
+    }
+
+    @Test
+    @DisplayName("carriageReturn generates correct sequence")
+    void carriageReturn() throws IOException {
+        backend.carriageReturn();
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo("\r");
+    }
+
+    @Test
+    @DisplayName("multiple operations generate correct sequence")
+    void multipleOperations() throws IOException {
+        backend.moveCursorUp(3);
+        backend.insertLines(2);
+        backend.moveCursorDown(1);
+        backend.eraseToEndOfLine();
+
+        String expected = "\u001b[3A" +  // Move up 3
+                         "\u001b[2L" +   // Insert 2 lines
+                         "\u001b[1B" +   // Move down 1
+                         "\u001b[K";     // Erase to EOL
+
+        assertThat(output.toString(StandardCharsets.UTF_8.name())).isEqualTo(expected);
+    }
+
+    /**
+     * Minimal Backend implementation for testing default methods.
+     */
+    private static class MinimalBackend implements Backend {
+        private final ByteArrayOutputStream output;
+
+        MinimalBackend(ByteArrayOutputStream output) {
+            this.output = output;
+        }
+
+        @Override
+        public void writeRaw(byte[] data) throws IOException {
+            output.write(data);
+        }
+
+        @Override
+        public void draw(Iterable<CellUpdate> updates) throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void flush() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void clear() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public Size size() throws IOException {
+            return new Size(80, 24);
+        }
+
+        @Override
+        public void showCursor() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void hideCursor() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public Position getCursorPosition() throws IOException {
+            return new Position(0, 0);
+        }
+
+        @Override
+        public void setCursorPosition(Position position) throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void enterAlternateScreen() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void leaveAlternateScreen() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void enableRawMode() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void disableRawMode() throws IOException {
+            // Not used in these tests
+        }
+
+        @Override
+        public void onResize(Runnable handler) {
+            // Not used in these tests
+        }
+
+        @Override
+        public int read(int timeoutMs) throws IOException {
+            return -1;
+        }
+
+        @Override
+        public int peek(int timeoutMs) throws IOException {
+            return -1;
+        }
+
+        @Override
+        public void close() throws IOException {
+            // Not used in these tests
+        }
+    }
+}

--- a/tamboui-core/src/testFixtures/java/dev/tamboui/terminal/TestBackend.java
+++ b/tamboui-core/src/testFixtures/java/dev/tamboui/terminal/TestBackend.java
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.terminal;
+
+import dev.tamboui.buffer.CellUpdate;
+import dev.tamboui.layout.Position;
+import dev.tamboui.layout.Size;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A test backend that captures all terminal operations for assertion.
+ * <p>
+ * Provides a higher-level DSL for verifying terminal behavior in tests:
+ * <pre>{@code
+ * TestBackend backend = new TestBackend(80, 24);
+ * // ... perform operations ...
+ * backend.assertOps()
+ *     .hasInsertLines(1)
+ *     .hasCursorUp(3)
+ *     .hasDeleteLines(2);
+ * }</pre>
+ */
+public class TestBackend implements Backend {
+
+    private final int width;
+    private final int height;
+    private final List<Op> ops = new ArrayList<>();
+    private final StringBuilder rawOutput = new StringBuilder();
+    private final List<Object> transcript = new ArrayList<>();
+
+    public TestBackend(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    /**
+     * Resets all captured operations and raw output.
+     */
+    public void reset() {
+        ops.clear();
+        rawOutput.setLength(0);
+        transcript.clear();
+    }
+
+    /**
+     * Returns the list of captured operations.
+     */
+    public List<Op> ops() {
+        return Collections.unmodifiableList(ops);
+    }
+
+    /**
+     * Returns the captured raw output.
+     */
+    public String rawOutput() {
+        return rawOutput.toString();
+    }
+
+    /**
+     * Returns the ordered transcript of all interactions (ops and raw writes).
+     * Elements are either {@link Op} instances or {@link String} instances (raw output).
+     */
+    public List<Object> transcript() {
+        return Collections.unmodifiableList(transcript);
+    }
+
+    /**
+     * Returns an assertion DSL for verifying operations.
+     */
+    public OpAssert assertOps() {
+        return new OpAssert(ops);
+    }
+
+    /**
+     * Returns an assertion DSL for verifying the transcript ordering.
+     */
+    public TranscriptAssert assertTranscript() {
+        return new TranscriptAssert(transcript);
+    }
+
+    // -- Backend implementation --
+
+    @Override
+    public void insertLines(int n) throws IOException {
+        Op op = new Op(OpType.INSERT_LINES, n);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void deleteLines(int n) throws IOException {
+        Op op = new Op(OpType.DELETE_LINES, n);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void moveCursorUp(int n) throws IOException {
+        Op op = new Op(OpType.CURSOR_UP, n);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void moveCursorDown(int n) throws IOException {
+        Op op = new Op(OpType.CURSOR_DOWN, n);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void moveCursorRight(int n) throws IOException {
+        Op op = new Op(OpType.CURSOR_RIGHT, n);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void moveCursorLeft(int n) throws IOException {
+        Op op = new Op(OpType.CURSOR_LEFT, n);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void eraseToEndOfLine() throws IOException {
+        Op op = new Op(OpType.ERASE_EOL, 0);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void carriageReturn() throws IOException {
+        Op op = new Op(OpType.CARRIAGE_RETURN, 0);
+        ops.add(op);
+        transcript.add(op);
+    }
+
+    @Override
+    public void writeRaw(byte[] data) throws IOException {
+        String s = new String(data);
+        rawOutput.append(s);
+        transcript.add(s);
+    }
+
+    @Override
+    public void draw(Iterable<CellUpdate> updates) throws IOException {
+    }
+
+    @Override
+    public void flush() throws IOException {
+    }
+
+    @Override
+    public void clear() throws IOException {
+    }
+
+    @Override
+    public Size size() throws IOException {
+        return new Size(width, height);
+    }
+
+    @Override
+    public void showCursor() throws IOException {
+        ops.add(new Op(OpType.SHOW_CURSOR, 0));
+    }
+
+    @Override
+    public void hideCursor() throws IOException {
+        ops.add(new Op(OpType.HIDE_CURSOR, 0));
+    }
+
+    @Override
+    public Position getCursorPosition() throws IOException {
+        return new Position(0, 0);
+    }
+
+    @Override
+    public void setCursorPosition(Position position) throws IOException {
+    }
+
+    @Override
+    public void enterAlternateScreen() throws IOException {
+    }
+
+    @Override
+    public void leaveAlternateScreen() throws IOException {
+    }
+
+    @Override
+    public void enableRawMode() throws IOException {
+    }
+
+    @Override
+    public void disableRawMode() throws IOException {
+    }
+
+    @Override
+    public void onResize(Runnable handler) {
+    }
+
+    @Override
+    public int read(int timeoutMs) throws IOException {
+        return -2;
+    }
+
+    @Override
+    public int peek(int timeoutMs) throws IOException {
+        return -2;
+    }
+
+    @Override
+    public void close() throws IOException {
+    }
+
+    // -- Structured operation types --
+
+    public enum OpType {
+        INSERT_LINES,
+        DELETE_LINES,
+        CURSOR_UP,
+        CURSOR_DOWN,
+        CURSOR_LEFT,
+        CURSOR_RIGHT,
+        ERASE_EOL,
+        CARRIAGE_RETURN,
+        SHOW_CURSOR,
+        HIDE_CURSOR
+    }
+
+    public static final class Op {
+        private final OpType type;
+        private final int count;
+
+        public Op(OpType type, int count) {
+            this.type = type;
+            this.count = count;
+        }
+
+        public OpType type() {
+            return type;
+        }
+
+        public int count() {
+            return count;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) { return true; }
+            if (!(o instanceof Op)) { return false; }
+            Op op = (Op) o;
+            return count == op.count && type == op.type;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * type.hashCode() + count;
+        }
+
+        @Override
+        public String toString() {
+            if (count == 0) {
+                return type.name();
+            }
+            return type.name() + "(" + count + ")";
+        }
+    }
+
+    /**
+     * Assertion DSL for verifying captured operations.
+     */
+    public static class OpAssert {
+        private final List<Op> ops;
+
+        OpAssert(List<Op> ops) {
+            this.ops = ops;
+        }
+
+        /**
+         * Asserts that an INSERT_LINES operation with the given count was recorded.
+         */
+        public OpAssert hasInsertLines(int n) {
+            assertContains(OpType.INSERT_LINES, n);
+            return this;
+        }
+
+        /**
+         * Asserts that a DELETE_LINES operation with the given count was recorded.
+         */
+        public OpAssert hasDeleteLines(int n) {
+            assertContains(OpType.DELETE_LINES, n);
+            return this;
+        }
+
+        /**
+         * Asserts that a CURSOR_UP operation with the given count was recorded.
+         */
+        public OpAssert hasCursorUp(int n) {
+            assertContains(OpType.CURSOR_UP, n);
+            return this;
+        }
+
+        /**
+         * Asserts that a CURSOR_DOWN operation with the given count was recorded.
+         */
+        public OpAssert hasCursorDown(int n) {
+            assertContains(OpType.CURSOR_DOWN, n);
+            return this;
+        }
+
+        /**
+         * Asserts that a CURSOR_RIGHT operation with the given count was recorded.
+         */
+        public OpAssert hasCursorRight(int n) {
+            assertContains(OpType.CURSOR_RIGHT, n);
+            return this;
+        }
+
+        /**
+         * Asserts that a CURSOR_LEFT operation with the given count was recorded.
+         */
+        public OpAssert hasCursorLeft(int n) {
+            assertContains(OpType.CURSOR_LEFT, n);
+            return this;
+        }
+
+        /**
+         * Asserts that an ERASE_EOL operation was recorded.
+         */
+        public OpAssert hasEraseEol() {
+            assertContains(OpType.ERASE_EOL, 0);
+            return this;
+        }
+
+        /**
+         * Asserts that a CARRIAGE_RETURN operation was recorded.
+         */
+        public OpAssert hasCarriageReturn() {
+            assertContains(OpType.CARRIAGE_RETURN, 0);
+            return this;
+        }
+
+        /**
+         * Asserts that no DELETE_LINES operations were recorded.
+         */
+        public OpAssert hasNoDeleteLines() {
+            assertNotContainsType(OpType.DELETE_LINES);
+            return this;
+        }
+
+        /**
+         * Asserts that a specific operation was NOT recorded.
+         */
+        public OpAssert hasNo(OpType type, int count) {
+            Op unexpected = new Op(type, count);
+            if (ops.contains(unexpected)) {
+                throw new AssertionError(
+                    "Unexpected operation " + unexpected + " found in: " + ops);
+            }
+            return this;
+        }
+
+        /**
+         * Asserts that no INSERT_LINES operations were recorded.
+         */
+        public OpAssert hasNoInsertLines() {
+            assertNotContainsType(OpType.INSERT_LINES);
+            return this;
+        }
+
+        /**
+         * Asserts that the total number of operations matches.
+         */
+        public OpAssert hasSize(int expected) {
+            if (ops.size() != expected) {
+                throw new AssertionError(
+                    "Expected " + expected + " operations, but got " + ops.size() + ": " + ops);
+            }
+            return this;
+        }
+
+        private void assertContains(OpType type, int count) {
+            Op expected = new Op(type, count);
+            if (!ops.contains(expected)) {
+                throw new AssertionError(
+                    "Expected operation " + expected + " not found in: " + ops);
+            }
+        }
+
+        private void assertNotContainsType(OpType type) {
+            for (Op op : ops) {
+                if (op.type() == type) {
+                    throw new AssertionError(
+                        "Expected no " + type + " operations, but found: " + op + " in: " + ops);
+                }
+            }
+        }
+    }
+
+    /**
+     * Assertion DSL for verifying the transcript ordering.
+     * <p>
+     * The transcript contains both {@link Op} instances and raw output {@link String}s
+     * in the order they were emitted. Assertions work with cumulative raw text to handle
+     * character-by-character writes (e.g., cell-by-cell rendering produces individual chars).
+     */
+    public static class TranscriptAssert {
+        private final List<Object> transcript;
+        private int position;
+
+        TranscriptAssert(List<Object> transcript) {
+            this.transcript = transcript;
+            this.position = 0;
+        }
+
+        /**
+         * Advances past entries until finding an op matching the given type and count.
+         * Fails if the end is reached without finding a match.
+         */
+        public TranscriptAssert expectEventually(OpType type, int count) {
+            Op expected = new Op(type, count);
+            for (int i = position; i < transcript.size(); i++) {
+                if (expected.equals(transcript.get(i))) {
+                    position = i + 1;
+                    return this;
+                }
+            }
+            throw new AssertionError(
+                "Expected " + expected + " not found after position " + position
+                    + " in transcript: " + formatTranscript());
+        }
+
+        /**
+         * Advances past entries until the cumulative raw text from current position
+         * contains the given text. Handles character-by-character writes.
+         */
+        public TranscriptAssert expectRawContaining(String text) {
+            StringBuilder accumulated = new StringBuilder();
+            for (int i = position; i < transcript.size(); i++) {
+                Object entry = transcript.get(i);
+                if (entry instanceof String) {
+                    accumulated.append((String) entry);
+                    if (accumulated.toString().contains(text)) {
+                        position = i + 1;
+                        return this;
+                    }
+                }
+            }
+            throw new AssertionError(
+                "Expected raw output containing \"" + escape(text) + "\" not found after position "
+                    + position + ". Accumulated raw: \"" + escape(accumulated.toString())
+                    + "\"\n  Transcript: " + formatTranscript());
+        }
+
+        /**
+         * Asserts that a specific Op appears BEFORE the cumulative raw output
+         * contains the given text. This validates output ordering.
+         */
+        public TranscriptAssert hasOpBefore(OpType type, int count, String rawText) {
+            Op expected = new Op(type, count);
+            int opIndex = -1;
+            int rawCompleteIndex = -1;
+            StringBuilder accumulated = new StringBuilder();
+
+            for (int i = 0; i < transcript.size(); i++) {
+                Object entry = transcript.get(i);
+                if (opIndex < 0 && expected.equals(entry)) {
+                    opIndex = i;
+                }
+                if (rawCompleteIndex < 0 && entry instanceof String) {
+                    accumulated.append((String) entry);
+                    if (accumulated.toString().contains(rawText)) {
+                        rawCompleteIndex = i;
+                    }
+                }
+                if (opIndex >= 0 && rawCompleteIndex >= 0) {
+                    break;
+                }
+            }
+
+            if (opIndex < 0) {
+                throw new AssertionError(
+                    "Operation " + expected + " not found in transcript: " + formatTranscript());
+            }
+            if (rawCompleteIndex < 0) {
+                throw new AssertionError(
+                    "Raw output containing \"" + escape(rawText)
+                        + "\" not found in transcript: " + formatTranscript());
+            }
+            if (opIndex >= rawCompleteIndex) {
+                throw new AssertionError(
+                    "Expected " + expected + " (at " + opIndex + ") to appear before raw \""
+                        + escape(rawText) + "\" (completed at " + rawCompleteIndex
+                        + ") in transcript: " + formatTranscript());
+            }
+            return this;
+        }
+
+        private String formatTranscript() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("[\n");
+            for (int i = 0; i < transcript.size(); i++) {
+                sb.append("  ").append(i).append(": ");
+                Object entry = transcript.get(i);
+                if (entry instanceof String) {
+                    sb.append("RAW(\"").append(escape((String) entry)).append("\")");
+                } else {
+                    sb.append(entry);
+                }
+                sb.append("\n");
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+
+        private static String escape(String s) {
+            return s.replace("\n", "\\n").replace("\r", "\\r").replace("\u001b", "\\e");
+        }
+    }
+}

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -204,6 +204,64 @@ public class JLineBackend implements Backend {
     }
 
     @Override
+    public void insertLines(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writer.print(CSI + n + "L");
+    }
+
+    @Override
+    public void deleteLines(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writer.print(CSI + n + "M");
+    }
+
+    @Override
+    public void moveCursorUp(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writer.print(CSI + n + "A");
+    }
+
+    @Override
+    public void moveCursorDown(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writer.print(CSI + n + "B");
+    }
+
+    @Override
+    public void moveCursorRight(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writer.print(CSI + n + "C");
+    }
+
+    @Override
+    public void moveCursorLeft(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        writer.print(CSI + n + "D");
+    }
+
+    @Override
+    public void eraseToEndOfLine() throws IOException {
+        writer.print(CSI + "K");
+    }
+
+    @Override
+    public void carriageReturn() throws IOException {
+        writer.print("\r");
+    }
+
+    @Override
     public void writeRaw(byte[] data) throws IOException {
         terminal.output().write(data);
     }

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -214,6 +214,64 @@ public class PanamaBackend implements Backend {
     }
 
     @Override
+    public void insertLines(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        outputBuffer.csi().appendInt(n).append((byte) 'L');
+    }
+
+    @Override
+    public void deleteLines(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        outputBuffer.csi().appendInt(n).append((byte) 'M');
+    }
+
+    @Override
+    public void moveCursorUp(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        outputBuffer.csi().appendInt(n).append((byte) 'A');
+    }
+
+    @Override
+    public void moveCursorDown(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        outputBuffer.csi().appendInt(n).append((byte) 'B');
+    }
+
+    @Override
+    public void moveCursorRight(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        outputBuffer.csi().appendInt(n).append((byte) 'C');
+    }
+
+    @Override
+    public void moveCursorLeft(int n) throws IOException {
+        if (n <= 0) {
+            return;
+        }
+        outputBuffer.csi().appendInt(n).append((byte) 'D');
+    }
+
+    @Override
+    public void eraseToEndOfLine() throws IOException {
+        outputBuffer.csi().append((byte) 'K');
+    }
+
+    @Override
+    public void carriageReturn() throws IOException {
+        outputBuffer.append((byte) '\r');
+    }
+
+    @Override
     public void onResize(Runnable handler) {
         terminal.onResize(handler);
     }
@@ -230,12 +288,12 @@ public class PanamaBackend implements Backend {
 
     @Override
     public void writeRaw(byte[] data) throws IOException {
-        terminal.write(data);
+        outputBuffer.append(data);
     }
 
     @Override
     public void writeRaw(String data) throws IOException {
-        terminal.write(data);
+        outputBuffer.appendUtf8(data);
     }
 
     @Override

--- a/tamboui-tfx-toolkit/demos/tfx-toolkit-demo/build.gradle.kts
+++ b/tamboui-tfx-toolkit/demos/tfx-toolkit-demo/build.gradle.kts
@@ -15,4 +15,6 @@ application {
 demo {
     displayName = "TFX Toolkit Integration Demo"
     tags = setOf("tfx", "effects", "animation", "toolkit")
+    // in docs, display the demo in the TFX section
+    module = "TFX"
 }

--- a/tamboui-tfx-tui/demos/tfx-tui-demo/build.gradle.kts
+++ b/tamboui-tfx-tui/demos/tfx-tui-demo/build.gradle.kts
@@ -15,4 +15,6 @@ application {
 demo {
     displayName = "TFX TUI Integration Demo"
     tags = setOf("tfx", "effects", "animation", "tui")
+    // in docs, display the demo in the TFX section
+    module = "TFX"
 }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/InlineToolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/InlineToolkit.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit;
+
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.elements.InlineScopeElement;
+
+/**
+ * DSL factory for inline-specific elements.
+ * <p>
+ * This class provides static factory methods for elements designed for
+ * inline display mode (non-alternate-screen rendering). Use these alongside
+ * the general-purpose methods in {@link Toolkit}.
+ *
+ * <pre>{@code
+ * import static dev.tamboui.toolkit.InlineToolkit.*;
+ * import static dev.tamboui.toolkit.Toolkit.*;
+ *
+ * Element ui = column(
+ *     text("Status: downloading").cyan(),
+ *     scope(downloading,
+ *         row(text("file1.zip: "), gauge(progress[0])),
+ *         row(text("file2.zip: "), gauge(progress[1]))
+ *     ),
+ *     text("Footer").dim()
+ * );
+ * }</pre>
+ *
+ * @see Toolkit
+ * @see InlineScopeElement
+ */
+public final class InlineToolkit {
+
+    private InlineToolkit() {
+    }
+
+    /**
+     * Creates an inline scope element with the given children.
+     * <p>
+     * A scope is a container that can be shown or hidden dynamically.
+     * When hidden, it collapses to zero height.
+     *
+     * <pre>{@code
+     * scope(
+     *     row(text("file1.zip: "), gauge(progress[0])),
+     *     row(text("file2.zip: "), gauge(progress[1]))
+     * ).visible(downloading)
+     * }</pre>
+     *
+     * @param children the child elements
+     * @return a new scope element
+     */
+    public static InlineScopeElement scope(Element... children) {
+        return new InlineScopeElement(children);
+    }
+
+    /**
+     * Creates an inline scope element with the given visibility and children.
+     * <p>
+     * Convenience method to set visibility at creation time.
+     *
+     * <pre>{@code
+     * scope(downloading,
+     *     row(text("file1.zip: "), gauge(progress[0])),
+     *     row(text("file2.zip: "), gauge(progress[1]))
+     * )
+     * }</pre>
+     *
+     * @param visible whether the scope is visible
+     * @param children the child elements
+     * @return a new scope element
+     */
+    public static InlineScopeElement scope(boolean visible, Element... children) {
+        return new InlineScopeElement(children).visible(visible);
+    }
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -30,7 +30,6 @@ import dev.tamboui.toolkit.elements.RichTextElement;
 import dev.tamboui.toolkit.elements.RichTextAreaElement;
 import dev.tamboui.toolkit.elements.MarkupTextElement;
 import dev.tamboui.toolkit.elements.MarkupTextAreaElement;
-import dev.tamboui.toolkit.elements.InlineScopeElement;
 import dev.tamboui.text.Text;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.style.Color;
@@ -923,45 +922,4 @@ public final class Toolkit {
         }
     }
 
-    // ==================== Inline Scope ====================
-
-    /**
-     * Creates an inline scope element with the given children.
-     * <p>
-     * A scope is a container that can be shown or hidden dynamically.
-     * When hidden, it collapses to zero height.
-     *
-     * <pre>{@code
-     * scope(
-     *     row(text("file1.zip: "), gauge(progress[0])),
-     *     row(text("file2.zip: "), gauge(progress[1]))
-     * ).visible(downloading)
-     * }</pre>
-     *
-     * @param children the child elements
-     * @return a new scope element
-     */
-    public static InlineScopeElement scope(Element... children) {
-        return new InlineScopeElement(children);
-    }
-
-    /**
-     * Creates an inline scope element with the given visibility and children.
-     * <p>
-     * Convenience method to set visibility at creation time.
-     *
-     * <pre>{@code
-     * scope(downloading,
-     *     row(text("file1.zip: "), gauge(progress[0])),
-     *     row(text("file2.zip: "), gauge(progress[1]))
-     * )
-     * }</pre>
-     *
-     * @param visible whether the scope is visible
-     * @param children the child elements
-     * @return a new scope element
-     */
-    public static InlineScopeElement scope(boolean visible, Element... children) {
-        return new InlineScopeElement(children).visible(visible);
-    }
 }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
@@ -139,6 +139,12 @@ public final class InlineToolkitRunner implements AutoCloseable {
                 // Get the current element tree
                 Element root = elementSupplier.get();
 
+                // Calculate and set content height for dynamic resizing
+                if (root != null) {
+                    int preferredHeight = root.preferredHeight(frame.area().width(), renderContext);
+                    tuiRunner.setContentHeight(preferredHeight);
+                }
+
                 // Render the element tree and register root for events
                 if (root != null) {
                     root.render(frame, frame.area(), renderContext);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/InlineScopeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/InlineScopeElement.java
@@ -35,6 +35,7 @@ import java.util.List;
  *
  * <h2>Example Usage</h2>
  * <pre>{@code
+ * import static dev.tamboui.toolkit.InlineToolkit.*;
  * import static dev.tamboui.toolkit.Toolkit.*;
  *
  * // State
@@ -65,7 +66,7 @@ import java.util.List;
  * }
  * }</pre>
  *
- * @see dev.tamboui.toolkit.Toolkit#scope(Element...)
+ * @see dev.tamboui.toolkit.InlineToolkit#scope(Element...)
  */
 public final class InlineScopeElement extends ContainerElement<InlineScopeElement> {
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/InlineScopeIntegrationTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/InlineScopeIntegrationTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit;
+
+import dev.tamboui.inline.InlineDisplay;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.TestBackend;
+import dev.tamboui.terminal.TestBackend.OpType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test for InlineDisplay dynamic resizing behavior
+ * when scopes collapse/expand.
+ */
+class InlineScopeIntegrationTest {
+
+    private TestBackend backend;
+
+    @BeforeEach
+    void setUp() {
+        backend = new TestBackend(80, 24);
+    }
+
+    @Test
+    @DisplayName("InlineDisplay resizes when scope collapses from 3 to 0 lines")
+    void inlineDisplayResizesOnScopeCollapse() throws IOException {
+        InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+        // Initial render with 3 lines
+        display.render((area, buf) -> {}, 3, -1, -1);
+
+        // Collapse to 0 lines
+        backend.reset();
+        display.render((area, buf) -> {}, 0, -1, -1);
+
+        // Should have deleted 3 lines when shrinking
+        backend.assertOps().hasDeleteLines(3);
+    }
+
+    @Test
+    @DisplayName("InlineDisplay resizes when scope expands from 0 to 3 lines")
+    void inlineDisplayResizesOnScopeExpand() throws IOException {
+        InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+        // Initial render with 0 lines (collapsed)
+        display.render((area, buf) -> {}, 0, -1, -1);
+
+        // Expand to 3 lines
+        backend.reset();
+        display.render((area, buf) -> {}, 3, -1, -1);
+
+        // Should have added lines (newlines in raw output) and moved cursor up
+        assertThat(backend.rawOutput()).contains("\n");
+        backend.assertOps().hasCursorUp(3);
+    }
+
+    @Test
+    @DisplayName("Rapid collapse and expand handles correctly")
+    void rapidCollapseExpandHandlesCorrectly() throws IOException {
+        InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+        // Start with 3 lines
+        display.render((area, buf) -> {}, 3, -1, -1);
+
+        // Collapse to 0
+        backend.reset();
+        display.render((area, buf) -> {}, 0, -1, -1);
+        backend.assertOps().hasDeleteLines(3);
+
+        // Expand to 3
+        backend.reset();
+        display.render((area, buf) -> {}, 3, -1, -1);
+        assertThat(backend.rawOutput()).contains("\n");
+
+        // Collapse to 0 again
+        backend.reset();
+        display.render((area, buf) -> {}, 0, -1, -1);
+        backend.assertOps().hasDeleteLines(3);
+    }
+
+    @Test
+    @DisplayName("Partial resize from 6 to 4 lines works correctly")
+    void partialResizeWorks() throws IOException {
+        InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+        // Start with 6 lines
+        display.render((area, buf) -> {}, 6, -1, -1);
+
+        // Shrink to 4 lines
+        backend.reset();
+        display.render((area, buf) -> {}, 4, -1, -1);
+
+        // Should delete 2 lines
+        backend.assertOps().hasDeleteLines(2);
+
+        // Grow back to 6
+        backend.reset();
+        display.render((area, buf) -> {}, 6, -1, -1);
+
+        // Should add 2 lines (newlines in raw output)
+        assertThat(backend.rawOutput()).contains("\n");
+    }
+
+    @Test
+    @DisplayName("Growing from non-zero height uses correct cursor positioning")
+    void growingFromNonZeroUsesCorrectCursorUp() throws IOException {
+        InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+        // Start with 3 lines
+        display.render((area, buf) -> {}, 3, -1, -1);
+
+        // Grow to 5 lines
+        backend.reset();
+        display.render((area, buf) -> {}, 5, -1, -1);
+
+        // Should NOT move cursor up by newHeight = 5 (off-by-one bug).
+        // Correct value is newHeight - 1 = 4 since cursor ends at line 4
+        // after moveCursorDown(2) + 2 newlines from line 2.
+        backend.assertOps()
+            .hasNo(OpType.CURSOR_UP, 5)
+            .hasCursorUp(4);
+    }
+
+    @Test
+    @DisplayName("Rendering same height does not resize")
+    void sameHeightDoesNotResize() throws IOException {
+        InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+        // Render at 3 lines
+        display.render((area, buf) -> {}, 3, -1, -1);
+
+        // Render again at 3 lines
+        backend.reset();
+        display.render((area, buf) -> {}, 3, -1, -1);
+
+        // Should not have any insert/delete operations
+        backend.assertOps()
+            .hasNoDeleteLines()
+            .hasNoInsertLines();
+    }
+
+    @Nested
+    @DisplayName("Rendering output ordering")
+    class RenderingOutputOrdering {
+
+        @Test
+        @DisplayName("Cursor positioned before content on initial render")
+        void cursorPositionedBeforeContent() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(3, 80, backend);
+
+            backend.reset();
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Hello", Style.EMPTY);
+                buf.setString(0, 1, "World", Style.EMPTY);
+            }, 2, -1, -1);
+
+            // CR must appear before content in the transcript
+            backend.assertTranscript()
+                .hasOpBefore(OpType.CARRIAGE_RETURN, 0, "Hello");
+        }
+
+        @Test
+        @DisplayName("Content on second line appears after newline")
+        void secondLineAfterNewline() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(3, 80, backend);
+
+            backend.reset();
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Line1", Style.EMPTY);
+                buf.setString(0, 1, "Line2", Style.EMPTY);
+            }, 2, -1, -1);
+
+            // In the transcript, newline must appear before Line2 content
+            backend.assertTranscript()
+                .expectRawContaining("Line1")
+                .expectRawContaining("\n")
+                .expectEventually(OpType.CARRIAGE_RETURN, 0)
+                .expectRawContaining("Line2");
+        }
+
+        @Test
+        @DisplayName("Repeated renders replace content correctly")
+        void repeatedRendersReplaceContent() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(3, 80, backend);
+
+            // First render
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "First", Style.EMPTY);
+            }, 1, -1, -1);
+
+            // Second render - should position cursor before writing
+            backend.reset();
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Second", Style.EMPTY);
+            }, 1, -1, -1);
+
+            // The transcript must show CR before the content of the second render
+            backend.assertTranscript()
+                .hasOpBefore(OpType.CARRIAGE_RETURN, 0, "Second");
+        }
+
+        @Test
+        @DisplayName("Multi-line render has correct ordering per line")
+        void multiLineRenderOrdering() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(4, 80, backend);
+
+            backend.reset();
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "AAA", Style.EMPTY);
+                buf.setString(0, 1, "BBB", Style.EMPTY);
+                buf.setString(0, 2, "CCC", Style.EMPTY);
+            }, 3, -1, -1);
+
+            // Verify ordering: CR → AAA → \n → CR → BBB → \n → CR → CCC
+            backend.assertTranscript()
+                .expectEventually(OpType.CARRIAGE_RETURN, 0)
+                .expectRawContaining("AAA")
+                .expectRawContaining("\n")
+                .expectEventually(OpType.CARRIAGE_RETURN, 0)
+                .expectRawContaining("BBB")
+                .expectRawContaining("\n")
+                .expectEventually(OpType.CARRIAGE_RETURN, 0)
+                .expectRawContaining("CCC");
+        }
+
+        @Test
+        @DisplayName("println inserts line before display content")
+        void printlnInsertsBeforeDisplay() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(3, 80, backend);
+
+            // Initial render
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Status", Style.EMPTY);
+            }, 1, -1, -1);
+
+            // Print above display
+            backend.reset();
+            display.println("Log message");
+
+            // Should: CR (go to line 0), INSERT_LINES, print message, then redraw
+            backend.assertTranscript()
+                .expectEventually(OpType.CARRIAGE_RETURN, 0)
+                .expectEventually(OpType.INSERT_LINES, 1)
+                .expectRawContaining("Log message");
+        }
+
+        @Test
+        @DisplayName("println followed by resize does not leave stale content")
+        void printlnFollowedByResizeNoStaleContent() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(6, 80, backend);
+
+            // Render with 6 lines
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Header", Style.EMPTY);
+                buf.setString(0, 5, "Footer", Style.EMPTY);
+            }, 6, -1, -1);
+
+            // println + shrink to 4 lines
+            display.println("Log entry");
+            backend.reset();
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Header", Style.EMPTY);
+                buf.setString(0, 3, "New Footer", Style.EMPTY);
+            }, 4, -1, -1);
+
+            // Should delete 2 lines when shrinking
+            backend.assertOps().hasDeleteLines(2);
+        }
+
+        @Test
+        @DisplayName("println with non-zero lastCursorY moves cursor up first")
+        void printlnWithNonZeroCursorMovesCursorUp() throws IOException {
+            InlineDisplay display = InlineDisplay.withBackend(3, 80, backend);
+
+            // Render with explicit cursor at line 2
+            display.render((area, buf) -> {
+                buf.setString(0, 0, "Line0", Style.EMPTY);
+                buf.setString(0, 2, "Line2", Style.EMPTY);
+            }, 3, 5, 2);
+
+            // Print above display - should move up from cursor position
+            backend.reset();
+            display.println("Message");
+
+            // Should move cursor up by 2 (lastCursorY) before inserting
+            backend.assertTranscript()
+                .expectEventually(OpType.CARRIAGE_RETURN, 0)
+                .expectEventually(OpType.CURSOR_UP, 2)
+                .expectEventually(OpType.INSERT_LINES, 1)
+                .expectRawContaining("Message");
+        }
+    }
+}

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2025 TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static dev.tamboui.toolkit.Toolkit.text;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InlineScopeElementTest {
+
+    @Test
+    @DisplayName("preferredHeight returns 0 when hidden")
+    void preferredHeightReturnsZeroWhenHidden() {
+        InlineScopeElement scope = new InlineScopeElement(
+            text("Line 1"),
+            text("Line 2"),
+            text("Line 3")
+        ).visible(false);
+
+        int height = scope.preferredHeight(80, RenderContext.empty());
+        assertThat(height).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight returns 0 when no children")
+    void preferredHeightReturnsZeroWhenNoChildren() {
+        InlineScopeElement scope = new InlineScopeElement();
+
+        int height = scope.preferredHeight(80, RenderContext.empty());
+        assertThat(height).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight sums children heights when visible")
+    void preferredHeightSumsChildrenWhenVisible() {
+        InlineScopeElement scope = new InlineScopeElement(
+            text("Line 1"),
+            text("Line 2"),
+            text("Line 3")
+        ).visible(true);
+
+        int height = scope.preferredHeight(80, RenderContext.empty());
+        // Each text element should have height 1
+        assertThat(height).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("show() sets visible to true")
+    void showSetsVisibleTrue() {
+        InlineScopeElement scope = new InlineScopeElement().visible(false);
+        scope.show();
+        assertThat(scope.isVisible()).isTrue();
+    }
+
+    @Test
+    @DisplayName("hide() sets visible to false")
+    void hideSetsVisibleFalse() {
+        InlineScopeElement scope = new InlineScopeElement().visible(true);
+        scope.hide();
+        assertThat(scope.isVisible()).isFalse();
+    }
+
+    @Test
+    @DisplayName("constraint returns zero height when hidden")
+    void constraintReturnsZeroHeightWhenHidden() {
+        InlineScopeElement scope = new InlineScopeElement(
+            text("Line 1"),
+            text("Line 2")
+        ).visible(false);
+
+        assertThat(scope.constraint().toString()).contains("Length[value=0]");
+    }
+
+    @Test
+    @DisplayName("toggling visibility changes preferred height")
+    void togglingVisibilityChangesPreferredHeight() {
+        InlineScopeElement scope = new InlineScopeElement(
+            text("Line 1"),
+            text("Line 2"),
+            text("Line 3")
+        );
+
+        // Initially visible (default)
+        int heightWhenVisible = scope.preferredHeight(80, RenderContext.empty());
+        assertThat(heightWhenVisible).isEqualTo(3);
+
+        // Hide
+        scope.hide();
+        int heightWhenHidden = scope.preferredHeight(80, RenderContext.empty());
+        assertThat(heightWhenHidden).isEqualTo(0);
+
+        // Show again
+        scope.show();
+        int heightWhenVisibleAgain = scope.preferredHeight(80, RenderContext.empty());
+        assertThat(heightWhenVisibleAgain).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("nested scopes calculate height correctly")
+    void nestedScopesCalculateHeightCorrectly() {
+        InlineScopeElement innerScope = new InlineScopeElement(
+            text("Inner line 1"),
+            text("Inner line 2")
+        );
+
+        InlineScopeElement outerScope = new InlineScopeElement(
+            text("Outer line 1"),
+            innerScope,
+            text("Outer line 3")
+        );
+
+        // Both visible: 1 + 2 + 1 = 4
+        int heightBothVisible = outerScope.preferredHeight(80, RenderContext.empty());
+        assertThat(heightBothVisible).isEqualTo(4);
+
+        // Hide inner scope: 1 + 0 + 1 = 2
+        innerScope.hide();
+        int heightInnerHidden = outerScope.preferredHeight(80, RenderContext.empty());
+        assertThat(heightInnerHidden).isEqualTo(2);
+
+        // Hide outer scope: 0
+        outerScope.hide();
+        int heightOuterHidden = outerScope.preferredHeight(80, RenderContext.empty());
+        assertThat(heightOuterHidden).isEqualTo(0);
+    }
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiRunner.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiRunner.java
@@ -261,6 +261,18 @@ public final class InlineTuiRunner implements AutoCloseable {
     }
 
     /**
+     * Sets the content height for the next draw.
+     * <p>
+     * This controls how many terminal lines are allocated for the inline display.
+     * Calling this before rendering allows the display to grow or shrink dynamically.
+     *
+     * @param height the desired content height in lines
+     */
+    public void setContentHeight(int height) {
+        viewport.setContentHeight(height);
+    }
+
+    /**
      * Executes an action on the render thread.
      * <p>
      * If called from the render thread, the action is executed immediately.


### PR DESCRIPTION
This commit refactors InlineDisplay to avoid the (ab)use of raw ascii escape sequences. Therefore, it expands the `Backend` API to introduce higher level abstractions. The `scope` inline toolkit mode was fixed accordingly, properly allowing lines to expand or collapse.

Test coverage was significantly improved, which highlighted a timing problem with the Panama backend (raw sequences could be written out of order).