### PR TITLE
fix: Remove hard limit on viewport

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/inline/InlineDisplay.java
+++ b/tamboui-core/src/main/java/dev/tamboui/inline/InlineDisplay.java
@@ -517,9 +517,8 @@ public final class InlineDisplay implements AutoCloseable {
      * @param newHeight the new height in lines
      */
     private void resizeDisplay(int newHeight) {
-        if (newHeight < 0 || newHeight > height) {
-            // Clamp to valid range
-            newHeight = Math.max(0, Math.min(newHeight, height));
+        if (newHeight < 0) {
+            newHeight = 0;
         }
 
         if (newHeight == currentHeight) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineApp.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineApp.java
@@ -21,11 +21,6 @@ import dev.tamboui.tui.InlineTuiConfig;
  *     private double progress = 0.0;
  *
  *     @Override
- *     protected int height() {
- *         return 3;
- *     }
- *
- *     @Override
  *     protected Element render() {
  *         return column(
  *             waveText("Installing packages...").cyan(),
@@ -61,13 +56,17 @@ public abstract class InlineApp {
     private InlineToolkitRunner runner;
 
     /**
-     * Returns the height of the inline display in lines.
+     * Returns the initial height of the inline display in lines.
      * <p>
-     * Override this method to specify the display height.
+     * The display will automatically grow beyond this if the content
+     * requires more space. Override this method to specify a starting height.
+     * The default is 1 line.
      *
-     * @return the display height
+     * @return the initial display height
      */
-    protected abstract int height();
+    protected int height() {
+        return 1;
+    }
 
     /**
      * Renders the application UI.

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineViewport.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineViewport.java
@@ -23,9 +23,9 @@ import java.util.function.Consumer;
 final class InlineViewport {
 
     private final InlineDisplay display;
-    private final Buffer buffer;
-    private final Rect area;
-    private final Frame frame;
+    private Buffer buffer;
+    private Rect area;
+    private Frame frame;
     private int contentHeight;  // Current content height to allocate
 
     /**
@@ -38,7 +38,7 @@ final class InlineViewport {
         this.area = Rect.of(display.width(), display.height());
         this.buffer = Buffer.empty(area);
         this.frame = Frame.forTesting(buffer);
-        this.contentHeight = display.height();  // Default to full height
+        this.contentHeight = display.height();  // Default to initial height
     }
 
     /**
@@ -73,12 +73,20 @@ final class InlineViewport {
      * <p>
      * This determines how many terminal lines will be allocated
      * for the inline display. The display will grow or shrink
-     * accordingly on the next draw() call.
+     * accordingly on the next draw() call. If the requested height
+     * exceeds the current buffer size, the buffer is resized.
      *
      * @param height the desired content height in lines
      */
     void setContentHeight(int height) {
-        this.contentHeight = Math.max(0, Math.min(height, area.height()));
+        height = Math.max(0, height);
+        // Grow buffer if needed
+        if (height > area.height()) {
+            this.area = Rect.of(area.width(), height);
+            this.buffer = Buffer.empty(area);
+            this.frame = Frame.forTesting(buffer);
+        }
+        this.contentHeight = height;
     }
 
     /**


### PR DESCRIPTION
This simplifies the InlineViewport so that it can dynamically grow. Before this change it was clamped to the initial inline area height, but it didn't have to.