### PR TITLE
fix: Inline viewport height

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
@@ -139,10 +139,14 @@ public final class InlineToolkitRunner implements AutoCloseable {
                 // Get the current element tree
                 Element root = elementSupplier.get();
 
-                // Calculate and set content height for dynamic resizing
+                // Calculate and set content height for dynamic resizing.
+                // A preferredHeight of 0 means the element doesn't report a known
+                // height (e.g. TableElement), so keep the configured viewport height.
                 if (root != null) {
                     int preferredHeight = root.preferredHeight(frame.area().width(), renderContext);
-                    tuiRunner.setContentHeight(preferredHeight);
+                    if (preferredHeight > 0) {
+                        tuiRunner.setContentHeight(preferredHeight);
+                    }
                 }
 
                 // Render the element tree and register root for events

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
@@ -180,6 +180,18 @@ class TableElementTest {
     }
 
     @Test
+    @DisplayName("preferredHeight returns 0 (unknown) for table elements")
+    void preferredHeightReturnsZero() {
+        TableElement element = table()
+            .header("Name", "Age")
+            .row("Alice", "30")
+            .row("Bob", "25");
+
+        assertThat(element.preferredHeight()).isZero();
+        assertThat(element.preferredHeight(80, RenderContext.empty())).isZero();
+    }
+
+    @Test
     @DisplayName("Attribute selector [title] affects Table border color")
     void attributeSelector_title_affectsBorderColor() {
         StyleEngine styleEngine = StyleEngine.create();

--- a/tamboui-tui/build.gradle.kts
+++ b/tamboui-tui/build.gradle.kts
@@ -8,4 +8,5 @@ dependencies {
     api(projects.tambouiCore)
     api(projects.tambouiWidgets)
     api(projects.tambouiAnnotations)
+    testImplementation(testFixtures(projects.tambouiCore))
 }

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/InlineViewportTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/InlineViewportTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui;
+
+import dev.tamboui.inline.InlineDisplay;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.TestBackend;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for InlineViewport content height behavior.
+ */
+class InlineViewportTest {
+
+    private TestBackend backend;
+
+    @BeforeEach
+    void setUp() {
+        backend = new TestBackend(80, 24);
+    }
+
+    @Test
+    @DisplayName("setContentHeight(0) causes draw to produce no visible content")
+    void setContentHeightZero_producesNoContent() throws Exception {
+        InlineDisplay display = InlineDisplay.withBackend(10, 80, backend);
+        InlineViewport viewport = new InlineViewport(display);
+
+        // Collapse viewport to 0
+        viewport.setContentHeight(0);
+
+        backend.reset();
+        viewport.draw(frame -> {
+            // Write content that should NOT be visible
+            frame.buffer().setString(0, 0, "Hello", Style.EMPTY);
+        });
+
+        // No content should appear in the output since contentHeight is 0
+        assertThat(backend.rawOutput()).doesNotContain("Hello");
+    }
+
+    @Test
+    @DisplayName("draw renders content when contentHeight is positive")
+    void positiveContentHeight_rendersContent() throws Exception {
+        InlineDisplay display = InlineDisplay.withBackend(10, 80, backend);
+        InlineViewport viewport = new InlineViewport(display);
+
+        // Keep viewport at configured height
+        viewport.setContentHeight(5);
+
+        backend.reset();
+        viewport.draw(frame -> {
+            frame.buffer().setString(0, 0, "Hello", Style.EMPTY);
+        });
+
+        assertThat(backend.rawOutput()).contains("Hello");
+    }
+
+    @Test
+    @DisplayName("contentHeight defaults to display height")
+    void defaultContentHeight_matchesDisplayHeight() throws Exception {
+        InlineDisplay display = InlineDisplay.withBackend(10, 80, backend);
+        InlineViewport viewport = new InlineViewport(display);
+
+        // Without calling setContentHeight, draw should render content
+        backend.reset();
+        viewport.draw(frame -> {
+            frame.buffer().setString(0, 0, "Visible", Style.EMPTY);
+        });
+
+        assertThat(backend.rawOutput()).contains("Visible");
+    }
+
+    @Test
+    @DisplayName("setContentHeight grows buffer beyond initial height")
+    void setContentHeight_growsBeyondInitialHeight() throws Exception {
+        InlineDisplay display = InlineDisplay.withBackend(5, 80, backend);
+        InlineViewport viewport = new InlineViewport(display);
+
+        // Grow beyond initial height
+        viewport.setContentHeight(10);
+
+        backend.reset();
+        viewport.draw(frame -> {
+            frame.buffer().setString(0, 9, "Line10", Style.EMPTY);
+        });
+
+        assertThat(backend.rawOutput()).contains("Line10");
+    }
+}


### PR DESCRIPTION
The inline viewport should ignore constrainst with height 0, because it means the component doesn't have a preferred height. Without this the component is hidden.