### PR TITLE
fix: elements now fit their content by default

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/BarChartElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/BarChartElement.java
@@ -303,6 +303,56 @@ public final class BarChartElement extends StyledElement<BarChartElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Calculate based on bar count, bar width, and gaps
+        int barCount = 0;
+        for (BarGroup group : groups) {
+            barCount += group.bars().size();
+        }
+        if (barCount == 0) {
+            barCount = 1;
+        }
+
+        int width;
+        if (direction == Direction.VERTICAL) {
+            // Vertical bars: width depends on bar count
+            width = barCount * barWidth + (barCount - 1) * barGap + (groups.size() - 1) * groupGap;
+        } else {
+            // Horizontal bars: width is the value range + labels
+            width = 30; // Reasonable default for horizontal bar display
+        }
+
+        // Add border if present
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return Math.max(width, 10) + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Calculate based on direction and content
+        int barCount = 0;
+        for (BarGroup group : groups) {
+            barCount += group.bars().size();
+        }
+        if (barCount == 0) {
+            barCount = 1;
+        }
+
+        int height;
+        if (direction == Direction.HORIZONTAL) {
+            // Horizontal bars: height depends on bar count + labels
+            height = barCount + (groups.size() - 1) * groupGap + 2; // +2 for labels
+        } else {
+            // Vertical bars: reasonable height for display
+            height = 10;
+        }
+
+        // Add border if present
+        int borderHeight = (title != null || borderType != null) ? 2 : 0;
+        return height + borderHeight;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/CalendarElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/CalendarElement.java
@@ -237,6 +237,28 @@ public final class CalendarElement extends StyledElement<CalendarElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Calendar shows 7 days * 3 chars each (day number + spaces) = 21 chars
+        int width = 7 * 3;
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return width + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Calendar shows: month header (optional) + weekday header (optional) + 6 weeks max
+        int height = 6; // 6 week rows
+        if (monthHeaderStyle != null) {
+            height++;
+        }
+        if (weekdaysHeaderStyle != null) {
+            height++;
+        }
+        int borderHeight = (title != null || borderType != null) ? 2 : 0;
+        return height + borderHeight;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/CanvasElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/CanvasElement.java
@@ -206,6 +206,42 @@ public final class CanvasElement extends StyledElement<CanvasElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Canvas width based on x bounds range, scaled for marker resolution
+        double range = xMax - xMin;
+        int width;
+        if (marker == Marker.BRAILLE) {
+            // Braille has 2x2 dots per cell
+            width = (int) Math.ceil(range / 2);
+        } else if (marker == Marker.HALF_BLOCK) {
+            // Half block is 1x2 pixels per cell
+            width = (int) Math.ceil(range);
+        } else {
+            width = (int) Math.ceil(range);
+        }
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return Math.max(width, 20) + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Canvas height based on y bounds range, scaled for marker resolution
+        double range = yMax - yMin;
+        int height;
+        if (marker == Marker.BRAILLE) {
+            // Braille has 4 dots vertically per cell
+            height = (int) Math.ceil(range / 4);
+        } else if (marker == Marker.HALF_BLOCK) {
+            // Half block has 2 dots vertically per cell
+            height = (int) Math.ceil(range / 2);
+        } else {
+            height = (int) Math.ceil(range);
+        }
+        int borderHeight = (title != null || borderType != null) ? 2 : 0;
+        return Math.max(height, 10) + borderHeight;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ChartElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ChartElement.java
@@ -183,6 +183,20 @@ public final class ChartElement extends StyledElement<ChartElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Charts need reasonable width for axis labels and data display
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return 40 + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Charts need reasonable height for visibility
+        int borderHeight = (title != null || borderType != null) ? 2 : 0;
+        return 10 + borderHeight;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -203,16 +203,19 @@ public final class Column extends ContainerElement<Column> {
                     c = childCss.heightConstraint().orElse(null);
                 }
             }
-            // Handle Fit constraint by querying preferred height
-            if (c instanceof Constraint.Fit) {
-                int preferred = child.preferredHeight();
-                c = preferred > 0 ? Constraint.length(preferred) : null;
-            }
+            // Handle null or Fit constraint by querying preferred height
             if (c == null) {
-                // For text elements without explicit constraint, calculate height from content
+                // First try text element special case
                 c = calculateDefaultConstraint(child);
+                if (c == null) {
+                    int preferred = child.preferredHeight();
+                    c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
+                }
+            } else if (c instanceof Constraint.Fit) {
+                int preferred = child.preferredHeight();
+                c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
             }
-            constraints.add(c != null ? c : Constraint.fill());
+            constraints.add(c);
 
             // Add spacing constraint between children
             if (effectiveSpacing > 0 && i < children.size() - 1) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GaugeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GaugeElement.java
@@ -178,6 +178,19 @@ public final class GaugeElement extends StyledElement<GaugeElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Label width + some space for the gauge bar
+        int labelWidth = label != null ? label.length() : 4; // "75%" default
+        return labelWidth + 10;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Gauge is typically 1 row, 3 if bordered (top + content + bottom)
+        return (title != null || borderType != null) ? 3 : 1;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GridElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GridElement.java
@@ -434,7 +434,15 @@ public final class GridElement extends ContainerElement<GridElement> {
                 if (effectiveGridColumns != null && !effectiveGridColumns.isEmpty()) {
                     hConstraints.add(effectiveGridColumns.get(c % effectiveGridColumns.size()));
                 } else {
-                    hConstraints.add(Constraint.fill());
+                    // Find max preferred width of children in this column
+                    int maxPreferred = 0;
+                    for (int row = 0; row < rows; row++) {
+                        int childIndex = row * cols + c;
+                        if (childIndex < childCount) {
+                            maxPreferred = Math.max(maxPreferred, children.get(childIndex).preferredWidth());
+                        }
+                    }
+                    hConstraints.add(maxPreferred > 0 ? Constraint.length(maxPreferred) : Constraint.fill());
                 }
                 if (hGutter > 0 && c < cols - 1) {
                     hConstraints.add(Constraint.length(hGutter));

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/InlineScopeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/InlineScopeElement.java
@@ -197,16 +197,21 @@ public final class InlineScopeElement extends ContainerElement<InlineScopeElemen
         List<Constraint> constraints = new ArrayList<>();
         for (Element child : children) {
             Constraint c = child.constraint();
-            // Handle Fit constraint
-            if (c instanceof Constraint.Fit) {
+            // Handle null or Fit constraint by querying preferred height
+            if (c == null) {
+                // First try text element special case
+                if (child instanceof TextElement) {
+                    c = ((TextElement) child).calculateHeightConstraint();
+                }
+                if (c == null) {
+                    int preferred = child.preferredHeight();
+                    c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
+                }
+            } else if (c instanceof Constraint.Fit) {
                 int preferred = child.preferredHeight();
-                c = preferred > 0 ? Constraint.length(preferred) : null;
+                c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
             }
-            // Calculate default constraint for text elements
-            if (c == null && child instanceof TextElement) {
-                c = ((TextElement) child).calculateHeightConstraint();
-            }
-            constraints.add(c != null ? c : Constraint.fill());
+            constraints.add(c);
         }
 
         // Layout children vertically

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/LazyElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/LazyElement.java
@@ -50,6 +50,24 @@ public final class LazyElement implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        // Evaluate to get preferred width if not yet rendered
+        if (lastElement == null) {
+            lastElement = supplier.get();
+        }
+        return lastElement != null ? lastElement.preferredWidth() : 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Evaluate to get preferred height if not yet rendered
+        if (lastElement == null) {
+            lastElement = supplier.get();
+        }
+        return lastElement != null ? lastElement.preferredHeight() : 0;
+    }
+
+    @Override
     public Constraint constraint() {
         // Evaluate to get constraint if not yet rendered
         if (lastElement == null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/LineGaugeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/LineGaugeElement.java
@@ -182,6 +182,19 @@ public final class LineGaugeElement extends StyledElement<LineGaugeElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Label width + a reasonable gauge width
+        int labelWidth = label != null ? label.length() : 0;
+        return labelWidth + 20;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // LineGauge is always 1 row
+        return 1;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (label != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ListElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ListElement.java
@@ -516,6 +516,45 @@ public final class ListElement<T> extends StyledElement<ListElement<T>> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Calculate max width from items
+        int maxWidth = 0;
+        List<StyledElement<?>> effectiveItems;
+        if (data != null && itemRenderer != null) {
+            effectiveItems = new ArrayList<>(data.size());
+            for (T item : data) {
+                effectiveItems.add(itemRenderer.apply(item));
+            }
+        } else {
+            effectiveItems = items;
+        }
+
+        for (StyledElement<?> item : effectiveItems) {
+            maxWidth = Math.max(maxWidth, item.preferredWidth());
+        }
+
+        // Add highlight symbol width and border width if present
+        String effectiveSymbol = highlightSymbol != null ? highlightSymbol : DEFAULT_HIGHLIGHT_SYMBOL;
+        int symbolWidth = effectiveSymbol.length();
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+
+        return maxWidth + symbolWidth + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Return number of items + border height if present
+        int itemCount;
+        if (data != null) {
+            itemCount = data.size();
+        } else {
+            itemCount = items.size();
+        }
+        int borderHeight = (title != null || borderType != null) ? 2 : 0;
+        return itemCount + borderHeight;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/MarkupTextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/MarkupTextAreaElement.java
@@ -446,6 +446,20 @@ public final class MarkupTextAreaElement extends StyledElement<MarkupTextAreaEle
     }
 
     @Override
+    public int preferredWidth() {
+        // Return max line width from parsed text
+        ensureTextParsed();
+        int maxWidth = 0;
+        for (Line line : parsedText.lines()) {
+            maxWidth = Math.max(maxWidth, line.width());
+        }
+        // Add line number width and border
+        int lineNumWidth = showLineNumbers ? String.valueOf(parsedText.lines().size()).length() + lineNumberSeparator.length() : 0;
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return maxWidth + lineNumWidth + borderWidth;
+    }
+
+    @Override
     public Constraint constraint() {
         if (layoutConstraint != null) {
             return layoutConstraint;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -632,8 +632,12 @@ public final class Panel extends ContainerElement<Panel> {
                             : childCss.heightConstraint().orElse(null);
                 }
             }
-            // Default to fill() so children expand to use available space
-            constraints.add(c != null ? c : Constraint.fill());
+            // Handle null constraint by querying preferred size
+            if (c == null) {
+                int preferred = isHorizontal ? child.preferredWidth() : child.preferredHeight();
+                c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
+            }
+            constraints.add(c);
         }
 
         Layout layout = effectiveDirection == Direction.HORIZONTAL

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/RichTextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/RichTextAreaElement.java
@@ -408,6 +408,19 @@ public final class RichTextAreaElement extends StyledElement<RichTextAreaElement
     }
 
     @Override
+    public int preferredWidth() {
+        // Return max line width from text
+        int maxWidth = 0;
+        for (Line line : text.lines()) {
+            maxWidth = Math.max(maxWidth, line.width());
+        }
+        // Add line number width and border
+        int lineNumWidth = showLineNumbers ? String.valueOf(text.lines().size()).length() + lineNumberSeparator.length() : 0;
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return maxWidth + lineNumWidth + borderWidth;
+    }
+
+    @Override
     public Constraint constraint() {
         if (layoutConstraint != null) {
             return layoutConstraint;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
@@ -212,12 +212,15 @@ public final class Row extends ContainerElement<Row> {
                     c = childCss.widthConstraint().orElse(null);
                 }
             }
-            // Handle Fit constraint by querying preferred width
-            if (c instanceof Constraint.Fit) {
+            // Handle null or Fit constraint by querying preferred width
+            if (c == null) {
+                int preferred = child.preferredWidth();
+                c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
+            } else if (c instanceof Constraint.Fit) {
                 int preferred = child.preferredWidth();
                 c = preferred > 0 ? Constraint.length(preferred) : Constraint.fill();
             }
-            constraints.add(c != null ? c : Constraint.fill());
+            constraints.add(c);
 
             // Add spacing constraint between children
             if (effectiveSpacing > 0 && i < children.size() - 1) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollbarElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollbarElement.java
@@ -291,6 +291,18 @@ public final class ScrollbarElement extends StyledElement<ScrollbarElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Scrollbar is 1 cell wide for vertical orientation
+        return orientation.isVertical() ? 1 : (state != null ? state.contentLength() : 10);
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Scrollbar is 1 cell tall for horizontal orientation
+        return orientation.isVertical() ? (state != null ? state.contentLength() : 10) : 1;
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (area.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/SparklineElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/SparklineElement.java
@@ -225,6 +225,20 @@ public final class SparklineElement extends StyledElement<SparklineElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Sparkline width is typically the data point count
+        int width = data != null ? data.length : 10;
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return Math.max(width, 10) + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Sparkline is typically 1 row, or 3 if bordered
+        return (title != null || borderType != null) ? 3 : 1;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TableElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TableElement.java
@@ -267,6 +267,75 @@ public final class TableElement extends StyledElement<TableElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Sum of column widths from constraints + column spacing
+        int totalWidth = 0;
+        int numCols = 0;
+
+        // Determine number of columns from header or first row
+        if (header != null) {
+            numCols = header.cells().size();
+        } else if (!rows.isEmpty()) {
+            numCols = rows.get(0).cells().size();
+        }
+
+        if (!widths.isEmpty()) {
+            // Use constraint widths
+            for (Constraint w : widths) {
+                if (w instanceof Constraint.Length) {
+                    totalWidth += ((Constraint.Length) w).value();
+                } else {
+                    totalWidth += 10; // Default column width
+                }
+            }
+            // Cycle if fewer widths than columns
+            for (int i = widths.size(); i < numCols; i++) {
+                Constraint w = widths.get(i % widths.size());
+                if (w instanceof Constraint.Length) {
+                    totalWidth += ((Constraint.Length) w).value();
+                } else {
+                    totalWidth += 10;
+                }
+            }
+        } else {
+            // Default width per column
+            totalWidth = numCols * 10;
+        }
+
+        // Add column spacing
+        if (numCols > 1) {
+            totalWidth += columnSpacing * (numCols - 1);
+        }
+
+        // Add highlight symbol width
+        String effectiveSymbol = highlightSymbol != null ? highlightSymbol : DEFAULT_HIGHLIGHT_SYMBOL;
+        totalWidth += effectiveSymbol.length();
+
+        // Add border width if present
+        if (title != null || borderType != null) {
+            totalWidth += 2;
+        }
+
+        return totalWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Header + rows + footer + border
+        int height = rows.size();
+        if (header != null) {
+            height++;
+        }
+        if (footer != null) {
+            height++;
+        }
+        if (title != null || borderType != null) {
+            height += 2;
+        }
+        return height;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -252,6 +252,34 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Calculate max line width from content
+        int maxWidth = 0;
+        if (state != null) {
+            String text = state.text();
+            for (String line : text.split("\n", -1)) {
+                maxWidth = Math.max(maxWidth, line.length());
+            }
+        }
+        // Add minimum width, line number width if applicable, and border
+        int lineNumWidth = showLineNumbers ? 5 : 0;
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return Math.max(maxWidth, 20) + lineNumWidth + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Return line count plus border
+        int lineCount = 1;
+        if (state != null) {
+            String text = state.text();
+            lineCount = text.isEmpty() ? 1 : text.split("\n", -1).length;
+        }
+        int borderHeight = (title != null || borderType != null) ? 2 : 0;
+        return lineCount + borderHeight;
+    }
+
+    @Override
     public boolean isFocusable() {
         return true;
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextInputElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextInputElement.java
@@ -223,6 +223,23 @@ public final class TextInputElement extends StyledElement<TextInputElement> {
     }
 
     @Override
+    public int preferredWidth() {
+        // Use max of placeholder width and current value width, plus border
+        int valueWidth = state != null ? state.text().length() : 0;
+        int placeholderWidth = placeholder != null ? placeholder.length() : 0;
+        int contentWidth = Math.max(valueWidth, placeholderWidth);
+        // Add minimum width for usability and border if present
+        int borderWidth = (title != null || borderType != null) ? 2 : 0;
+        return Math.max(contentWidth, 10) + borderWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Single-line input: 1 row, or 3 if bordered
+        return (title != null || borderType != null) ? 3 : 1;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
@@ -145,6 +145,7 @@ class ConstraintCssTest {
             setupBuffer(40, 1);
 
             // .parent-row .child-text { width: fit; }
+            // .parent-row { flex: center; }
             row(
                 text("Short").addClass("child-text"),
                 text("Rest")
@@ -152,9 +153,12 @@ class ConstraintCssTest {
              .render(frame, new Rect(0, 0, 40, 1), context);
 
             // With width: fit, "Short" takes only 5 columns
-            assertThat(buffer).hasSymbolAt(0, 0, "S");
-            // With flex: center on parent-row, rest of space is distributed
-            // So "Rest" won't be immediately after "Short"
+            // "Rest" also fits to its preferred width of 4 columns
+            // Total: 9 columns in 40-column buffer
+            // With flex: center, content is centered: (40 - 9) / 2 = 15
+            assertThat(buffer).hasSymbolAt(15, 0, "S");
+            // "Rest" starts at position 20 (15 + 5)
+            assertThat(buffer).hasSymbolAt(20, 0, "R");
         }
     }
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
@@ -180,15 +180,16 @@ class TableElementTest {
     }
 
     @Test
-    @DisplayName("preferredHeight returns 0 (unknown) for table elements")
-    void preferredHeightReturnsZero() {
+    @DisplayName("preferredHeight returns content height for table elements")
+    void preferredHeightReturnsContentHeight() {
         TableElement element = table()
             .header("Name", "Age")
             .row("Alice", "30")
             .row("Bob", "25");
 
-        assertThat(element.preferredHeight()).isZero();
-        assertThat(element.preferredHeight(80, RenderContext.empty())).isZero();
+        // 1 header row + 2 data rows = 3
+        assertThat(element.preferredHeight()).isEqualTo(3);
+        assertThat(element.preferredHeight(80, RenderContext.empty())).isEqualTo(3);
     }
 
     @Test


### PR DESCRIPTION
This makes layouts are more intuitive - elements use their natural size instead of stretching to fill all available space. This means a button in a row will be button-sized, not row-sized for example.

Row, Column, Panel, Grid, and InlineScopeElement now query each child's preferred size when no explicit constraint is set. Elements that don't report a preferred size (returning 0) still fall back to fill().