### PR TITLE
chore: Fail javadoc generation on warnings

### DIFF
--- a/buildSrc/src/main/kotlin/dev.tamboui.java-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.java-base.gradle.kts
@@ -43,6 +43,7 @@ tasks.withType<Javadoc>().configureEach {
     JavadocTheming.configure(this, project)
     (options as StandardJavadocDocletOptions).apply {
         addStringOption("Xmaxwarns", "10000")
+        addBooleanOption("Xwerror", true)
     }
 }
 


### PR DESCRIPTION
So that we never face the same situation as before :)