### PR TITLE
refactor: Avoid code duplication and instanceof checks

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/style/Color.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Color.java
@@ -14,6 +14,21 @@ public interface Color {
      */
     final class Reset implements Color {
         @Override
+        public String toAnsiForeground() {
+            return "39";
+        }
+
+        @Override
+        public String toAnsiBackground() {
+            return "49";
+        }
+
+        @Override
+        public Rgb toRgb() {
+            return new Rgb(255, 255, 255);
+        }
+
+        @Override
         public boolean equals(Object o) {
             return o instanceof Reset;
         }
@@ -49,6 +64,21 @@ public interface Color {
          */
         public AnsiColor color() {
             return color;
+        }
+
+        @Override
+        public String toAnsiForeground() {
+            return String.valueOf(color.fgCode());
+        }
+
+        @Override
+        public String toAnsiBackground() {
+            return String.valueOf(color.bgCode());
+        }
+
+        @Override
+        public Rgb toRgb() {
+            return ansiToRgb(color);
         }
 
         @Override
@@ -95,6 +125,26 @@ public interface Color {
         /** Returns the palette index. */
         public int index() {
             return index;
+        }
+
+        @Override
+        public String toAnsiForeground() {
+            return "38;5;" + index;
+        }
+
+        @Override
+        public String toAnsiBackground() {
+            return "48;5;" + index;
+        }
+
+        @Override
+        public String toAnsiUnderline() {
+            return "58;5;" + index;
+        }
+
+        @Override
+        public Rgb toRgb() {
+            return indexedToRgb(index);
         }
 
         @Override
@@ -153,6 +203,21 @@ public interface Color {
          */
         public Color defaultValue() {
             return defaultValue;
+        }
+
+        @Override
+        public String toAnsiForeground() {
+            return defaultValue.toAnsiForeground();
+        }
+
+        @Override
+        public String toAnsiBackground() {
+            return defaultValue.toAnsiBackground();
+        }
+
+        @Override
+        public String toAnsiUnderline() {
+            return defaultValue.toAnsiUnderline();
         }
 
         @Override
@@ -221,6 +286,26 @@ public interface Color {
         /** Returns the blue component. */
         public int b() {
             return b;
+        }
+
+        @Override
+        public String toAnsiForeground() {
+            return "38;2;" + r + ";" + g + ";" + b;
+        }
+
+        @Override
+        public String toAnsiBackground() {
+            return "48;2;" + r + ";" + g + ";" + b;
+        }
+
+        @Override
+        public String toAnsiUnderline() {
+            return "58;2;" + r + ";" + g + ";" + b;
+        }
+
+        @Override
+        public Rgb toRgb() {
+            return this;
         }
 
         /**
@@ -322,6 +407,37 @@ public interface Color {
     }
 
     /**
+     * Converts this color to an ANSI foreground color code.
+     *
+     * @return the ANSI code string (without CSI prefix or 'm' suffix),
+     *         or empty string if not applicable
+     */
+    default String toAnsiForeground() {
+        return "";
+    }
+
+    /**
+     * Converts this color to an ANSI background color code.
+     *
+     * @return the ANSI code string (without CSI prefix or 'm' suffix),
+     *         or empty string if not applicable
+     */
+    default String toAnsiBackground() {
+        return "";
+    }
+
+    /**
+     * Converts this color to an ANSI underline color code.
+     * Note that underline colors are only supported by some terminal emulators.
+     *
+     * @return the ANSI code string (without CSI prefix or 'm' suffix),
+     *         or empty string if the color type doesn't support underline coloring
+     */
+    default String toAnsiUnderline() {
+        return "";
+    }
+
+    /**
      * Converts this color to RGB.
      * <p>
      * ANSI and indexed colors are converted using standard terminal color palettes.
@@ -330,19 +446,6 @@ public interface Color {
      * @return the RGB representation of this color
      */
     default Rgb toRgb() {
-        if (this instanceof Rgb) {
-            return (Rgb) this;
-        }
-        if (this instanceof Named) {
-            return ((Named) this).defaultValue().toRgb();
-        }
-        if (this instanceof Ansi) {
-            return ansiToRgb(((Ansi) this).color());
-        }
-        if (this instanceof Indexed) {
-            return indexedToRgb(((Indexed) this).index());
-        }
-        // Reset or unknown - default to white
         return new Rgb(255, 255, 255);
     }
 

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/AnsiStringBuilder.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/AnsiStringBuilder.java
@@ -4,8 +4,6 @@
  */
 package dev.tamboui.terminal;
 
-import dev.tamboui.style.AnsiColor;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
@@ -60,13 +58,13 @@ public final class AnsiStringBuilder {
         // Foreground color
         if (style.fg().isPresent()) {
             sb.append(";");
-            sb.append(colorToAnsiForeground(style.fg().get()));
+            sb.append(style.fg().get().toAnsiForeground());
         }
 
         // Background color
         if (style.bg().isPresent()) {
             sb.append(";");
-            sb.append(colorToAnsiBackground(style.bg().get()));
+            sb.append(style.bg().get().toAnsiBackground());
         }
 
         // Modifiers
@@ -77,7 +75,7 @@ public final class AnsiStringBuilder {
 
         // Underline color (if supported by terminal)
         if (style.underlineColor().isPresent()) {
-            String underlineAnsi = underlineColorToAnsi(style.underlineColor().get());
+            String underlineAnsi = style.underlineColor().get().toAnsiUnderline();
             if (!underlineAnsi.isEmpty()) {
                 sb.append(";").append(underlineAnsi);
             }
@@ -85,78 +83,6 @@ public final class AnsiStringBuilder {
 
         sb.append("m");
         return sb.toString();
-    }
-
-    /**
-     * Converts a {@link Color} to an ANSI foreground color code.
-     *
-     * @param color the color to convert
-     * @return the ANSI code string (without CSI prefix or 'm' suffix)
-     */
-    public static String colorToAnsiForeground(Color color) {
-        if (color instanceof Color.Named) {
-            // Named colors delegate to their default value
-            return colorToAnsiForeground(((Color.Named) color).defaultValue());
-        } else if (color instanceof Color.Reset) {
-            return "39";
-        } else if (color instanceof Color.Ansi) {
-            AnsiColor c = ((Color.Ansi) color).color();
-            return String.valueOf(c.fgCode());
-        } else if (color instanceof Color.Indexed) {
-            int idx = ((Color.Indexed) color).index();
-            return "38;5;" + idx;
-        } else if (color instanceof Color.Rgb) {
-            Color.Rgb rgb = (Color.Rgb) color;
-            return "38;2;" + rgb.r() + ";" + rgb.g() + ";" + rgb.b();
-        }
-        return "";
-    }
-
-    /**
-     * Converts a {@link Color} to an ANSI background color code.
-     *
-     * @param color the color to convert
-     * @return the ANSI code string (without CSI prefix or 'm' suffix)
-     */
-    public static String colorToAnsiBackground(Color color) {
-        if (color instanceof Color.Named) {
-            // Named colors delegate to their default value
-            return colorToAnsiBackground(((Color.Named) color).defaultValue());
-        } else if (color instanceof Color.Reset) {
-            return "49";
-        } else if (color instanceof Color.Ansi) {
-            AnsiColor c = ((Color.Ansi) color).color();
-            return String.valueOf(c.bgCode());
-        } else if (color instanceof Color.Indexed) {
-            int idx = ((Color.Indexed) color).index();
-            return "48;5;" + idx;
-        } else if (color instanceof Color.Rgb) {
-            Color.Rgb rgb = (Color.Rgb) color;
-            return "48;2;" + rgb.r() + ";" + rgb.g() + ";" + rgb.b();
-        }
-        return "";
-    }
-
-    /**
-     * Converts a {@link Color} to an ANSI underline color code.
-     * Note that underline colors are only supported by some terminal emulators.
-     *
-     * @param color the color to convert
-     * @return the ANSI code string (without CSI prefix or 'm' suffix),
-     *         or empty string if the color type doesn't support underline coloring
-     */
-    public static String underlineColorToAnsi(Color color) {
-        if (color instanceof Color.Named) {
-            // Named colors delegate to their default value
-            return underlineColorToAnsi(((Color.Named) color).defaultValue());
-        } else if (color instanceof Color.Indexed) {
-            int idx = ((Color.Indexed) color).index();
-            return "58;5;" + idx;
-        } else if (color instanceof Color.Rgb) {
-            Color.Rgb rgb = (Color.Rgb) color;
-            return "58;2;" + rgb.r() + ";" + rgb.g() + ";" + rgb.b();
-        }
-        return "";
     }
 
     /**

--- a/tamboui-core/src/test/java/dev/tamboui/style/ColorTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/style/ColorTest.java
@@ -87,4 +87,149 @@ class ColorTest {
         assertThat(rgb.g()).isEqualTo(0);
         assertThat(rgb.b()).isEqualTo(0);
     }
+
+    // toAnsiForeground tests
+
+    @Test
+    @DisplayName("Reset.toAnsiForeground returns 39")
+    void resetToAnsiForeground() {
+        assertThat(Color.RESET.toAnsiForeground()).isEqualTo("39");
+    }
+
+    @Test
+    @DisplayName("Ansi.toAnsiForeground returns foreground SGR code")
+    void ansiToAnsiForeground() {
+        Color color = new Color.Ansi(AnsiColor.RED);
+        assertThat(color.toAnsiForeground()).isEqualTo("31");
+
+        Color bright = new Color.Ansi(AnsiColor.BRIGHT_CYAN);
+        assertThat(bright.toAnsiForeground()).isEqualTo("96");
+    }
+
+    @Test
+    @DisplayName("Indexed.toAnsiForeground returns 38;5;index")
+    void indexedToAnsiForeground() {
+        Color color = new Color.Indexed(42);
+        assertThat(color.toAnsiForeground()).isEqualTo("38;5;42");
+    }
+
+    @Test
+    @DisplayName("Rgb.toAnsiForeground returns 38;2;r;g;b")
+    void rgbToAnsiForeground() {
+        Color color = new Color.Rgb(100, 150, 200);
+        assertThat(color.toAnsiForeground()).isEqualTo("38;2;100;150;200");
+    }
+
+    @Test
+    @DisplayName("Named.toAnsiForeground delegates to default value")
+    void namedToAnsiForeground() {
+        // Color.RED is Named with Ansi(RED) default → fgCode 31
+        assertThat(Color.RED.toAnsiForeground()).isEqualTo("31");
+    }
+
+    // toAnsiBackground tests
+
+    @Test
+    @DisplayName("Reset.toAnsiBackground returns 49")
+    void resetToAnsiBackground() {
+        assertThat(Color.RESET.toAnsiBackground()).isEqualTo("49");
+    }
+
+    @Test
+    @DisplayName("Ansi.toAnsiBackground returns background SGR code")
+    void ansiToAnsiBackground() {
+        Color color = new Color.Ansi(AnsiColor.RED);
+        assertThat(color.toAnsiBackground()).isEqualTo("41");
+
+        Color bright = new Color.Ansi(AnsiColor.BRIGHT_CYAN);
+        assertThat(bright.toAnsiBackground()).isEqualTo("106");
+    }
+
+    @Test
+    @DisplayName("Indexed.toAnsiBackground returns 48;5;index")
+    void indexedToAnsiBackground() {
+        Color color = new Color.Indexed(42);
+        assertThat(color.toAnsiBackground()).isEqualTo("48;5;42");
+    }
+
+    @Test
+    @DisplayName("Rgb.toAnsiBackground returns 48;2;r;g;b")
+    void rgbToAnsiBackground() {
+        Color color = new Color.Rgb(100, 150, 200);
+        assertThat(color.toAnsiBackground()).isEqualTo("48;2;100;150;200");
+    }
+
+    @Test
+    @DisplayName("Named.toAnsiBackground delegates to default value")
+    void namedToAnsiBackground() {
+        assertThat(Color.RED.toAnsiBackground()).isEqualTo("41");
+    }
+
+    // toAnsiUnderline tests
+
+    @Test
+    @DisplayName("Reset.toAnsiUnderline returns empty string")
+    void resetToAnsiUnderline() {
+        assertThat(Color.RESET.toAnsiUnderline()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Ansi.toAnsiUnderline returns empty string")
+    void ansiToAnsiUnderline() {
+        Color color = new Color.Ansi(AnsiColor.RED);
+        assertThat(color.toAnsiUnderline()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Indexed.toAnsiUnderline returns 58;5;index")
+    void indexedToAnsiUnderline() {
+        Color color = new Color.Indexed(42);
+        assertThat(color.toAnsiUnderline()).isEqualTo("58;5;42");
+    }
+
+    @Test
+    @DisplayName("Rgb.toAnsiUnderline returns 58;2;r;g;b")
+    void rgbToAnsiUnderline() {
+        Color color = new Color.Rgb(100, 150, 200);
+        assertThat(color.toAnsiUnderline()).isEqualTo("58;2;100;150;200");
+    }
+
+    @Test
+    @DisplayName("Named.toAnsiUnderline delegates to default value")
+    void namedToAnsiUnderline() {
+        // Ansi colors don't support underline color, so Named wrapping Ansi returns empty
+        assertThat(Color.RED.toAnsiUnderline()).isEmpty();
+
+        // Named wrapping Rgb should delegate
+        Color named = new Color.Named("custom", new Color.Rgb(10, 20, 30));
+        assertThat(named.toAnsiUnderline()).isEqualTo("58;2;10;20;30");
+    }
+
+    // toRgb polymorphic tests
+
+    @Test
+    @DisplayName("Rgb.toRgb returns this")
+    void rgbToRgbReturnsSelf() {
+        Color.Rgb rgb = new Color.Rgb(10, 20, 30);
+        assertThat(rgb.toRgb()).isSameAs(rgb);
+    }
+
+    @Test
+    @DisplayName("Reset.toRgb returns white")
+    void resetToRgb() {
+        Color.Rgb rgb = Color.RESET.toRgb();
+        assertThat(rgb.r()).isEqualTo(255);
+        assertThat(rgb.g()).isEqualTo(255);
+        assertThat(rgb.b()).isEqualTo(255);
+    }
+
+    @Test
+    @DisplayName("Indexed.toRgb converts via palette")
+    void indexedToRgb() {
+        // Index 0 = ANSI BLACK = (0, 0, 0)
+        Color.Rgb rgb = new Color.Indexed(0).toRgb();
+        assertThat(rgb.r()).isEqualTo(0);
+        assertThat(rgb.g()).isEqualTo(0);
+        assertThat(rgb.b()).isEqualTo(0);
+    }
 }

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/AnsiStringBuilderTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/AnsiStringBuilderTest.java
@@ -4,7 +4,6 @@ a * Copyright TamboUI Contributors
  */
 package dev.tamboui.terminal;
 
-import dev.tamboui.style.AnsiColor;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Modifier;
@@ -84,90 +83,6 @@ class AnsiStringBuilderTest {
         assertThat(result).contains(";36");  // cyan fg
         assertThat(result).contains(";45");  // magenta bg
         assertThat(result).contains(";1");   // bold
-    }
-
-    @Test
-    @DisplayName("colorToAnsiForeground with Reset")
-    void foregroundReset() {
-        String result = AnsiStringBuilder.colorToAnsiForeground(Color.RESET);
-        assertThat(result).isEqualTo("39");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiForeground with ANSI color")
-    void foregroundAnsiColor() {
-        String result = AnsiStringBuilder.colorToAnsiForeground(Color.RED);
-        assertThat(result).isEqualTo("31");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiForeground with bright ANSI color")
-    void foregroundBrightAnsiColor() {
-        String result = AnsiStringBuilder.colorToAnsiForeground(new Color.Ansi(AnsiColor.BRIGHT_RED));
-        assertThat(result).isEqualTo("91");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiForeground with indexed color")
-    void foregroundIndexedColor() {
-        String result = AnsiStringBuilder.colorToAnsiForeground(Color.indexed(123));
-        assertThat(result).isEqualTo("38;5;123");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiForeground with RGB color")
-    void foregroundRgbColor() {
-        String result = AnsiStringBuilder.colorToAnsiForeground(Color.rgb(100, 150, 200));
-        assertThat(result).isEqualTo("38;2;100;150;200");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiBackground with Reset")
-    void backgroundReset() {
-        String result = AnsiStringBuilder.colorToAnsiBackground(Color.RESET);
-        assertThat(result).isEqualTo("49");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiBackground with ANSI color")
-    void backgroundAnsiColor() {
-        String result = AnsiStringBuilder.colorToAnsiBackground(Color.RED);
-        assertThat(result).isEqualTo("41");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiBackground with indexed color")
-    void backgroundIndexedColor() {
-        String result = AnsiStringBuilder.colorToAnsiBackground(Color.indexed(45));
-        assertThat(result).isEqualTo("48;5;45");
-    }
-
-    @Test
-    @DisplayName("colorToAnsiBackground with RGB color")
-    void backgroundRgbColor() {
-        String result = AnsiStringBuilder.colorToAnsiBackground(Color.rgb(255, 128, 64));
-        assertThat(result).isEqualTo("48;2;255;128;64");
-    }
-
-    @Test
-    @DisplayName("underlineColorToAnsi with indexed color")
-    void underlineIndexedColor() {
-        String result = AnsiStringBuilder.underlineColorToAnsi(Color.indexed(200));
-        assertThat(result).isEqualTo("58;5;200");
-    }
-
-    @Test
-    @DisplayName("underlineColorToAnsi with RGB color")
-    void underlineRgbColor() {
-        String result = AnsiStringBuilder.underlineColorToAnsi(Color.rgb(10, 20, 30));
-        assertThat(result).isEqualTo("58;2;10;20;30");
-    }
-
-    @Test
-    @DisplayName("underlineColorToAnsi with unsupported color returns empty")
-    void underlineUnsupportedColor() {
-        String result = AnsiStringBuilder.underlineColorToAnsi(Color.RED);
-        assertThat(result).isEmpty();
     }
 
     @Test

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -8,8 +8,6 @@ import dev.tamboui.buffer.Cell;
 import dev.tamboui.buffer.CellUpdate;
 import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Size;
-import dev.tamboui.style.AnsiColor;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
@@ -343,13 +341,13 @@ public class JLineBackend implements Backend {
         // Foreground color
         style.fg().ifPresent(color -> {
             sb.append(";");
-            sb.append(colorToAnsi(color, true));
+            sb.append(color.toAnsiForeground());
         });
 
         // Background color
         style.bg().ifPresent(color -> {
             sb.append(";");
-            sb.append(colorToAnsi(color, false));
+            sb.append(color.toAnsiBackground());
         });
 
         // Modifiers
@@ -361,42 +359,11 @@ public class JLineBackend implements Backend {
         // Underline color (if supported)
         style.underlineColor().ifPresent(color -> {
             sb.append(";");
-            sb.append(underlineColorToAnsi(color));
+            sb.append(color.toAnsiUnderline());
         });
 
         sb.append("m");
         writer.print(sb.toString());
-    }
-
-    private String colorToAnsi(Color color, boolean foreground) {
-        if (color instanceof Color.Named) {
-            return colorToAnsi(((Color.Named) color).defaultValue(), foreground);
-        } else if (color instanceof Color.Reset) {
-            return foreground ? "39" : "49";
-        } else if (color instanceof Color.Ansi) {
-            AnsiColor c = ((Color.Ansi) color).color();
-            return String.valueOf(foreground ? c.fgCode() : c.bgCode());
-        } else if (color instanceof Color.Indexed) {
-            int idx = ((Color.Indexed) color).index();
-            return (foreground ? "38;5;" : "48;5;") + idx;
-        } else if (color instanceof Color.Rgb) {
-            Color.Rgb rgb = (Color.Rgb) color;
-            return (foreground ? "38;2;" : "48;2;") + rgb.r() + ";" + rgb.g() + ";" + rgb.b();
-        }
-        return "";
-    }
-
-    private String underlineColorToAnsi(Color color) {
-        if (color instanceof Color.Named) {
-            return underlineColorToAnsi(((Color.Named) color).defaultValue());
-        } else if (color instanceof Color.Indexed) {
-            int idx = ((Color.Indexed) color).index();
-            return "58;5;" + idx;
-        } else if (color instanceof Color.Rgb) {
-            Color.Rgb rgb = (Color.Rgb) color;
-            return "58;2;" + rgb.r() + ";" + rgb.g() + ";" + rgb.b();
-        }
-        return "";
     }
 
     /**

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -11,8 +11,6 @@ import dev.tamboui.buffer.Cell;
 import dev.tamboui.buffer.CellUpdate;
 import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Size;
-import dev.tamboui.style.AnsiColor;
-import dev.tamboui.style.Color;
 import dev.tamboui.style.Hyperlink;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
@@ -358,13 +356,13 @@ public class PanamaBackend implements Backend {
         // Foreground color
         style.fg().ifPresent(color -> {
             outputBuffer.append((byte) ';');
-            appendColorToAnsi(color, true);
+            outputBuffer.appendAscii(color.toAnsiForeground());
         });
 
         // Background color
         style.bg().ifPresent(color -> {
             outputBuffer.append((byte) ';');
-            appendColorToAnsi(color, false);
+            outputBuffer.appendAscii(color.toAnsiBackground());
         });
 
         // Modifiers
@@ -375,49 +373,14 @@ public class PanamaBackend implements Backend {
 
         // Underline color (if supported)
         style.underlineColor().ifPresent(color -> {
-            outputBuffer.append((byte) ';');
-            appendUnderlineColorToAnsi(color);
+            String s = color.toAnsiUnderline();
+            if (!s.isEmpty()) {
+                outputBuffer.append((byte) ';');
+                outputBuffer.appendAscii(s);
+            }
         });
 
         outputBuffer.append((byte) 'm');
-    }
-
-    private void appendColorToAnsi(Color color, boolean foreground) {
-        if (color instanceof Color.Named named) {
-            appendColorToAnsi(named.defaultValue(), foreground);
-        } else if (color instanceof Color.Reset) {
-            outputBuffer.appendInt(foreground ? 39 : 49);
-        } else if (color instanceof Color.Ansi ansi) {
-            outputBuffer.appendInt(foreground ? ansi.color().fgCode() : ansi.color().bgCode());
-        } else if (color instanceof Color.Indexed indexed) {
-            outputBuffer.appendInt(foreground ? 38 : 48)
-                    .appendAscii(";5;")
-                    .appendInt(indexed.index());
-        } else if (color instanceof Color.Rgb rgb) {
-            outputBuffer.appendInt(foreground ? 38 : 48)
-                    .appendAscii(";2;")
-                    .appendInt(rgb.r())
-                    .append((byte) ';')
-                    .appendInt(rgb.g())
-                    .append((byte) ';')
-                    .appendInt(rgb.b());
-        }
-    }
-
-    private void appendUnderlineColorToAnsi(Color color) {
-        if (color instanceof Color.Named named) {
-            appendUnderlineColorToAnsi(named.defaultValue());
-            return;
-        } else if (color instanceof Color.Indexed indexed) {
-            outputBuffer.appendAscii("58;5;").appendInt(indexed.index());
-        } else if (color instanceof Color.Rgb rgb) {
-            outputBuffer.appendAscii("58;2;")
-                    .appendInt(rgb.r())
-                    .append((byte) ';')
-                    .appendInt(rgb.g())
-                    .append((byte) ';')
-                    .appendInt(rgb.b());
-        }
     }
 
     /**

--- a/tamboui-tfx/src/main/java/dev/tamboui/tfx/TFxColorSpace.java
+++ b/tamboui-tfx/src/main/java/dev/tamboui/tfx/TFxColorSpace.java
@@ -171,23 +171,12 @@ public enum TFxColorSpace {
      * Converts a color to RGB components [r, g, b].
      */
     int[] toRgbComponents(Color color) {
-        if (color instanceof Color.Named) {
-            return toRgbComponents(((Color.Named) color).defaultValue());
-        } else if (color instanceof Color.Rgb) {
-            Color.Rgb rgb = (Color.Rgb) color;
-            return new int[]{rgb.r(), rgb.g(), rgb.b()};
-        } else if (color instanceof Color.Ansi) {
-            // Convert ANSI color to approximate RGB
-            Color.Ansi ansi = (Color.Ansi) color;
-            return ansiToRgb(ansi.color());
-        } else if (color instanceof Color.Indexed) {
-            // Convert indexed color to approximate RGB
-            Color.Indexed indexed = (Color.Indexed) color;
-            return indexedToRgb(indexed.index());
-        } else {
-            // Default to black for Reset or unknown
+        if (color instanceof Color.Reset) {
+            // Reset defaults to black for effects
             return new int[]{0, 0, 0};
         }
+        Color.Rgb rgb = color.toRgb();
+        return new int[]{rgb.r(), rgb.g(), rgb.b()};
     }
     
     /**


### PR DESCRIPTION
This commit simplifies `Color` with default methods to handle ANSI color conversion.

fixes #159