### PR TITLE
feat: Generic element wrapping widgets

### DIFF
--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -696,6 +696,39 @@ barChart(10, 20, 30)
     .barColor(Color.BLUE)
 ----
 
+=== Wrapping Low-Level Widgets
+
+If you have a custom widget or a widget that doesn't yet have a dedicated Toolkit element, you can wrap it with `widget()`:
+
+[source,java]
+----
+// Wrap any Widget for use in the Toolkit DSL
+widget(myCustomWidget)
+    .addClass("custom")
+    .fill()
+
+// Use in layouts like any other element
+row(
+    widget(customWidget1).fill(),
+    widget(customWidget2).fill()
+)
+----
+
+This is only useful when:
+
+* You have a custom widget without a dedicated element wrapper
+* You want quick integration of a widget into the Toolkit DSL
+* You need to apply layout constraints, CSS classes, or event handlers to a widget
+
+**Limitations:**
+
+* **Styling does not propagate** - Colors and modifiers set on the element don't affect the widget's internal rendering.
+  The widget renders directly to the buffer using its own styling logic.
+* **No CSS child selectors** - GenericWidgetElement has no sub-components that can be styled via CSS.
+* **No preferred size** - The element doesn't know the widget's size requirements, so the container must specify constraints.
+
+For full styling support, consider creating a dedicated element wrapper for your widget type (see `TextElement` or `GaugeElement` as examples).
+
 === Using ToolkitRunner Directly
 
 `ToolkitApp` is convenient, but `ToolkitRunner` gives more control:

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -9,6 +9,7 @@ import dev.tamboui.toolkit.elements.BarChartElement;
 import dev.tamboui.toolkit.elements.CalendarElement;
 import dev.tamboui.toolkit.elements.CanvasElement;
 import dev.tamboui.toolkit.elements.ChartElement;
+import dev.tamboui.toolkit.elements.GenericWidgetElement;
 import dev.tamboui.toolkit.elements.Column;
 import dev.tamboui.toolkit.elements.DialogElement;
 import dev.tamboui.toolkit.elements.GaugeElement;
@@ -37,6 +38,7 @@ import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.widgets.input.TextAreaState;
 import dev.tamboui.widgets.input.TextInputState;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
+import dev.tamboui.widget.Widget;
 import dev.tamboui.tui.event.KeyEvent;
 
 import java.time.LocalDate;
@@ -873,6 +875,33 @@ public final class Toolkit {
      */
     public static ScrollbarElement scrollbar() {
         return new ScrollbarElement();
+    }
+
+    // ==================== Generic Widget ====================
+
+    /**
+     * Wraps any low-level {@link Widget} as a {@link GenericWidgetElement}.
+     * <p>
+     * This is useful when you need to use a widget that doesn't have a dedicated
+     * element wrapper, allowing it to participate in the toolkit's styling and layout system.
+     * <pre>{@code
+     * widget(someWidget)
+     *     .fg(Color.RED)
+     *     .addClass("custom-class")
+     *     .fill()
+     * }</pre>
+     * <p>
+     * Note: The styling applied to this element affects the element itself but may not
+     * propagate to the wrapped widget's internal rendering, as the widget renders directly
+     * to the buffer.
+     *
+     * @param <T> the type of the widget
+     * @param widget the widget to wrap
+     * @return a new generic widget element
+     * @throws IllegalArgumentException if widget is null
+     */
+    public static <T extends Widget> GenericWidgetElement<T> widget(T widget) {
+        return GenericWidgetElement.of(widget);
     }
 
     // ==================== Input Utilities ====================

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GenericWidgetElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GenericWidgetElement.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.element.StyledElement;
+import dev.tamboui.widget.Widget;
+
+/**
+ * A generic element that wraps any {@link Widget} and exposes it as a {@link StyledElement}.
+ * <p>
+ * This is useful when you need to use a widget that doesn't have a dedicated element wrapper,
+ * allowing it to participate in the toolkit's styling and layout system.
+ *
+ * <h2>When to Use</h2>
+ * <ul>
+ *   <li>You have a custom or third-party widget without a dedicated toolkit element</li>
+ *   <li>You need quick integration of a widget into the toolkit DSL</li>
+ *   <li>You want to apply layout constraints, CSS classes, or event handlers to a widget</li>
+ * </ul>
+ *
+ * <h2>Example Usage</h2>
+ * <pre>{@code
+ * // Wrap any widget
+ * GenericWidgetElement.of(someWidget)
+ *     .fg(Color.RED)
+ *     .addClass("custom-class")
+ *     .fill()
+ *
+ * // Or use the Toolkit DSL
+ * import static dev.tamboui.toolkit.Toolkit.*;
+ * widget(someWidget).bold()
+ * }</pre>
+ *
+ * <h2>Limitations</h2>
+ * <ul>
+ *   <li><strong>Styling does not propagate:</strong> Styles set on this element (colors, modifiers)
+ *       do not affect the widget's internal rendering. The widget renders directly to the buffer
+ *       using its own styling logic.</li>
+ *   <li><strong>No CSS child selectors:</strong> This element has no sub-components that can be
+ *       styled via CSS child selectors.</li>
+ *   <li><strong>No preferred size:</strong> This element does not implement {@code preferredWidth()}
+ *       or {@code preferredHeight()} since the wrapped widget's size requirements are unknown.</li>
+ * </ul>
+ * <p>
+ * For full styling support, consider creating a dedicated element wrapper for the specific widget type.
+ *
+ * @param <T> the type of the wrapped widget
+ */
+public final class GenericWidgetElement<T extends Widget> extends StyledElement<GenericWidgetElement<T>> {
+
+    private final T widget;
+
+    private GenericWidgetElement(T widget) {
+        if (widget == null) {
+            throw new IllegalArgumentException("Widget cannot be null");
+        }
+        this.widget = widget;
+    }
+
+    /**
+     * Creates a new GenericWidgetElement wrapping the given widget.
+     *
+     * @param <T> the type of the widget
+     * @param widget the widget to wrap
+     * @return a new GenericWidgetElement
+     * @throws IllegalArgumentException if widget is null
+     */
+    public static <T extends Widget> GenericWidgetElement<T> of(T widget) {
+        return new GenericWidgetElement<>(widget);
+    }
+
+    /**
+     * Creates a new GenericWidgetElement wrapping the given widget.
+     * <p>
+     * This is an alias for {@link #of(Widget)} intended for static imports.
+     *
+     * @param <T> the type of the widget
+     * @param widget the widget to wrap
+     * @return a new GenericWidgetElement
+     * @throws IllegalArgumentException if widget is null
+     */
+    public static <T extends Widget> GenericWidgetElement<T> widget(T widget) {
+        return new GenericWidgetElement<>(widget);
+    }
+
+    /**
+     * Returns the wrapped widget.
+     *
+     * @return the widget
+     */
+    public T widget() {
+        return widget;
+    }
+
+    @Override
+    protected void renderContent(Frame frame, Rect area, RenderContext context) {
+        frame.renderWidget(widget, area);
+    }
+}

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.widget.Widget;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for GenericWidgetElement.
+ */
+class GenericWidgetElementTest {
+
+    @Nested
+    @DisplayName("Factory methods")
+    class FactoryMethodTests {
+
+        @Test
+        @DisplayName("GenericWidgetElement.of() creates element")
+        void ofCreatesElement() {
+            Widget testWidget = (area, buffer) -> buffer.setString(0, 0, "Test", Style.EMPTY);
+
+            GenericWidgetElement<?> element = GenericWidgetElement.of(testWidget);
+
+            assertThat(element).isNotNull();
+            assertThat(element.widget()).isSameAs(testWidget);
+        }
+
+        @Test
+        @DisplayName("GenericWidgetElement.widget() creates element (alias)")
+        void widgetCreatesElement() {
+            Widget testWidget = (area, buffer) -> buffer.setString(0, 0, "Test", Style.EMPTY);
+
+            GenericWidgetElement<?> element = GenericWidgetElement.widget(testWidget);
+
+            assertThat(element).isNotNull();
+            assertThat(element.widget()).isSameAs(testWidget);
+        }
+
+        @Test
+        @DisplayName("Toolkit.widget() creates element")
+        void toolkitWidgetCreatesElement() {
+            Widget testWidget = (area, buffer) -> buffer.setString(0, 0, "Test", Style.EMPTY);
+
+            GenericWidgetElement<?> element = widget(testWidget);
+
+            assertThat(element).isNotNull();
+            assertThat(element.widget()).isSameAs(testWidget);
+        }
+
+        @Test
+        @DisplayName("of() throws on null widget")
+        void ofThrowsOnNull() {
+            assertThatThrownBy(() -> GenericWidgetElement.of(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Widget cannot be null");
+        }
+
+        @Test
+        @DisplayName("widget() throws on null widget")
+        void widgetThrowsOnNull() {
+            assertThatThrownBy(() -> GenericWidgetElement.widget(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Widget cannot be null");
+        }
+    }
+
+    @Nested
+    @DisplayName("Fluent API")
+    class FluentApiTests {
+
+        @Test
+        @DisplayName("Fluent API chains correctly")
+        void fluentApiChaining() {
+            Widget testWidget = (area, buffer) -> {};
+
+            GenericWidgetElement<?> element = widget(testWidget)
+                    .bold()
+                    .italic()
+                    .fg(Color.CYAN)
+                    .bg(Color.BLACK)
+                    .id("my-element")
+                    .addClass("custom-class")
+                    .fill();
+
+            assertThat(element).isInstanceOf(GenericWidgetElement.class);
+            assertThat(element.id()).isEqualTo("my-element");
+            assertThat(element.cssClasses()).contains("custom-class");
+            assertThat(element.constraint()).isEqualTo(Constraint.fill());
+        }
+
+        @Test
+        @DisplayName("Constraint methods work")
+        void constraintMethods() {
+            Widget testWidget = (area, buffer) -> {};
+
+            assertThat(widget(testWidget).length(10).constraint())
+                    .isEqualTo(Constraint.length(10));
+            assertThat(widget(testWidget).percent(50).constraint())
+                    .isEqualTo(Constraint.percentage(50));
+            assertThat(widget(testWidget).fill().constraint())
+                    .isEqualTo(Constraint.fill());
+            assertThat(widget(testWidget).fill(2).constraint())
+                    .isEqualTo(Constraint.fill(2));
+            assertThat(widget(testWidget).min(5).constraint())
+                    .isEqualTo(Constraint.min(5));
+            assertThat(widget(testWidget).max(20).constraint())
+                    .isEqualTo(Constraint.max(20));
+        }
+
+        @Test
+        @DisplayName("Focusable and event handlers work")
+        void focusableAndEventHandlers() {
+            Widget testWidget = (area, buffer) -> {};
+
+            GenericWidgetElement<?> element = widget(testWidget)
+                    .focusable()
+                    .onKeyEvent(event -> dev.tamboui.toolkit.event.EventResult.HANDLED)
+                    .onMouseEvent(event -> dev.tamboui.toolkit.event.EventResult.HANDLED);
+
+            assertThat(element.isFocusable()).isTrue();
+            assertThat(element.keyEventHandler()).isNotNull();
+            assertThat(element.mouseEventHandler()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Rendering")
+    class RenderingTests {
+
+        @Test
+        @DisplayName("Renders wrapped widget to buffer")
+        void rendersWidgetToBuffer() {
+            Widget testWidget = (area, buffer) -> {
+                buffer.setString(area.x(), area.y(), "Hello", Style.EMPTY);
+            };
+
+            Rect area = new Rect(0, 0, 20, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            widget(testWidget).render(frame, area, RenderContext.empty());
+
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("H");
+            assertThat(buffer.get(1, 0).symbol()).isEqualTo("e");
+            assertThat(buffer.get(2, 0).symbol()).isEqualTo("l");
+            assertThat(buffer.get(3, 0).symbol()).isEqualTo("l");
+            assertThat(buffer.get(4, 0).symbol()).isEqualTo("o");
+        }
+
+        @Test
+        @DisplayName("Widget receives correct area")
+        void widgetReceivesCorrectArea() {
+            Rect expectedArea = new Rect(5, 3, 10, 5);
+            Rect[] capturedArea = new Rect[1];
+
+            Widget testWidget = (area, buffer) -> {
+                capturedArea[0] = area;
+            };
+
+            Buffer buffer = Buffer.empty(new Rect(0, 0, 20, 10));
+            Frame frame = Frame.forTesting(buffer);
+
+            widget(testWidget).render(frame, expectedArea, RenderContext.empty());
+
+            assertThat(capturedArea[0]).isEqualTo(expectedArea);
+        }
+
+        @Test
+        @DisplayName("Empty area does not render")
+        void emptyAreaNoRender() {
+            boolean[] rendered = {false};
+            Widget testWidget = (area, buffer) -> rendered[0] = true;
+
+            Rect emptyArea = new Rect(0, 0, 0, 0);
+            Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+            Frame frame = Frame.forTesting(buffer);
+
+            widget(testWidget).render(frame, emptyArea, RenderContext.empty());
+
+            assertThat(rendered[0]).isFalse();
+        }
+
+        @Test
+        @DisplayName("Widget with custom styling renders")
+        void widgetWithCustomStyling() {
+            Widget testWidget = (area, buffer) -> {
+                buffer.setString(area.x(), area.y(), "X", Style.EMPTY.fg(Color.GREEN));
+            };
+
+            Rect area = new Rect(0, 0, 10, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            // Element styling doesn't override widget's internal styling
+            widget(testWidget)
+                    .fg(Color.RED)  // This won't affect widget's internal rendering
+                    .render(frame, area, RenderContext.empty());
+
+            // Widget renders with its own style (GREEN)
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("X");
+            assertThat(buffer.get(0, 0).style().fg()).contains(Color.GREEN);
+        }
+    }
+
+    @Nested
+    @DisplayName("Layout integration")
+    class LayoutIntegrationTests {
+
+        @Test
+        @DisplayName("Works inside row")
+        void worksInsideRow() {
+            Widget leftWidget = (area, buffer) -> buffer.setString(area.x(), area.y(), "L", Style.EMPTY);
+            Widget rightWidget = (area, buffer) -> buffer.setString(area.x(), area.y(), "R", Style.EMPTY);
+
+            Rect area = new Rect(0, 0, 20, 1);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            row(
+                    widget(leftWidget).fill(),
+                    widget(rightWidget).fill()
+            ).render(frame, area, RenderContext.empty());
+
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("L");
+            assertThat(buffer.get(10, 0).symbol()).isEqualTo("R");
+        }
+
+        @Test
+        @DisplayName("Works inside column")
+        void worksInsideColumn() {
+            Widget topWidget = (area, buffer) -> buffer.setString(area.x(), area.y(), "T", Style.EMPTY);
+            Widget bottomWidget = (area, buffer) -> buffer.setString(area.x(), area.y(), "B", Style.EMPTY);
+
+            Rect area = new Rect(0, 0, 10, 4);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            column(
+                    widget(topWidget).length(2),
+                    widget(bottomWidget).length(2)
+            ).render(frame, area, RenderContext.empty());
+
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("T");
+            assertThat(buffer.get(0, 2).symbol()).isEqualTo("B");
+        }
+
+        @Test
+        @DisplayName("Works inside panel")
+        void worksInsidePanel() {
+            Widget contentWidget = (area, buffer) ->
+                    buffer.setString(area.x(), area.y(), "Content", Style.EMPTY);
+
+            Rect area = new Rect(0, 0, 20, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            panel("Title", widget(contentWidget))
+                    .render(frame, area, RenderContext.empty());
+
+            // Content should be inside the panel (after border)
+            assertThat(buffer.get(1, 1).symbol()).isEqualTo("C");
+        }
+
+        @Test
+        @DisplayName("Default constraint is null")
+        void defaultConstraintIsNull() {
+            Widget testWidget = (area, buffer) -> {};
+
+            assertThat(widget(testWidget).constraint()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("CSS support")
+    class CssSupportTests {
+
+        @Test
+        @DisplayName("Style type is GenericWidgetElement")
+        void styleType() {
+            Widget testWidget = (area, buffer) -> {};
+
+            GenericWidgetElement<?> element = widget(testWidget);
+
+            assertThat(element.styleType()).isEqualTo("GenericWidgetElement");
+        }
+
+        @Test
+        @DisplayName("CSS classes can be added")
+        void cssClasses() {
+            Widget testWidget = (area, buffer) -> {};
+
+            GenericWidgetElement<?> element = widget(testWidget)
+                    .addClass("primary", "highlighted");
+
+            assertThat(element.cssClasses()).containsExactlyInAnyOrder("primary", "highlighted");
+        }
+
+        @Test
+        @DisplayName("CSS ID can be set")
+        void cssId() {
+            Widget testWidget = (area, buffer) -> {};
+
+            GenericWidgetElement<?> element = widget(testWidget).id("my-widget");
+
+            assertThat(element.cssId()).contains("my-widget");
+        }
+
+        @Test
+        @DisplayName("Style attributes can be set")
+        void styleAttributes() {
+            Widget testWidget = (area, buffer) -> {};
+
+            GenericWidgetElement<?> element = widget(testWidget)
+                    .attr("data-type", "custom")
+                    .attr("data-index", "5");
+
+            assertThat(element.styleAttributes())
+                    .containsEntry("data-type", "custom")
+                    .containsEntry("data-index", "5");
+        }
+    }
+}


### PR DESCRIPTION
Sometimes you may have a Widget at hand that you want to integrate, but toolkit has no support for it. This commit makes it possible to use any widget like that directly, with some documented limitations.