### PR TITLE
feat: Add event handling tracing

### DIFF
--- a/tamboui-toolkit/build.gradle.kts
+++ b/tamboui-toolkit/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("dev.tamboui.java-library")
+    `java-test-fixtures`
 }
 
 description = "Fluent DSL for building TUI applications with TamboUI"
@@ -10,4 +11,9 @@ dependencies {
     api(projects.tambouiTui)
     api(projects.tambouiCss)
     testImplementation(testFixtures(projects.tambouiCore))
+
+    // Test fixtures dependencies
+    testFixturesApi(projects.tambouiCore)
+    testFixturesApi(projects.tambouiTui)
+    testFixturesImplementation(libs.assertj.core)
 }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
@@ -431,6 +431,7 @@ public final class ToolkitRunner implements AutoCloseable {
     @Override
     public void close() {
         scheduler.shutdownNow();
+        eventRouter.close();
         tuiRunner.close();
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventTracer.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventTracer.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.event;
+
+import dev.tamboui.tui.event.Event;
+
+/**
+ * Interface for tracing event routing decisions.
+ * <p>
+ * Implementations log detailed information about how events are routed
+ * through the element tree, which is useful for debugging focus and
+ * event handling issues.
+ * <p>
+ * Enable tracing by setting the {@code TAMBOUI_EVENT_TRACE} environment
+ * variable to a file path:
+ * <pre>
+ * TAMBOUI_EVENT_TRACE=/tmp/trace.log ./run-demo.sh my-demo
+ * </pre>
+ * <p>
+ * The trace file uses JSON Lines format (each line is a complete JSON object):
+ * <pre>
+ * {"ts":"2026-01-29T10:00:00.123","type":"route_start","event":"KeyEvent[TAB]","focused":"input1","elements":3}
+ * {"ts":"2026-01-29T10:00:00.124","type":"candidate","id":"input1","phase":"focused","decision":"tried"}
+ * {"ts":"2026-01-29T10:00:00.125","type":"route_end","event":"KeyEvent[TAB]","result":"HANDLED"}
+ * </pre>
+ *
+ * @see FileEventTracer
+ * @see EventTracerFactory
+ */
+public interface EventTracer extends AutoCloseable {
+
+    /**
+     * A no-op tracer that does nothing.
+     */
+    EventTracer NOOP = new EventTracer() {
+        @Override
+        public void traceRouteStart(long routeId, Event event, String focusedId, int elementCount) {
+        }
+
+        @Override
+        public void traceRouteEnd(long routeId, Event event, EventResult result) {
+        }
+
+        @Override
+        public void traceCandidate(long routeId, String elementId, String elementType, String phase, String decision, String reason) {
+        }
+
+        @Override
+        public void traceFocusChange(long routeId, String fromId, String toId, String reason) {
+        }
+
+        @Override
+        public void traceFocusNavigation(long routeId, String action, boolean success, String fromId, String toId) {
+        }
+
+        @Override
+        public void traceDragState(long routeId, String action, String elementId, int x, int y) {
+        }
+
+        @Override
+        public void traceGlobalHandler(long routeId, int index, EventResult result) {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    /**
+     * Traces the start of event routing.
+     *
+     * @param routeId      unique ID for this routing operation
+     * @param event        the event being routed
+     * @param focusedId    the currently focused element ID (may be null)
+     * @param elementCount the number of registered elements
+     */
+    void traceRouteStart(long routeId, Event event, String focusedId, int elementCount);
+
+    /**
+     * Traces the end of event routing.
+     *
+     * @param routeId the routing operation ID
+     * @param event   the event that was routed
+     * @param result  the routing result
+     */
+    void traceRouteEnd(long routeId, Event event, EventResult result);
+
+    /**
+     * Traces an element being considered for event handling.
+     *
+     * @param routeId     the routing operation ID
+     * @param elementId   the element ID (may be null)
+     * @param elementType the element type (class name or style type)
+     * @param phase       the routing phase (e.g., "focused", "global", "unfocused")
+     * @param decision    the decision (e.g., "tried", "skipped", "handled")
+     * @param reason      optional reason for the decision (may be null)
+     */
+    void traceCandidate(long routeId, String elementId, String elementType, String phase, String decision, String reason);
+
+    /**
+     * Traces a focus change.
+     *
+     * @param routeId the routing operation ID
+     * @param fromId  the previous focused element ID (may be null)
+     * @param toId    the new focused element ID (may be null)
+     * @param reason  the reason for the change (e.g., "Tab navigation", "click")
+     */
+    void traceFocusChange(long routeId, String fromId, String toId, String reason);
+
+    /**
+     * Traces a focus navigation action (Tab/Shift+Tab).
+     *
+     * @param routeId the routing operation ID
+     * @param action  the action (e.g., "focusNext", "focusPrevious")
+     * @param success whether the navigation succeeded
+     * @param fromId  the element focused before (may be null)
+     * @param toId    the element focused after (may be null)
+     */
+    void traceFocusNavigation(long routeId, String action, boolean success, String fromId, String toId);
+
+    /**
+     * Traces a drag state change.
+     *
+     * @param routeId   the routing operation ID
+     * @param action    the action (e.g., "start", "drag", "end", "cancel")
+     * @param elementId the element being dragged (may be null for end/cancel)
+     * @param x         the x coordinate
+     * @param y         the y coordinate
+     */
+    void traceDragState(long routeId, String action, String elementId, int x, int y);
+
+    /**
+     * Traces a global handler invocation.
+     *
+     * @param routeId the routing operation ID
+     * @param index   the handler index
+     * @param result  the result of the handler
+     */
+    void traceGlobalHandler(long routeId, int index, EventResult result);
+
+    /**
+     * Closes the tracer and releases any resources.
+     */
+    @Override
+    void close();
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventTracerFactory.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventTracerFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.event;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Factory for creating event tracers based on environment configuration.
+ * <p>
+ * The tracer is enabled by setting the {@code TAMBOUI_EVENT_TRACE} environment
+ * variable to a file path:
+ * <pre>
+ * export TAMBOUI_EVENT_TRACE=/tmp/trace.log
+ * ./run-demo.sh my-demo
+ * </pre>
+ * <p>
+ * If the environment variable is not set or is empty, a no-op tracer is returned.
+ * If the file cannot be opened, a warning is logged and a no-op tracer is returned.
+ *
+ * @see EventTracer
+ * @see FileEventTracer
+ */
+public final class EventTracerFactory {
+
+    private static final Logger LOGGER = Logger.getLogger(EventTracerFactory.class.getName());
+
+    /**
+     * Environment variable name for enabling event tracing.
+     */
+    public static final String ENV_VAR = "TAMBOUI_EVENT_TRACE";
+
+    private EventTracerFactory() {
+        // Factory class
+    }
+
+    /**
+     * Creates an event tracer based on environment configuration.
+     * <p>
+     * If the {@code TAMBOUI_EVENT_TRACE} environment variable is set to a file path,
+     * returns a {@link FileEventTracer}. Otherwise, returns a no-op tracer.
+     *
+     * @return an event tracer
+     */
+    public static EventTracer create() {
+        String tracePath = System.getenv(ENV_VAR);
+        if (tracePath == null || tracePath.trim().isEmpty()) {
+            return EventTracer.NOOP;
+        }
+        return create(Paths.get(tracePath.trim()));
+    }
+
+    /**
+     * Creates an event tracer writing to the specified file.
+     * <p>
+     * If the file cannot be opened, a warning is logged and a no-op tracer is returned.
+     *
+     * @param filePath the path to the trace file
+     * @return an event tracer
+     */
+    public static EventTracer create(Path filePath) {
+        try {
+            return new FileEventTracer(filePath);
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to open trace file: " + filePath + ". Event tracing is disabled.", e);
+            return EventTracer.NOOP;
+        }
+    }
+
+    /**
+     * Returns whether event tracing is enabled via environment variable.
+     *
+     * @return true if the TAMBOUI_EVENT_TRACE environment variable is set
+     */
+    public static boolean isEnabled() {
+        String tracePath = System.getenv(ENV_VAR);
+        return tracePath != null && !tracePath.trim().isEmpty();
+    }
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/FileEventTracer.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/FileEventTracer.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.event;
+
+import dev.tamboui.tui.event.Event;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Event tracer that writes JSON Lines to a file.
+ * <p>
+ * Each line is a complete JSON object, making the file easy to parse,
+ * grep, and analyze with standard tools. The format is:
+ * <pre>
+ * {"ts":"2026-01-29T10:00:00.123Z","type":"route_start","event":"KeyEvent[TAB]",...}
+ * </pre>
+ * <p>
+ * The file is opened for append, so multiple runs can be captured in the same file.
+ * Output is flushed after each trace call to ensure data is written even if the
+ * application crashes.
+ *
+ * @see EventTracer
+ * @see EventTracerFactory
+ */
+public final class FileEventTracer implements EventTracer {
+
+    private static final Logger LOGGER = Logger.getLogger(FileEventTracer.class.getName());
+    private static final DateTimeFormatter TIMESTAMP_FORMAT =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneOffset.UTC);
+
+    private final BufferedWriter writer;
+    private final Path filePath;
+    private volatile boolean closed;
+
+    /**
+     * Creates a new file event tracer.
+     *
+     * @param filePath the path to the trace file
+     * @throws IOException if the file cannot be opened for writing
+     */
+    public FileEventTracer(Path filePath) throws IOException {
+        this.filePath = filePath;
+        this.writer = Files.newBufferedWriter(
+            filePath,
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.APPEND
+        );
+        this.closed = false;
+
+        // Write header line to mark start of session
+        writeLine("{\"ts\":\"%s\",\"type\":\"session_start\"}", timestamp());
+    }
+
+    @Override
+    public void traceRouteStart(long routeId, Event event, String focusedId, int elementCount) {
+        writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"route_start\",\"event\":\"%s\",\"focused\":%s,\"elements\":%d}",
+            timestamp(), routeId, escape(event.toString()), jsonString(focusedId), elementCount);
+    }
+
+    @Override
+    public void traceRouteEnd(long routeId, Event event, EventResult result) {
+        writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"route_end\",\"event\":\"%s\",\"result\":\"%s\"}",
+            timestamp(), routeId, escape(event.toString()), result.name());
+    }
+
+    @Override
+    public void traceCandidate(long routeId, String elementId, String elementType, String phase, String decision, String reason) {
+        if (reason != null) {
+            writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"candidate\",\"id\":%s,\"elementType\":\"%s\",\"phase\":\"%s\",\"decision\":\"%s\",\"reason\":\"%s\"}",
+                timestamp(), routeId, jsonString(elementId), escape(elementType), phase, decision, escape(reason));
+        } else {
+            writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"candidate\",\"id\":%s,\"elementType\":\"%s\",\"phase\":\"%s\",\"decision\":\"%s\"}",
+                timestamp(), routeId, jsonString(elementId), escape(elementType), phase, decision);
+        }
+    }
+
+    @Override
+    public void traceFocusChange(long routeId, String fromId, String toId, String reason) {
+        writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"focus_change\",\"from\":%s,\"to\":%s,\"reason\":\"%s\"}",
+            timestamp(), routeId, jsonString(fromId), jsonString(toId), escape(reason));
+    }
+
+    @Override
+    public void traceFocusNavigation(long routeId, String action, boolean success, String fromId, String toId) {
+        writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"focus_nav\",\"action\":\"%s\",\"success\":%b,\"from\":%s,\"to\":%s}",
+            timestamp(), routeId, action, success, jsonString(fromId), jsonString(toId));
+    }
+
+    @Override
+    public void traceDragState(long routeId, String action, String elementId, int x, int y) {
+        writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"drag\",\"action\":\"%s\",\"element\":%s,\"x\":%d,\"y\":%d}",
+            timestamp(), routeId, action, jsonString(elementId), x, y);
+    }
+
+    @Override
+    public void traceGlobalHandler(long routeId, int index, EventResult result) {
+        writeLine("{\"ts\":\"%s\",\"rid\":%d,\"type\":\"global_handler\",\"index\":%d,\"result\":\"%s\"}",
+            timestamp(), routeId, index, result.name());
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        try {
+            writeLine("{\"ts\":\"%s\",\"type\":\"session_end\"}", timestamp());
+            writer.close();
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to close trace file: " + filePath, e);
+        }
+    }
+
+    private String timestamp() {
+        return TIMESTAMP_FORMAT.format(Instant.now());
+    }
+
+    private void writeLine(String format, Object... args) {
+        if (closed) {
+            return;
+        }
+        try {
+            writer.write(String.format(format, args));
+            writer.newLine();
+            writer.flush();
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Failed to write trace: " + filePath, e);
+        }
+    }
+
+    private static String jsonString(String value) {
+        if (value == null) {
+            return "null";
+        }
+        return "\"" + escape(value) + "\"";
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/EventRouterTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/EventRouterTest.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.event;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.toolkit.test.TestElement;
+import dev.tamboui.toolkit.test.TestToolkitApp;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseButton;
+import dev.tamboui.tui.event.MouseEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link EventRouter} covering key routing, mouse routing,
+ * global handlers, and drag handling.
+ */
+@DisplayName("EventRouter")
+class EventRouterTest {
+
+    private TestToolkitApp app;
+
+    @BeforeEach
+    void setUp() {
+        app = TestToolkitApp.create();
+    }
+
+    @Nested
+    @DisplayName("Key event routing")
+    class KeyEventRouting {
+
+        @Test
+        @DisplayName("routes key events to focused element first")
+        void routesToFocusedElementFirst() {
+            TestElement input1 = TestElement.create("input1").focusable().handlesAllKeys();
+            TestElement input2 = TestElement.create("input2").focusable().handlesAllKeys();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofChar('a'))
+               .assertHandled()
+               .assertFocusIs("input1");
+
+            assertThat(input1.keyEvents()).hasSize(1);
+            assertThat(input1.receivedFocusedKeyEvent()).isTrue();
+            assertThat(input2.keyEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("passes key events to unfocused elements if focused element doesn't handle")
+        void passesToUnfocusedIfNotHandled() {
+            TestElement input1 = TestElement.create("input1").focusable(); // Does NOT handle keys
+            TestElement input2 = TestElement.create("input2").focusable().handlesAllKeys();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofChar('a'))
+               .assertUnhandled();  // Neither handles in unfocused mode
+
+            assertThat(input1.keyEvents()).hasSize(1);  // Got event (focused=true)
+            assertThat(input2.keyEvents()).hasSize(1);  // Got event (focused=false)
+        }
+
+        @Test
+        @DisplayName("focused element receives focused=true, others receive focused=false")
+        void focusedStateIsCorrect() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement input2 = TestElement.create("input2").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofChar('x'));
+
+            assertThat(input1.focusedStates()).containsExactly(true);
+            assertThat(input2.focusedStates()).containsExactly(false);
+        }
+    }
+
+    @Nested
+    @DisplayName("Mouse event routing")
+    class MouseEventRouting {
+
+        @Test
+        @DisplayName("routes mouse press to element at position")
+        void routesToElementAtPosition() {
+            TestElement input1 = TestElement.create("input1").focusable().handlesAllMouse();
+            TestElement input2 = TestElement.create("input2").focusable().handlesAllMouse();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1));
+
+            // Click on input2 (y=1)
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 1))
+               .assertHandled()
+               .assertFocusIs("input2");
+
+            assertThat(input1.mouseEvents()).isEmpty();
+            assertThat(input2.mouseEvents()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("click focuses element even without mouse handler")
+        void clickFocusesElement() {
+            TestElement input1 = TestElement.create("input1").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1));
+
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 0))
+               .assertHandled()
+               .assertFocusIs("input1");
+        }
+
+        @Test
+        @DisplayName("click outside all elements clears focus")
+        void clickOutsideClearsFocus() {
+            TestElement input1 = TestElement.create("input1").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withFocus("input1");
+
+            // Click outside (y=5, no element there)
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 5))
+               .assertNoFocus();
+        }
+
+        @Test
+        @DisplayName("top element (last registered) receives events first in z-order")
+        void zOrderRespected() {
+            TestElement bottom = TestElement.create("bottom").focusable().handlesAllMouse();
+            TestElement top = TestElement.create("top").focusable().handlesAllMouse();
+
+            // Both elements at same position - top is registered last
+            app.withElement(bottom, new Rect(0, 0, 10, 5))
+               .withElement(top, new Rect(0, 0, 10, 5));
+
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 2))
+               .assertHandled()
+               .assertFocusIs("top");
+
+            // Top element gets the event, bottom doesn't
+            assertThat(top.mouseEvents()).hasSize(1);
+            assertThat(bottom.mouseEvents()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Global event handlers")
+    class GlobalHandlers {
+
+        @Test
+        @DisplayName("global handlers are called for non-key events before elements")
+        void globalHandlersCalledFirst() {
+            boolean[] handlerCalled = {false};
+
+            app.withGlobalHandler(event -> {
+                handlerCalled[0] = true;
+                return EventResult.HANDLED;
+            });
+
+            TestElement input1 = TestElement.create("input1").focusable().handlesAllMouse();
+            app.withElement(input1, new Rect(0, 0, 10, 1));
+
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 0))
+               .assertHandled();
+
+            assertThat(handlerCalled[0]).isTrue();
+            // Element doesn't receive event because global handler consumed it
+            assertThat(input1.mouseEvents()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("global handlers are called after focused element for key events")
+        void globalHandlersAfterFocusedForKeys() {
+            int[] callOrder = {0};
+            int[] globalOrder = {0};
+            int[] elementOrder = {0};
+
+            app.withGlobalHandler(event -> {
+                globalOrder[0] = ++callOrder[0];
+                return EventResult.UNHANDLED;
+            });
+
+            TestElement input1 = TestElement.create("input1").focusable()
+                .onKeyEvent(event -> {
+                    elementOrder[0] = ++callOrder[0];
+                    return EventResult.UNHANDLED;
+                });
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofChar('a'));
+
+            // Element (focused) is called first, then global handler
+            assertThat(elementOrder[0]).isEqualTo(1);
+            assertThat(globalOrder[0]).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("Element count and registration")
+    class Registration {
+
+        @Test
+        @DisplayName("reports correct element count")
+        void reportsElementCount() {
+            TestElement e1 = TestElement.create("e1");
+            TestElement e2 = TestElement.create("e2");
+            TestElement e3 = TestElement.create("e3");
+
+            app.withElement(e1, new Rect(0, 0, 10, 1))
+               .withElement(e2, new Rect(0, 1, 10, 1))
+               .withElement(e3, new Rect(0, 2, 10, 1));
+
+            assertThat(app.eventRouter().elementCount()).isEqualTo(3);
+        }
+    }
+}

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/FocusNavigationTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/FocusNavigationTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.event;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.toolkit.test.TestElement;
+import dev.tamboui.toolkit.test.TestToolkitApp;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+import dev.tamboui.tui.event.MouseButton;
+import dev.tamboui.tui.event.MouseEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for focus navigation (Tab/Shift+Tab, Escape, click-to-focus).
+ */
+@DisplayName("Focus Navigation")
+class FocusNavigationTest {
+
+    private TestToolkitApp app;
+
+    @BeforeEach
+    void setUp() {
+        app = TestToolkitApp.create();
+    }
+
+    @Nested
+    @DisplayName("Tab navigation")
+    class TabNavigation {
+
+        @Test
+        @DisplayName("Tab moves focus to next element")
+        void tabMovesToNext() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement input2 = TestElement.create("input2").focusable();
+            TestElement input3 = TestElement.create("input3").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withElement(input3, new Rect(0, 2, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB))
+               .assertHandled()
+               .assertFocusMovedTo("input2");
+        }
+
+        @Test
+        @DisplayName("Tab wraps from last to first element")
+        void tabWrapsAround() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement input2 = TestElement.create("input2").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withFocus("input2");  // Start at last
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB))
+               .assertHandled()
+               .assertFocusMovedTo("input1");
+        }
+
+        @Test
+        @DisplayName("Tab with single element keeps focus")
+        void tabWithSingleElement() {
+            TestElement input1 = TestElement.create("input1").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB))
+               .assertUnhandled()  // No change, returns unhandled
+               .assertFocusIs("input1");
+        }
+    }
+
+    @Nested
+    @DisplayName("Shift+Tab navigation")
+    class ShiftTabNavigation {
+
+        @Test
+        @DisplayName("Shift+Tab moves focus to previous element")
+        void shiftTabMovesToPrevious() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement input2 = TestElement.create("input2").focusable();
+            TestElement input3 = TestElement.create("input3").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withElement(input3, new Rect(0, 2, 10, 1))
+               .withFocus("input2");
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB, KeyModifiers.SHIFT))
+               .assertHandled()
+               .assertFocusMovedTo("input1");
+        }
+
+        @Test
+        @DisplayName("Shift+Tab wraps from first to last element")
+        void shiftTabWrapsAround() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement input2 = TestElement.create("input2").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withFocus("input1");  // Start at first
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB, KeyModifiers.SHIFT))
+               .assertHandled()
+               .assertFocusMovedTo("input2");
+        }
+    }
+
+    @Nested
+    @DisplayName("Escape clears focus")
+    class EscapeClearsFocus {
+
+        @Test
+        @DisplayName("Escape clears focus when no element handles it")
+        void escapeClearsFocus() {
+            TestElement input1 = TestElement.create("input1").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofKey(KeyCode.ESCAPE))
+               .assertHandled()
+               .assertFocusCleared();
+        }
+
+        @Test
+        @DisplayName("Escape does not clear focus if element handles it")
+        void escapeRespectedIfHandled() {
+            TestElement input1 = TestElement.create("input1").focusable()
+                .onKeyEvent(event -> {
+                    if (event.isKey(KeyCode.ESCAPE)) {
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withFocus("input1");
+
+            app.send(KeyEvent.ofKey(KeyCode.ESCAPE))
+               .assertHandled()
+               .assertFocusIs("input1");  // Focus not cleared because element handled it
+        }
+    }
+
+    @Nested
+    @DisplayName("Click-to-focus")
+    class ClickToFocus {
+
+        @Test
+        @DisplayName("clicking focusable element focuses it")
+        void clickFocuses() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement input2 = TestElement.create("input2").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(input2, new Rect(0, 1, 10, 1))
+               .withFocus("input1");
+
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 1))  // Click on input2
+               .assertHandled()
+               .assertFocusMovedTo("input2");
+        }
+
+        @Test
+        @DisplayName("clicking non-focusable element that handles click keeps focus unchanged")
+        void clickNonFocusableWithHandlerKeepsFocus() {
+            TestElement input1 = TestElement.create("input1").focusable();
+            TestElement label = TestElement.create("label").handlesAllMouse();  // Handles click
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withElement(label, new Rect(0, 1, 10, 1))
+               .withFocus("input1");
+
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 1))  // Click on label
+               .assertHandled()  // Handled by label
+               .assertFocusIs("input1");  // Focus unchanged because label is not focusable
+        }
+
+        @Test
+        @DisplayName("clicking outside all elements clears focus")
+        void clickOutsideClearsFocus() {
+            TestElement input1 = TestElement.create("input1").focusable();
+
+            app.withElement(input1, new Rect(0, 0, 10, 1))
+               .withFocus("input1");
+
+            app.send(MouseEvent.press(MouseButton.LEFT, 5, 5))  // Click outside
+               .assertNoFocus();
+        }
+    }
+
+    @Nested
+    @DisplayName("Focus order")
+    class FocusOrder {
+
+        @Test
+        @DisplayName("focus order matches registration order")
+        void focusOrderMatchesRegistration() {
+            TestElement a = TestElement.create("a").focusable();
+            TestElement b = TestElement.create("b").focusable();
+            TestElement c = TestElement.create("c").focusable();
+
+            app.withElement(a, new Rect(0, 0, 10, 1))
+               .withElement(b, new Rect(0, 1, 10, 1))
+               .withElement(c, new Rect(0, 2, 10, 1))
+               .withFocus("a");
+
+            // Tab through all elements
+            assertThat(app.focusedId()).isEqualTo("a");
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB));
+            assertThat(app.focusedId()).isEqualTo("b");
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB));
+            assertThat(app.focusedId()).isEqualTo("c");
+
+            app.send(KeyEvent.ofKey(KeyCode.TAB));
+            assertThat(app.focusedId()).isEqualTo("a");  // Wrapped around
+        }
+
+        @Test
+        @DisplayName("non-focusable elements are skipped in focus order")
+        void nonFocusableSkipped() {
+            TestElement a = TestElement.create("a").focusable();
+            TestElement b = TestElement.create("b");  // Not focusable
+            TestElement c = TestElement.create("c").focusable();
+
+            app.withElement(a, new Rect(0, 0, 10, 1))
+               .withElement(b, new Rect(0, 1, 10, 1))
+               .withElement(c, new Rect(0, 2, 10, 1))
+               .withFocus("a");
+
+            // Tab from a should go directly to c (skipping b)
+            app.send(KeyEvent.ofKey(KeyCode.TAB))
+               .assertHandled()
+               .assertFocusMovedTo("c");
+        }
+    }
+}

--- a/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/test/EventRouterResult.java
+++ b/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/test/EventRouterResult.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.test;
+
+import dev.tamboui.toolkit.event.EventResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Wrapper around routing results with fluent assertions for testing.
+ * <p>
+ * Provides a readable API for verifying event routing behavior:
+ *
+ * <pre>{@code
+ * app.send(KeyEvent.ofKey(KeyCode.TAB))
+ *     .assertHandled()
+ *     .assertFocusMovedTo("input2");
+ *
+ * app.send(MouseEvent.press(MouseButton.LEFT, 5, 5))
+ *     .assertHandled()
+ *     .assertFocusIs("input1");
+ * }</pre>
+ */
+public final class EventRouterResult {
+
+    private final EventResult result;
+    private final String focusBefore;
+    private final String focusAfter;
+    private final TestToolkitApp app;
+
+    EventRouterResult(EventResult result, String focusBefore, String focusAfter, TestToolkitApp app) {
+        this.result = result;
+        this.focusBefore = focusBefore;
+        this.focusAfter = focusAfter;
+        this.app = app;
+    }
+
+    /**
+     * Returns the raw event result.
+     *
+     * @return the event result
+     */
+    public EventResult result() {
+        return result;
+    }
+
+    /**
+     * Returns the focused element ID before the event was routed.
+     *
+     * @return the focused ID before, or null if nothing was focused
+     */
+    public String focusBefore() {
+        return focusBefore;
+    }
+
+    /**
+     * Returns the focused element ID after the event was routed.
+     *
+     * @return the focused ID after, or null if nothing is focused
+     */
+    public String focusAfter() {
+        return focusAfter;
+    }
+
+    /**
+     * Returns the test app for chaining further operations.
+     *
+     * @return the test app
+     */
+    public TestToolkitApp app() {
+        return app;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Fluent assertions
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Asserts that the event was handled.
+     *
+     * @return this for chaining
+     */
+    public EventRouterResult assertHandled() {
+        assertThat(result)
+            .as("Expected event to be HANDLED")
+            .isEqualTo(EventResult.HANDLED);
+        return this;
+    }
+
+    /**
+     * Asserts that the event was not handled.
+     *
+     * @return this for chaining
+     */
+    public EventRouterResult assertUnhandled() {
+        assertThat(result)
+            .as("Expected event to be UNHANDLED")
+            .isEqualTo(EventResult.UNHANDLED);
+        return this;
+    }
+
+    /**
+     * Asserts that focus moved to the specified element.
+     *
+     * @param expectedId the expected focused element ID
+     * @return this for chaining
+     */
+    public EventRouterResult assertFocusMovedTo(String expectedId) {
+        assertThat(focusAfter)
+            .as("Expected focus to move to '%s' but focus is '%s' (was '%s' before)",
+                expectedId, focusAfter, focusBefore)
+            .isEqualTo(expectedId);
+        assertThat(focusAfter)
+            .as("Expected focus to change, but focus is still '%s'", focusBefore)
+            .isNotEqualTo(focusBefore);
+        return this;
+    }
+
+    /**
+     * Asserts that focus is currently on the specified element.
+     *
+     * @param expectedId the expected focused element ID
+     * @return this for chaining
+     */
+    public EventRouterResult assertFocusIs(String expectedId) {
+        assertThat(focusAfter)
+            .as("Expected focus to be '%s' but was '%s'", expectedId, focusAfter)
+            .isEqualTo(expectedId);
+        return this;
+    }
+
+    /**
+     * Asserts that focus did not change.
+     *
+     * @return this for chaining
+     */
+    public EventRouterResult assertFocusUnchanged() {
+        assertThat(focusAfter)
+            .as("Expected focus to remain '%s' but changed to '%s'", focusBefore, focusAfter)
+            .isEqualTo(focusBefore);
+        return this;
+    }
+
+    /**
+     * Asserts that nothing is focused.
+     *
+     * @return this for chaining
+     */
+    public EventRouterResult assertNoFocus() {
+        assertThat(focusAfter)
+            .as("Expected no focus but '%s' is focused", focusAfter)
+            .isNull();
+        return this;
+    }
+
+    /**
+     * Asserts that focus was cleared (something was focused before, nothing now).
+     *
+     * @return this for chaining
+     */
+    public EventRouterResult assertFocusCleared() {
+        assertThat(focusBefore)
+            .as("Expected something to have been focused before clearing")
+            .isNotNull();
+        assertThat(focusAfter)
+            .as("Expected focus to be cleared but '%s' is focused", focusAfter)
+            .isNull();
+        return this;
+    }
+}

--- a/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/test/TestElement.java
+++ b/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/test/TestElement.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.test;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.toolkit.event.KeyEventHandler;
+import dev.tamboui.toolkit.event.MouseEventHandler;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A mock element for testing event routing and focus management.
+ * <p>
+ * Provides configurable behavior for focus, event handling, and
+ * records all received events for later assertion.
+ *
+ * <pre>{@code
+ * TestElement element = TestElement.create("input1")
+ *     .focusable()
+ *     .handlesAllKeys();
+ *
+ * // After routing events
+ * assertThat(element.keyEvents()).hasSize(2);
+ * assertThat(element.receivedFocusedKeyEvent()).isTrue();
+ * }</pre>
+ */
+public final class TestElement implements Element {
+
+    private final String elementId;
+    private boolean focusable;
+    private boolean handlesAllKeys;
+    private boolean handlesAllMouse;
+    private KeyEventHandler keyHandler;
+    private MouseEventHandler mouseHandler;
+    private Rect lastRenderedArea;
+
+    // Event recording
+    private final List<KeyEvent> keyEvents = new ArrayList<>();
+    private final List<MouseEvent> mouseEvents = new ArrayList<>();
+    private final List<Boolean> focusedStates = new ArrayList<>();
+
+    private TestElement(String elementId) {
+        this.elementId = elementId;
+    }
+
+    /**
+     * Creates a new test element with the given ID.
+     *
+     * @param elementId the element ID
+     * @return a new test element
+     */
+    public static TestElement create(String elementId) {
+        return new TestElement(elementId);
+    }
+
+    /**
+     * Makes this element focusable.
+     *
+     * @return this element for chaining
+     */
+    public TestElement focusable() {
+        this.focusable = true;
+        return this;
+    }
+
+    /**
+     * Sets whether this element is focusable.
+     *
+     * @param focusable true to make focusable
+     * @return this element for chaining
+     */
+    public TestElement focusable(boolean focusable) {
+        this.focusable = focusable;
+        return this;
+    }
+
+    /**
+     * Configures this element to handle all key events when focused.
+     *
+     * @return this element for chaining
+     */
+    public TestElement handlesAllKeys() {
+        this.handlesAllKeys = true;
+        return this;
+    }
+
+    /**
+     * Configures this element to handle all mouse events.
+     *
+     * @return this element for chaining
+     */
+    public TestElement handlesAllMouse() {
+        this.handlesAllMouse = true;
+        return this;
+    }
+
+    /**
+     * Sets a custom key event handler.
+     *
+     * @param handler the handler
+     * @return this element for chaining
+     */
+    public TestElement onKeyEvent(KeyEventHandler handler) {
+        this.keyHandler = handler;
+        return this;
+    }
+
+    /**
+     * Sets a custom mouse event handler.
+     *
+     * @param handler the handler
+     * @return this element for chaining
+     */
+    public TestElement onMouseEvent(MouseEventHandler handler) {
+        this.mouseHandler = handler;
+        return this;
+    }
+
+    @Override
+    public void render(Frame frame, Rect area, RenderContext context) {
+        this.lastRenderedArea = area;
+    }
+
+    @Override
+    public Constraint constraint() {
+        return null;
+    }
+
+    @Override
+    public boolean isFocusable() {
+        return focusable;
+    }
+
+    @Override
+    public String id() {
+        return elementId;
+    }
+
+    @Override
+    public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
+        keyEvents.add(event);
+        focusedStates.add(focused);
+
+        // Don't call keyHandler here - the EventRouter will call keyEventHandler() separately
+        // This avoids double-calling the handler
+
+        if (focused && handlesAllKeys) {
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    }
+
+    @Override
+    public EventResult handleMouseEvent(MouseEvent event) {
+        mouseEvents.add(event);
+
+        if (mouseHandler != null) {
+            return mouseHandler.handle(event);
+        }
+
+        if (handlesAllMouse) {
+            return EventResult.HANDLED;
+        }
+        return EventResult.UNHANDLED;
+    }
+
+    @Override
+    public KeyEventHandler keyEventHandler() {
+        return keyHandler;
+    }
+
+    @Override
+    public MouseEventHandler mouseEventHandler() {
+        return mouseHandler;
+    }
+
+    @Override
+    public Rect renderedArea() {
+        return lastRenderedArea;
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Event recording accessors for testing assertions
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Returns all received key events.
+     *
+     * @return the list of key events
+     */
+    public List<KeyEvent> keyEvents() {
+        return keyEvents;
+    }
+
+    /**
+     * Returns all received mouse events.
+     *
+     * @return the list of mouse events
+     */
+    public List<MouseEvent> mouseEvents() {
+        return mouseEvents;
+    }
+
+    /**
+     * Returns whether any key event was received while this element was focused.
+     *
+     * @return true if a focused key event was received
+     */
+    public boolean receivedFocusedKeyEvent() {
+        return focusedStates.contains(true);
+    }
+
+    /**
+     * Returns whether any key event was received while this element was NOT focused.
+     *
+     * @return true if an unfocused key event was received
+     */
+    public boolean receivedUnfocusedKeyEvent() {
+        return focusedStates.contains(false);
+    }
+
+    /**
+     * Returns the focused states for each received key event.
+     *
+     * @return the list of focused states (parallel to keyEvents)
+     */
+    public List<Boolean> focusedStates() {
+        return focusedStates;
+    }
+
+    /**
+     * Clears all recorded events.
+     */
+    public void clearRecordedEvents() {
+        keyEvents.clear();
+        mouseEvents.clear();
+        focusedStates.clear();
+    }
+}

--- a/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/test/TestToolkitApp.java
+++ b/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/test/TestToolkitApp.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.test;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.toolkit.element.ElementRegistry;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.toolkit.event.EventRouter;
+import dev.tamboui.toolkit.event.GlobalEventHandler;
+import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.tui.bindings.ActionHandler;
+import dev.tamboui.tui.event.Event;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A headless test harness for testing event routing without a TUI backend.
+ * <p>
+ * Provides a fluent API for setting up elements and sending events:
+ *
+ * <pre>{@code
+ * TestToolkitApp app = TestToolkitApp.create()
+ *     .withElement(TestElement.create("input1").focusable(), new Rect(0, 0, 10, 1))
+ *     .withElement(TestElement.create("input2").focusable(), new Rect(0, 1, 10, 1));
+ *
+ * app.send(KeyEvent.ofKey(KeyCode.TAB))
+ *     .assertHandled()
+ *     .assertFocusMovedTo("input2");
+ * }</pre>
+ * <p>
+ * Note: This bypasses render thread checks since tests don't run on a render thread.
+ * The check passes when no render thread has been set (per RenderThread design).
+ */
+public final class TestToolkitApp {
+
+    private final FocusManager focusManager;
+    private final ElementRegistry elementRegistry;
+    private final EventRouter eventRouter;
+    private final List<TestElement> elements = new ArrayList<>();
+
+    private TestToolkitApp() {
+        this.focusManager = new FocusManager();
+        this.elementRegistry = new ElementRegistry();
+        this.eventRouter = new EventRouter(focusManager, elementRegistry);
+    }
+
+    /**
+     * Creates a new test app.
+     *
+     * @return a new test app
+     */
+    public static TestToolkitApp create() {
+        return new TestToolkitApp();
+    }
+
+    /**
+     * Adds an element to the app at the specified area.
+     * <p>
+     * The element is registered with both the event router and focus manager
+     * (if focusable).
+     *
+     * @param element the test element
+     * @param area    the element's area
+     * @return this app for chaining
+     */
+    public TestToolkitApp withElement(TestElement element, Rect area) {
+        elements.add(element);
+        eventRouter.registerElement(element, area);
+        if (element.isFocusable() && element.id() != null) {
+            focusManager.registerFocusable(element.id(), area);
+        }
+        return this;
+    }
+
+    /**
+     * Adds a global event handler.
+     *
+     * @param handler the global handler
+     * @return this app for chaining
+     */
+    public TestToolkitApp withGlobalHandler(GlobalEventHandler handler) {
+        eventRouter.addGlobalHandler(handler);
+        return this;
+    }
+
+    /**
+     * Adds an action handler as a global event handler.
+     *
+     * @param handler the action handler
+     * @return this app for chaining
+     */
+    public TestToolkitApp withGlobalHandler(ActionHandler handler) {
+        eventRouter.addGlobalHandler(handler);
+        return this;
+    }
+
+    /**
+     * Sets the initial focus to the element with the given ID.
+     *
+     * @param elementId the element ID to focus
+     * @return this app for chaining
+     */
+    public TestToolkitApp withFocus(String elementId) {
+        focusManager.setFocus(elementId);
+        return this;
+    }
+
+    /**
+     * Sends an event through the router and returns the result.
+     *
+     * @param event the event to send
+     * @return the result with fluent assertions
+     */
+    public EventRouterResult send(Event event) {
+        String focusBefore = focusManager.focusedId();
+        EventResult result = eventRouter.route(event);
+        String focusAfter = focusManager.focusedId();
+        return new EventRouterResult(result, focusBefore, focusAfter, this);
+    }
+
+    /**
+     * Returns the focus manager.
+     *
+     * @return the focus manager
+     */
+    public FocusManager focusManager() {
+        return focusManager;
+    }
+
+    /**
+     * Returns the event router.
+     *
+     * @return the event router
+     */
+    public EventRouter eventRouter() {
+        return eventRouter;
+    }
+
+    /**
+     * Returns the element registry.
+     *
+     * @return the element registry
+     */
+    public ElementRegistry elementRegistry() {
+        return elementRegistry;
+    }
+
+    /**
+     * Returns the currently focused element ID.
+     *
+     * @return the focused ID, or null if nothing is focused
+     */
+    public String focusedId() {
+        return focusManager.focusedId();
+    }
+
+    /**
+     * Returns all registered elements.
+     *
+     * @return unmodifiable list of elements
+     */
+    public List<TestElement> elements() {
+        return Collections.unmodifiableList(elements);
+    }
+
+    /**
+     * Returns the element with the given ID.
+     *
+     * @param elementId the element ID
+     * @return the element, or null if not found
+     */
+    public TestElement element(String elementId) {
+        for (TestElement element : elements) {
+            if (elementId.equals(element.id())) {
+                return element;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Clears all recorded events from all elements.
+     */
+    public void clearRecordedEvents() {
+        for (TestElement element : elements) {
+            element.clearRecordedEvents();
+        }
+    }
+
+    /**
+     * Clears the router state and re-registers all elements.
+     * <p>
+     * Call this at the start of each test scenario to simulate a fresh render.
+     */
+    public void reset() {
+        eventRouter.clear();
+        focusManager.clearFocusables();
+        for (TestElement element : elements) {
+            Rect area = element.renderedArea();
+            if (area != null) {
+                eventRouter.registerElement(element, area);
+                if (element.isFocusable() && element.id() != null) {
+                    focusManager.registerFocusable(element.id(), area);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a mechanism to trace and debug event handling in toolkit. This is because sometimes, the apps don't behave as we expect, and it's difficult to understand why, for example, a key event is not handled, or, more interestingly, what component decided to handle an event in place of another that you expected.

This also adds test fixtures so that we can test the behavior of an application in that regards.