### PR TITLE
feat: Make base colors overridable

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/style/Modifier.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Modifier.java
@@ -8,6 +8,7 @@ package dev.tamboui.style;
  * Text style modifiers (SGR attributes).
  */
 public enum Modifier {
+    NORMAL(0),
     BOLD(1),
     DIM(2),
     ITALIC(3),
@@ -32,28 +33,15 @@ public enum Modifier {
     }
 
     /**
-     * Returns the ANSI SGR code to disable this modifier.
+     * Returns the implicit style name for this modifier.
+     * <p>
+     * Maps each modifier to the conventional style name used
+     * for style resolution (e.g., BOLD → "bold", CROSSED_OUT → "strikethrough").
+     *
+     * @return the style name
      */
-    public int resetCode() {
-        switch (this) {
-            case BOLD:
-            case DIM:
-                return 22;  // Both reset by 22
-            case ITALIC:
-                return 23;
-            case UNDERLINED:
-                return 24;
-            case SLOW_BLINK:
-            case RAPID_BLINK:
-                return 25;
-            case REVERSED:
-                return 27;
-            case HIDDEN:
-                return 28;
-            case CROSSED_OUT:
-                return 29;
-            default:
-                return 0;
-        }
+    public String implicitStyleName() {
+        return name().toLowerCase().replace('_', '-');
     }
+
 }

--- a/tamboui-core/src/main/java/dev/tamboui/style/ModifierConverter.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/ModifierConverter.java
@@ -40,6 +40,7 @@ public final class ModifierConverter implements PropertyConverter<Set<Modifier>>
         MODIFIER_MAP.put("bold", Modifier.BOLD);
         MODIFIER_MAP.put("dim", Modifier.DIM);
         MODIFIER_MAP.put("italic", Modifier.ITALIC);
+        MODIFIER_MAP.put("normal", Modifier.NORMAL);
         MODIFIER_MAP.put("underlined", Modifier.UNDERLINED);
         MODIFIER_MAP.put("underline", Modifier.UNDERLINED);
         MODIFIER_MAP.put("reversed", Modifier.REVERSED);

--- a/tamboui-core/src/main/java/dev/tamboui/style/Style.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Style.java
@@ -7,9 +7,11 @@ package dev.tamboui.style;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A complete style definition including foreground, background, and modifiers.
@@ -530,6 +532,29 @@ public final class Style {
      */
     public EnumSet<Modifier> subModifiers() {
         return EnumSet.copyOf(subModifiers);
+    }
+
+    /**
+     * Returns the style names implied by this style's Named colors and modifiers.
+     * <p>
+     * Named foreground colors contribute their name (e.g., "red"),
+     * Named background colors contribute "bg-" + name (e.g., "bg-red"),
+     * and modifiers contribute their {@link Modifier#implicitStyleName()} (e.g., "bold").
+     *
+     * @return an unmodifiable set of implied CSS class names
+     */
+    public Set<String> implicitStyleNames() {
+        Set<String> classes = new LinkedHashSet<>();
+        if (fg instanceof Color.Named) {
+            classes.add(((Color.Named) fg).name());
+        }
+        if (bg instanceof Color.Named) {
+            classes.add("bg-" + ((Color.Named) bg).name());
+        }
+        for (Modifier mod : addModifiers) {
+            classes.add(mod.implicitStyleName());
+        }
+        return Collections.unmodifiableSet(classes);
     }
 
     @Override

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/AnsiStringBuilder.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/AnsiStringBuilder.java
@@ -94,7 +94,10 @@ public final class AnsiStringBuilder {
      * @return the ANSI code string (without CSI prefix or 'm' suffix)
      */
     public static String colorToAnsiForeground(Color color) {
-        if (color instanceof Color.Reset) {
+        if (color instanceof Color.Named) {
+            // Named colors delegate to their default value
+            return colorToAnsiForeground(((Color.Named) color).defaultValue());
+        } else if (color instanceof Color.Reset) {
             return "39";
         } else if (color instanceof Color.Ansi) {
             AnsiColor c = ((Color.Ansi) color).color();
@@ -116,7 +119,10 @@ public final class AnsiStringBuilder {
      * @return the ANSI code string (without CSI prefix or 'm' suffix)
      */
     public static String colorToAnsiBackground(Color color) {
-        if (color instanceof Color.Reset) {
+        if (color instanceof Color.Named) {
+            // Named colors delegate to their default value
+            return colorToAnsiBackground(((Color.Named) color).defaultValue());
+        } else if (color instanceof Color.Reset) {
             return "49";
         } else if (color instanceof Color.Ansi) {
             AnsiColor c = ((Color.Ansi) color).color();
@@ -140,7 +146,10 @@ public final class AnsiStringBuilder {
      *         or empty string if the color type doesn't support underline coloring
      */
     public static String underlineColorToAnsi(Color color) {
-        if (color instanceof Color.Indexed) {
+        if (color instanceof Color.Named) {
+            // Named colors delegate to their default value
+            return underlineColorToAnsi(((Color.Named) color).defaultValue());
+        } else if (color instanceof Color.Indexed) {
             int idx = ((Color.Indexed) color).index();
             return "58;5;" + idx;
         } else if (color instanceof Color.Rgb) {

--- a/tamboui-core/src/test/java/dev/tamboui/style/ColorTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/style/ColorTest.java
@@ -12,13 +12,22 @@ import static org.assertj.core.api.Assertions.*;
 class ColorTest {
 
     @Test
-    @DisplayName("Color constants are Ansi colors")
+    @DisplayName("Color constants are Named colors with Ansi defaults")
     void colorConstants() {
-        assertThat(Color.RED).isInstanceOf(Color.Ansi.class);
-        assertThat(Color.GREEN).isInstanceOf(Color.Ansi.class);
-        assertThat(Color.BLUE).isInstanceOf(Color.Ansi.class);
-        assertThat(Color.BLACK).isInstanceOf(Color.Ansi.class);
-        assertThat(Color.WHITE).isInstanceOf(Color.Ansi.class);
+        assertThat(Color.RED).isInstanceOf(Color.Named.class);
+        assertThat(Color.GREEN).isInstanceOf(Color.Named.class);
+        assertThat(Color.BLUE).isInstanceOf(Color.Named.class);
+        assertThat(Color.BLACK).isInstanceOf(Color.Named.class);
+        assertThat(Color.WHITE).isInstanceOf(Color.Named.class);
+
+        // Verify named colors have correct CSS class names
+        assertThat(((Color.Named) Color.RED).name()).isEqualTo("red");
+        assertThat(((Color.Named) Color.GREEN).name()).isEqualTo("green");
+        assertThat(((Color.Named) Color.BLUE).name()).isEqualTo("blue");
+
+        // Verify named colors have Ansi defaults
+        assertThat(((Color.Named) Color.RED).defaultValue()).isInstanceOf(Color.Ansi.class);
+        assertThat(((Color.Named) Color.GREEN).defaultValue()).isInstanceOf(Color.Ansi.class);
     }
 
     @Test
@@ -66,5 +75,16 @@ class ColorTest {
         Color color = Color.indexed(128);
         assertThat(color).isInstanceOf(Color.Indexed.class);
         assertThat(((Color.Indexed) color).index()).isEqualTo(128);
+    }
+
+    @Test
+    @DisplayName("Named color converts to RGB via its default value")
+    void namedColorToRgb() {
+        Color.Named red = (Color.Named) Color.RED;
+        Color.Rgb rgb = red.toRgb();
+        // RED's default is Ansi RED which converts to (170, 0, 0)
+        assertThat(rgb.r()).isEqualTo(170);
+        assertThat(rgb.g()).isEqualTo(0);
+        assertThat(rgb.b()).isEqualTo(0);
     }
 }

--- a/tamboui-core/src/testFixtures/java/dev/tamboui/assertj/BufferDiffFormatter.java
+++ b/tamboui-core/src/testFixtures/java/dev/tamboui/assertj/BufferDiffFormatter.java
@@ -165,7 +165,9 @@ final class BufferDiffFormatter {
         if (color == null) {
             return "Reset";
         }
-        if (color instanceof Color.Reset) {
+        if (color instanceof Color.Named) {
+            return ((Color.Named) color).name();
+        } else if (color instanceof Color.Reset) {
             return "Reset";
         } else if (color instanceof Color.Ansi) {
             return ((Color.Ansi) color).color().name();

--- a/tamboui-css/src/main/java/dev/tamboui/css/engine/StyleEngine.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/engine/StyleEngine.java
@@ -340,16 +340,26 @@ public final class StyleEngine {
     private List<Rule> collectRules() {
         List<Rule> rules = new ArrayList<>();
 
+        // Assign global source order so rules from later stylesheets
+        // always win over earlier ones with the same specificity.
+        // Each stylesheet's rules are parsed with per-stylesheet source orders
+        // starting from 0, so we renumber them globally here.
+        int globalOrder = 0;
+
         // Add rules from inline stylesheets
         for (Stylesheet stylesheet : inlineStylesheets) {
-            rules.addAll(stylesheet.rules());
+            for (Rule rule : stylesheet.rules()) {
+                rules.add(new Rule(rule.selector(), rule.declarations(), globalOrder++));
+            }
         }
 
         // Add rules from active named stylesheet
         if (activeStylesheetName != null) {
             StylesheetEntry entry = namedStylesheets.get(activeStylesheetName);
             if (entry != null) {
-                rules.addAll(entry.stylesheet().rules());
+                for (Rule rule : entry.stylesheet().rules()) {
+                    rules.add(new Rule(rule.selector(), rule.declarations(), globalOrder++));
+                }
             }
         }
 

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -369,7 +369,9 @@ public class JLineBackend implements Backend {
     }
 
     private String colorToAnsi(Color color, boolean foreground) {
-        if (color instanceof Color.Reset) {
+        if (color instanceof Color.Named) {
+            return colorToAnsi(((Color.Named) color).defaultValue(), foreground);
+        } else if (color instanceof Color.Reset) {
             return foreground ? "39" : "49";
         } else if (color instanceof Color.Ansi) {
             AnsiColor c = ((Color.Ansi) color).color();
@@ -385,7 +387,9 @@ public class JLineBackend implements Backend {
     }
 
     private String underlineColorToAnsi(Color color) {
-        if (color instanceof Color.Indexed) {
+        if (color instanceof Color.Named) {
+            return underlineColorToAnsi(((Color.Named) color).defaultValue());
+        } else if (color instanceof Color.Indexed) {
             int idx = ((Color.Indexed) color).index();
             return "58;5;" + idx;
         } else if (color instanceof Color.Rgb) {

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -383,7 +383,9 @@ public class PanamaBackend implements Backend {
     }
 
     private void appendColorToAnsi(Color color, boolean foreground) {
-        if (color instanceof Color.Reset) {
+        if (color instanceof Color.Named named) {
+            appendColorToAnsi(named.defaultValue(), foreground);
+        } else if (color instanceof Color.Reset) {
             outputBuffer.appendInt(foreground ? 39 : 49);
         } else if (color instanceof Color.Ansi ansi) {
             outputBuffer.appendInt(foreground ? ansi.color().fgCode() : ansi.color().bgCode());
@@ -403,7 +405,10 @@ public class PanamaBackend implements Backend {
     }
 
     private void appendUnderlineColorToAnsi(Color color) {
-        if (color instanceof Color.Indexed indexed) {
+        if (color instanceof Color.Named named) {
+            appendUnderlineColorToAnsi(named.defaultValue());
+            return;
+        } else if (color instanceof Color.Indexed indexed) {
             outputBuffer.appendAscii("58;5;").appendInt(indexed.index());
         } else if (color instanceof Color.Rgb rgb) {
             outputBuffer.appendAscii("58;2;")

--- a/tamboui-tfx/src/main/java/dev/tamboui/tfx/TFxColorSpace.java
+++ b/tamboui-tfx/src/main/java/dev/tamboui/tfx/TFxColorSpace.java
@@ -171,7 +171,9 @@ public enum TFxColorSpace {
      * Converts a color to RGB components [r, g, b].
      */
     int[] toRgbComponents(Color color) {
-        if (color instanceof Color.Rgb) {
+        if (color instanceof Color.Named) {
+            return toRgbComponents(((Color.Named) color).defaultValue());
+        } else if (color instanceof Color.Rgb) {
             Color.Rgb rgb = (Color.Rgb) color;
             return new int[]{rgb.r(), rgb.g(), rgb.b()};
         } else if (color instanceof Color.Ansi) {

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/NamedColorCssOverrideTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/NamedColorCssOverrideTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.buffer.Cell;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.DefaultRenderContext;
+import dev.tamboui.toolkit.elements.TextElement;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test that verifies CSS can override programmatic named colors.
+ * <p>
+ * When code uses {@code .red()} or {@code .fg(Color.RED)}, a CSS class "red" is added.
+ * Theme stylesheets should be able to override the color via {@code .red { color: #FF5555; }}.
+ */
+class NamedColorCssOverrideTest {
+
+    private static final Rect AREA = new Rect(0, 0, 10, 1);
+
+    private Cell renderAndGetFirst(String text, TextElement element, String... cssRules) {
+        StyleEngine styleEngine = StyleEngine.create();
+        for (String css : cssRules) {
+            styleEngine.addStylesheet(css);
+        }
+        DefaultRenderContext context = DefaultRenderContext.createEmpty();
+        context.setStyleEngine(styleEngine);
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 80, 24));
+        Frame frame = Frame.forTesting(buffer);
+
+        element.render(frame, AREA, context);
+        return buffer.get(0, 0);
+    }
+
+    @Test
+    void cssClassSelectorOverridesNamedForegroundColor() {
+        TextElement text = new TextElement("Error").red();
+        Cell cell = renderAndGetFirst("Error", text, ".red { color: #FF5555; }");
+
+        assertThat(cell.style().fg()).isPresent();
+        assertThat(cell.style().fg().get()).isInstanceOf(Color.Rgb.class);
+        Color.Rgb fg = (Color.Rgb) cell.style().fg().get();
+        assertThat(fg.r()).isEqualTo(0xFF);
+        assertThat(fg.g()).isEqualTo(0x55);
+        assertThat(fg.b()).isEqualTo(0x55);
+    }
+
+    @Test
+    void cssClassSelectorOverridesNamedBackgroundColor() {
+        TextElement text = new TextElement("Alert").onRed();
+        Cell cell = renderAndGetFirst("Alert", text, ".bg-red { background: #CC0000; }");
+
+        assertThat(cell.style().bg()).isPresent();
+        assertThat(cell.style().bg().get()).isInstanceOf(Color.Rgb.class);
+        Color.Rgb bg = (Color.Rgb) cell.style().bg().get();
+        assertThat(bg.r()).isEqualTo(0xCC);
+        assertThat(bg.g()).isEqualTo(0x00);
+        assertThat(bg.b()).isEqualTo(0x00);
+    }
+
+    @Test
+    void genericCssRuleOverridesNamedColor() {
+        // Named colors are "soft" — CSS always wins (standard CSS behavior)
+        TextElement text = new TextElement("Error").red();
+        Cell cell = renderAndGetFirst("Error", text, "* { color: white; }");
+
+        // CSS white overrides the Named red
+        assertThat(cell.style().fg()).isPresent();
+        Color fg = cell.style().fg().get();
+        assertThat(fg).isInstanceOf(Color.Named.class);
+        assertThat(((Color.Named) fg).name()).isEqualTo("white");
+    }
+
+    @Test
+    void namedColorFallsBackToAnsiWithoutCss() {
+        // Without any CSS engine, Named colors render as their ANSI default
+        TextElement text = new TextElement("Error").red();
+        DefaultRenderContext context = DefaultRenderContext.createEmpty();
+        // No style engine set
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 80, 24));
+        Frame frame = Frame.forTesting(buffer);
+
+        text.render(frame, AREA, context);
+
+        Cell cell = buffer.get(0, 0);
+        assertThat(cell.style().fg()).isPresent();
+        Color fg = cell.style().fg().get();
+        // Should be the Named red (which delegates to ANSI red for rendering)
+        assertThat(fg).isInstanceOf(Color.Named.class);
+        assertThat(((Color.Named) fg).name()).isEqualTo("red");
+    }
+
+    @Test
+    void explicitRgbColorStillOverridesCss() {
+        // Explicit non-Named colors should still override CSS
+        TextElement text = new TextElement("Custom").fg(Color.rgb(1, 2, 3));
+        Cell cell = renderAndGetFirst("Custom", text, "* { color: white; }");
+
+        assertThat(cell.style().fg()).isPresent();
+        assertThat(cell.style().fg().get()).isInstanceOf(Color.Rgb.class);
+        Color.Rgb fg = (Color.Rgb) cell.style().fg().get();
+        assertThat(fg.r()).isEqualTo(1);
+        assertThat(fg.g()).isEqualTo(2);
+        assertThat(fg.b()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
This commit makes it possible to override the default colors using a style engine (typically CSS). While it may sound weird, it allows for example overriding `red` to blue, etc. This is interesting for several use cases:

- accessibility, where we'd want users to change the default theme for daltonism or other visual deficiences
- theming, where we simply want to be able to override the styles, but even for widgets which use base ANSI colors

The goal of this commit is to avoid an independent "Theme" which would introduce a redundancy with the CSS styling. Instead, it tries to normalize regular styles by giving them names. For example, you can disable dimming by doing:

```
.dim {
   text-style: normal;
}
```

This works because default styles are mapped to style names.

Side note: if you use a named color on the right-hand side of the style, e.g:

```
   color: blue;
```

then `blue` doesn't refer to a style, but to a color.
