### PR TITLE
feat: Add CSS style grid layout

### DIFF
--- a/docs/src/docs/asciidoc/layouts.adoc
+++ b/docs/src/docs/asciidoc/layouts.adoc
@@ -97,6 +97,15 @@ NOTE: The widget-level `Columns` requires an explicit column count. For auto-det
 A CSS Grid-inspired layout widget that arranges children into a grid with explicit control over grid dimensions, per-column/per-row sizing constraints, and gutter spacing.
 Unlike `Columns` (which uses ordering modes and spacing), `Grid` provides independent horizontal and vertical gutter, per-column width constraints, per-row height constraints, and constraint cycling when fewer constraints than grid dimensions (matching Textual behavior).
 
+Grid supports two mutually exclusive modes:
+
+* **Children mode**: Sequential placement using `children()` and `columnCount()`
+* **Area mode**: Template-based placement using `gridAreas()` and `area()` (CSS grid-template-areas style)
+
+The staged builder pattern ensures compile-time safety — you cannot mix modes.
+
+=== Children Mode
+
 [source,java]
 ----
 Grid grid = Grid.builder()
@@ -109,10 +118,11 @@ Grid grid = Grid.builder()
 grid.render(area, buffer);
 ----
 
-Builder options:
+ChildrenBuilder options:
 
 * `children(Widget...)` / `children(List<Widget>)` - The child widgets to arrange
 * `columnCount(int)` - Number of columns (defaults to 1)
+* `rowCount(int)` - Optional maximum rows (validates children fit within columns × rows)
 * `horizontalGutter(int)` - Gap between columns in cells (default: 0)
 * `verticalGutter(int)` - Gap between rows in cells (default: 0)
 * `flex(Flex)` - How remaining space is distributed (default: `Flex.START`)
@@ -151,7 +161,76 @@ Grid uniform = Grid.builder()
     .build();
 ----
 
-NOTE: The widget-level `Grid` requires an explicit column count. For auto-sizing based on child count (`ceil(sqrt(n))` columns) and CSS property support, use `GridElement` in the Toolkit DSL (via the `grid()` factory method).
+=== Area Mode (Grid Template Areas)
+
+Area mode uses CSS `grid-template-areas` style templates for defining layouts where cells can span multiple rows and columns.
+Named areas must form contiguous rectangles — L-shapes and disconnected regions are rejected with a `LayoutException`.
+
+[source,java]
+----
+// "Holy grail" layout with spanning regions
+Grid layout = Grid.builder()
+    .gridAreas("header header header",
+               "nav    main   main",
+               "nav    main   main",
+               "footer footer footer")
+    .area("header", headerWidget)
+    .area("nav", navWidget)
+    .area("main", mainWidget)
+    .area("footer", footerWidget)
+    .horizontalGutter(1)
+    .verticalGutter(1)
+    .build();
+
+layout.render(area, buffer);
+----
+
+AreaBuilder options:
+
+* `gridAreas(String...)` - Row templates defining named areas (use `.` for empty cells)
+* `area(String, Widget)` - Assign a widget to a named area
+* `horizontalGutter(int)` - Gap between columns (default: 0)
+* `verticalGutter(int)` - Gap between rows (default: 0)
+* `flex(Flex)` - How remaining space is distributed (default: `Flex.START`)
+* `columnConstraints(Constraint...)` - Per-column width constraints
+* `rowConstraints(Constraint...)` - Per-row height constraints
+
+Template rules:
+
+* Each row is a space-separated list of area names
+* All rows must have the same number of columns
+* Area names must start with a letter (alphanumeric and underscores allowed)
+* Use `.` (dot) for empty cells
+* Named areas must form contiguous rectangles
+
+[source,java]
+----
+// Dashboard with 2x2 spanning main area
+Grid dashboard = Grid.builder()
+    .gridAreas("A A B",
+               "A A C",
+               "D D D")
+    .area("A", mainPanel)    // 2x2 span
+    .area("B", sidePanel1)
+    .area("C", sidePanel2)
+    .area("D", statusBar)    // full-width span
+    .horizontalGutter(1)
+    .verticalGutter(1)
+    .build();
+
+// Empty cells with dot notation
+Grid sparse = Grid.builder()
+    .gridAreas("A . B",
+               ". C .")
+    .area("A", widget1)
+    .area("B", widget2)
+    .area("C", widget3)
+    .build();
+----
+
+NOTE: Areas without assigned widgets render as empty space. Assigning a widget to an undefined area throws `LayoutException`.
+
+NOTE: The widget-level `Grid` requires an explicit column count or grid areas template. For auto-sizing based on child count (`ceil(sqrt(n))` columns) and CSS property support, use `GridElement` in the Toolkit DSL (via the `grid()` factory method).
 
 [[dock]]
 == Dock
@@ -261,6 +340,18 @@ grid(header, content, sidebar, footer)
     .gridSize(2, 2)
     .gridColumns(Constraint.length(20), Constraint.fill())
     .gutter(1, 0)
+
+// Grid with template areas (CSS grid-template-areas style)
+grid()
+    .gridAreas("header header header",
+               "nav    main   main",
+               "nav    main   main",
+               "footer footer footer")
+    .area("header", text("Header").bold())
+    .area("nav", list("Nav 1", "Nav 2"))
+    .area("main", text("Main Content"))
+    .area("footer", text("Footer").dim())
+    .gutter(1)
 
 // 5-region dock layout
 dock()

--- a/docs/src/docs/asciidoc/styling.adoc
+++ b/docs/src/docs/asciidoc/styling.adoc
@@ -629,6 +629,10 @@ These properties control how elements are sized and positioned within their cont
 |Gutter spacing for GridElement — uniform or horizontal/vertical
 |`grid-gutter: 2;` `grid-gutter: 1 2;`
 
+|`grid-template-areas`
+|CSS grid-template-areas style layout with named regions that can span multiple cells
+|`grid-template-areas: "H H H; S M M; F F F";`
+
 |`dock-top-height`
 |Height constraint for DockElement top region
 |`dock-top-height: 3;`
@@ -653,6 +657,40 @@ These properties control how elements are sized and positioned within their cont
 |Vertical spacing between rows in FlowElement
 |`flow-row-spacing: 1;`
 |===
+
+===== Grid Template Areas
+
+The `grid-template-areas` property enables CSS grid-template-areas style layouts where named regions can span multiple rows and columns. This is useful for complex dashboard layouts.
+
+Template format:
+
+* Use semicolon-separated rows: `"header header; nav main; footer footer"`
+* Or quoted strings (CSS format): `"header header" "nav main" "footer footer"`
+* Use `.` for empty cells
+* Area names must start with a letter (alphanumeric and underscores allowed)
+* Named areas must form contiguous rectangles
+
+[source,css]
+----
+/* Dashboard layout with spanning regions */
+.dashboard {
+    grid-template-areas: "header header header; nav main main; nav main main; footer footer footer";
+    grid-gutter: 1;
+}
+----
+
+[source,java]
+----
+// Combine CSS template with programmatic area assignment
+grid()
+    .cssClass("dashboard")
+    .area("header", text("Dashboard").bold())
+    .area("nav", list("Menu 1", "Menu 2"))
+    .area("main", content)
+    .area("footer", text("Status").dim())
+----
+
+NOTE: The template can be defined in CSS, but widgets must be assigned to areas programmatically using `.area(name, element)`. CSS alone cannot bind elements to named areas.
 
 ===== Constraint Values
 

--- a/tamboui-core/src/main/java/dev/tamboui/layout/grid/Grid.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/grid/Grid.java
@@ -8,12 +8,15 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.LayoutException;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.widget.Widget;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static dev.tamboui.util.CollectionUtil.listCopyOf;
 
@@ -22,9 +25,15 @@ import static dev.tamboui.util.CollectionUtil.listCopyOf;
  * with explicit control over grid dimensions, per-column/per-row sizing
  * constraints, and gutter spacing.
  * <p>
- * Column and row constraints cycle when fewer constraints than grid dimensions
- * (matching Textual behavior).
+ * Grid supports two mutually exclusive modes:
+ * <ul>
+ *   <li><b>Children mode</b>: Sequential placement using {@code children()} and {@code columnCount()}</li>
+ *   <li><b>Area mode</b>: Template-based placement using {@code gridAreas()} and {@code area()}</li>
+ * </ul>
+ * <p>
+ * The staged builder pattern ensures compile-time safety - you cannot mix modes.
  *
+ * <h2>Children Mode Example</h2>
  * <pre>{@code
  * Grid grid = Grid.builder()
  *     .children(widget1, widget2, widget3, widget4)
@@ -32,32 +41,56 @@ import static dev.tamboui.util.CollectionUtil.listCopyOf;
  *     .horizontalGutter(1)
  *     .verticalGutter(1)
  *     .build();
+ * }</pre>
  *
- * grid.render(area, buffer);
+ * <h2>Area Mode Example</h2>
+ * <pre>{@code
+ * Grid grid = Grid.builder()
+ *     .gridAreas("header header header",
+ *                "nav    main   main",
+ *                "nav    main   main",
+ *                "footer footer footer")
+ *     .area("header", headerWidget)
+ *     .area("nav", navWidget)
+ *     .area("main", mainWidget)
+ *     .area("footer", footerWidget)
+ *     .horizontalGutter(1)
+ *     .verticalGutter(1)
+ *     .build();
  * }</pre>
  */
 public final class Grid implements Widget {
 
+    // Children mode fields
     private final List<Widget> children;
     private final int columnCount;
+    private final int[] rowHeights;
+
+    // Area mode fields
+    private final GridArea gridArea;
+    private final Map<String, Widget> areaWidgets;
+
+    // Common fields
     private final int horizontalGutter;
     private final int verticalGutter;
     private final Flex flex;
     private final List<Constraint> columnConstraints;
     private final List<Constraint> rowConstraints;
-    private final int[] rowHeights;
 
-    private Grid(Builder builder) {
-        this.children = listCopyOf(builder.children);
-        this.columnCount = builder.columnCount;
-        this.horizontalGutter = builder.horizontalGutter;
-        this.verticalGutter = builder.verticalGutter;
-        this.flex = builder.flex;
-        this.columnConstraints = builder.columnConstraints != null
-            ? listCopyOf(builder.columnConstraints) : null;
-        this.rowConstraints = builder.rowConstraints != null
-            ? listCopyOf(builder.rowConstraints) : null;
-        this.rowHeights = builder.rowHeights != null ? builder.rowHeights.clone() : null;
+    private Grid(List<Widget> children, int columnCount, int[] rowHeights,
+                 GridArea gridArea, Map<String, Widget> areaWidgets,
+                 int horizontalGutter, int verticalGutter, Flex flex,
+                 List<Constraint> columnConstraints, List<Constraint> rowConstraints) {
+        this.children = children;
+        this.columnCount = columnCount;
+        this.rowHeights = rowHeights;
+        this.gridArea = gridArea;
+        this.areaWidgets = areaWidgets;
+        this.horizontalGutter = horizontalGutter;
+        this.verticalGutter = verticalGutter;
+        this.flex = flex;
+        this.columnConstraints = columnConstraints;
+        this.rowConstraints = rowConstraints;
     }
 
     /**
@@ -71,7 +104,18 @@ public final class Grid implements Widget {
 
     @Override
     public void render(Rect area, Buffer buffer) {
-        if (area.isEmpty() || children.isEmpty() || columnCount <= 0) {
+        if (area.isEmpty()) {
+            return;
+        }
+
+        // Area-based rendering
+        if (gridArea != null) {
+            renderWithAreas(area, buffer);
+            return;
+        }
+
+        // Children-based rendering
+        if (children.isEmpty() || columnCount <= 0) {
             return;
         }
 
@@ -96,6 +140,154 @@ public final class Grid implements Widget {
         } else {
             renderWithEqualRowHeights(area, buffer, rows, cols, columnRects);
         }
+    }
+
+    private void renderWithAreas(Rect area, Buffer buffer) {
+        if (areaWidgets == null || areaWidgets.isEmpty()) {
+            return;
+        }
+
+        int cols = gridArea.columns();
+        int rows = gridArea.rows();
+
+        // Build horizontal constraints with gutter gaps
+        List<Constraint> hConstraints = buildHorizontalConstraintsForAreas(cols);
+
+        List<Rect> colAreas = Layout.horizontal()
+            .constraints(hConstraints)
+            .flex(flex)
+            .split(area);
+
+        // Extract only column areas (skip gutter areas)
+        List<Rect> columnRects = extractColumnRects(colAreas);
+
+        // Compute row heights and Y positions
+        int[] heights;
+        if (rowConstraints != null && !rowConstraints.isEmpty()) {
+            heights = computeRowHeightsFromConstraints(area, rows);
+        } else {
+            heights = computeEqualRowHeightsForAreas(area.height(), rows);
+        }
+
+        int[] rowYPositions = computeRowYPositions(area.y(), heights, rows);
+
+        // Render each named area
+        for (Map.Entry<String, Widget> entry : areaWidgets.entrySet()) {
+            String areaName = entry.getKey();
+            Widget widget = entry.getValue();
+            GridArea.AreaBounds bounds = gridArea.boundsFor(areaName);
+
+            if (bounds == null) {
+                // Should not happen - validated at build time
+                continue;
+            }
+
+            // Calculate merged cell rect
+            Rect cellRect = computeMergedCellRect(bounds, columnRects, rowYPositions, heights);
+            widget.render(cellRect, buffer);
+        }
+    }
+
+    private List<Constraint> buildHorizontalConstraintsForAreas(int cols) {
+        List<Constraint> constraints = new ArrayList<>();
+        for (int c = 0; c < cols; c++) {
+            if (columnConstraints != null && !columnConstraints.isEmpty()) {
+                constraints.add(columnConstraints.get(c % columnConstraints.size()));
+            } else {
+                constraints.add(Constraint.fill());
+            }
+            if (horizontalGutter > 0 && c < cols - 1) {
+                constraints.add(Constraint.length(horizontalGutter));
+            }
+        }
+        return constraints;
+    }
+
+    private int[] computeRowHeightsFromConstraints(Rect area, int rows) {
+        // Build row constraints with gutters
+        List<Constraint> vConstraints = new ArrayList<>();
+        for (int r = 0; r < rows; r++) {
+            vConstraints.add(rowConstraints.get(r % rowConstraints.size()));
+            if (verticalGutter > 0 && r < rows - 1) {
+                vConstraints.add(Constraint.length(verticalGutter));
+            }
+        }
+
+        List<Rect> allRowAreas = Layout.vertical()
+            .constraints(vConstraints)
+            .flex(flex)
+            .split(area);
+
+        // Extract row heights (skip gutter areas)
+        int[] heights = new int[rows];
+        int rowIndex = 0;
+        for (int i = 0; i < allRowAreas.size() && rowIndex < rows; i++) {
+            if (verticalGutter > 0 && i % 2 == 1) {
+                continue;
+            }
+            heights[rowIndex++] = allRowAreas.get(i).height();
+        }
+        return heights;
+    }
+
+    private int[] computeEqualRowHeightsForAreas(int availableHeight, int rows) {
+        int totalGutter = verticalGutter * (rows - 1);
+        int distributable = Math.max(0, availableHeight - totalGutter);
+        int baseHeight = distributable / rows;
+        int remainder = distributable % rows;
+
+        int[] heights = new int[rows];
+        for (int i = 0; i < rows; i++) {
+            heights[i] = baseHeight + (i < remainder ? 1 : 0);
+        }
+        return heights;
+    }
+
+    private int[] computeRowYPositions(int startY, int[] heights, int rows) {
+        int[] positions = new int[rows];
+        int currentY = startY;
+        for (int r = 0; r < rows; r++) {
+            positions[r] = currentY;
+            currentY += heights[r] + verticalGutter;
+        }
+        return positions;
+    }
+
+    private Rect computeMergedCellRect(GridArea.AreaBounds bounds,
+            List<Rect> columnRects, int[] rowYPositions, int[] rowHeights) {
+
+        int startCol = bounds.column();
+        int endCol = bounds.endColumn() - 1;
+        int startRow = bounds.row();
+        int endRow = bounds.endRow() - 1;
+
+        // Clamp to available columns/rows
+        if (startCol >= columnRects.size() || startRow >= rowYPositions.length) {
+            return new Rect(0, 0, 0, 0);
+        }
+        endCol = Math.min(endCol, columnRects.size() - 1);
+        endRow = Math.min(endRow, rowYPositions.length - 1);
+
+        // X position from first column
+        int x = columnRects.get(startCol).x();
+
+        // Width spans from first column start to last column end (includes gutters between)
+        int endX = columnRects.get(endCol).right();
+        int width = endX - x;
+
+        // Y position from first row
+        int y = rowYPositions[startRow];
+
+        // Height spans rows plus gutters between them
+        int totalHeight = 0;
+        for (int r = startRow; r <= endRow; r++) {
+            totalHeight += rowHeights[r];
+            if (r < endRow) {
+                totalHeight += verticalGutter;
+            }
+        }
+
+        return new Rect(x, y, width, totalHeight);
     }
 
     private void renderWithRowConstraints(Rect area, Buffer buffer, int rows, int cols,
@@ -217,53 +409,83 @@ public final class Grid implements Widget {
     }
 
     /**
-     * Builder for {@link Grid}.
+     * Initial builder for {@link Grid}.
+     * <p>
+     * Call {@link #gridAreas(String...)} for area-based layout or
+     * {@link #children(Widget...)} for children-based layout.
      */
     public static final class Builder {
-        private final List<Widget> children = new ArrayList<>();
-        private int columnCount = 1;
-        private int horizontalGutter = 0;
-        private int verticalGutter = 0;
-        private Flex flex = Flex.START;
-        private List<Constraint> columnConstraints;
-        private List<Constraint> rowConstraints;
-        private int[] rowHeights;
 
         private Builder() {
         }
 
         /**
-         * Sets the children widgets.
+         * Creates an area-based grid layout using CSS grid-template-areas style.
+         * <p>
+         * Each string represents a row; tokens are space-separated area names.
+         * Use "." for empty cells. Named areas must form contiguous rectangles.
          *
-         * @param children the child widgets
-         * @return this builder
+         * @param rowTemplates the row templates (e.g., "A A B", "A A C")
+         * @return an AreaBuilder for further configuration
+         * @throws LayoutException if the template is invalid
          */
-        public Builder children(Widget... children) {
-            this.children.clear();
-            this.children.addAll(Arrays.asList(children));
-            return this;
+        public AreaBuilder gridAreas(String... rowTemplates) {
+            GridArea gridArea = GridArea.parse(rowTemplates);
+            return new AreaBuilder(gridArea);
         }
 
         /**
-         * Sets the children widgets from a list.
+         * Creates a children-based grid layout with sequential placement.
          *
          * @param children the child widgets
-         * @return this builder
+         * @return a ChildrenBuilder for further configuration
          */
-        public Builder children(List<Widget> children) {
-            this.children.clear();
-            this.children.addAll(children);
-            return this;
+        public ChildrenBuilder children(Widget... children) {
+            return new ChildrenBuilder(Arrays.asList(children));
         }
 
         /**
-         * Sets the number of columns.
+         * Creates a children-based grid layout with sequential placement.
          *
-         * @param count the column count (must be at least 1)
-         * @return this builder
+         * @param children the child widgets
+         * @return a ChildrenBuilder for further configuration
          */
-        public Builder columnCount(int count) {
-            this.columnCount = Math.max(1, count);
+        public ChildrenBuilder children(List<Widget> children) {
+            return new ChildrenBuilder(new ArrayList<>(children));
+        }
+    }
+
+    /**
+     * Builder for area-based grid layouts.
+     */
+    public static final class AreaBuilder {
+        private final GridArea gridArea;
+        private final Map<String, Widget> areaWidgets = new LinkedHashMap<>();
+        private int horizontalGutter = 0;
+        private int verticalGutter = 0;
+        private Flex flex = Flex.START;
+        private List<Constraint> columnConstraints;
+        private List<Constraint> rowConstraints;
+
+        private AreaBuilder(GridArea gridArea) {
+            this.gridArea = gridArea;
+        }
+
+        /**
+         * Assigns a widget to a named area.
+         * <p>
+         * Areas without assigned widgets render as empty space.
+         *
+         * @param areaName the area name from the template
+         * @param widget the widget to place in that area
+         * @return this builder
+         * @throws LayoutException if the area name is not defined in the template
+         */
+        public AreaBuilder area(String areaName, Widget widget) {
+            if (gridArea.boundsFor(areaName) == null) {
+                throw new LayoutException("Widget assigned to undefined area '" + areaName + "'");
+            }
+            areaWidgets.put(areaName, widget);
             return this;
         }
 
@@ -273,7 +495,7 @@ public final class Grid implements Widget {
          * @param gutter the horizontal gutter in cells
          * @return this builder
          */
-        public Builder horizontalGutter(int gutter) {
+        public AreaBuilder horizontalGutter(int gutter) {
             this.horizontalGutter = Math.max(0, gutter);
             return this;
         }
@@ -284,7 +506,7 @@ public final class Grid implements Widget {
          * @param gutter the vertical gutter in cells
          * @return this builder
          */
-        public Builder verticalGutter(int gutter) {
+        public AreaBuilder verticalGutter(int gutter) {
             this.verticalGutter = Math.max(0, gutter);
             return this;
         }
@@ -295,7 +517,7 @@ public final class Grid implements Widget {
          * @param flex the flex mode
          * @return this builder
          */
-        public Builder flex(Flex flex) {
+        public AreaBuilder flex(Flex flex) {
             this.flex = flex;
             return this;
         }
@@ -308,7 +530,7 @@ public final class Grid implements Widget {
          * @param constraints the column width constraints
          * @return this builder
          */
-        public Builder columnConstraints(Constraint... constraints) {
+        public AreaBuilder columnConstraints(Constraint... constraints) {
             this.columnConstraints = Arrays.asList(constraints);
             return this;
         }
@@ -319,7 +541,147 @@ public final class Grid implements Widget {
          * @param constraints the column width constraints
          * @return this builder
          */
-        public Builder columnConstraints(List<Constraint> constraints) {
+        public AreaBuilder columnConstraints(List<Constraint> constraints) {
+            this.columnConstraints = new ArrayList<>(constraints);
+            return this;
+        }
+
+        /**
+         * Sets the height constraints for rows.
+         * <p>
+         * Constraints cycle when fewer than the row count.
+         *
+         * @param constraints the row height constraints
+         * @return this builder
+         */
+        public AreaBuilder rowConstraints(Constraint... constraints) {
+            this.rowConstraints = Arrays.asList(constraints);
+            return this;
+        }
+
+        /**
+         * Sets the height constraints for rows from a list.
+         *
+         * @param constraints the row height constraints
+         * @return this builder
+         */
+        public AreaBuilder rowConstraints(List<Constraint> constraints) {
+            this.rowConstraints = new ArrayList<>(constraints);
+            return this;
+        }
+
+        /**
+         * Builds the {@link Grid} widget.
+         *
+         * @return a new Grid widget
+         */
+        public Grid build() {
+            return new Grid(
+                null, 0, null,
+                gridArea, new LinkedHashMap<>(areaWidgets),
+                horizontalGutter, verticalGutter, flex,
+                columnConstraints != null ? listCopyOf(columnConstraints) : null,
+                rowConstraints != null ? listCopyOf(rowConstraints) : null
+            );
+        }
+    }
+
+    /**
+     * Builder for children-based grid layouts.
+     */
+    public static final class ChildrenBuilder {
+        private final List<Widget> children;
+        private int columnCount = 1;
+        private Integer rowCount;
+        private int horizontalGutter = 0;
+        private int verticalGutter = 0;
+        private Flex flex = Flex.START;
+        private List<Constraint> columnConstraints;
+        private List<Constraint> rowConstraints;
+        private int[] rowHeights;
+
+        private ChildrenBuilder(List<Widget> children) {
+            this.children = children;
+        }
+
+        /**
+         * Sets the number of columns.
+         *
+         * @param count the column count (must be at least 1)
+         * @return this builder
+         */
+        public ChildrenBuilder columnCount(int count) {
+            this.columnCount = Math.max(1, count);
+            return this;
+        }
+
+        /**
+         * Sets the number of rows.
+         * <p>
+         * When set, validates that children fit within columns × rows cells.
+         * When not set, rows expand automatically to fit all children.
+         *
+         * @param count the row count (must be at least 1)
+         * @return this builder
+         */
+        public ChildrenBuilder rowCount(int count) {
+            this.rowCount = Math.max(1, count);
+            return this;
+        }
+
+        /**
+         * Sets the horizontal gutter between columns.
+         *
+         * @param gutter the horizontal gutter in cells
+         * @return this builder
+         */
+        public ChildrenBuilder horizontalGutter(int gutter) {
+            this.horizontalGutter = Math.max(0, gutter);
+            return this;
+        }
+
+        /**
+         * Sets the vertical gutter between rows.
+         *
+         * @param gutter the vertical gutter in cells
+         * @return this builder
+         */
+        public ChildrenBuilder verticalGutter(int gutter) {
+            this.verticalGutter = Math.max(0, gutter);
+            return this;
+        }
+
+        /**
+         * Sets how remaining space is distributed.
+         *
+         * @param flex the flex mode
+         * @return this builder
+         */
+        public ChildrenBuilder flex(Flex flex) {
+            this.flex = flex;
+            return this;
+        }
+
+        /**
+         * Sets the width constraints for columns.
+         * <p>
+         * Constraints cycle when fewer than the column count.
+         *
+         * @param constraints the column width constraints
+         * @return this builder
+         */
+        public ChildrenBuilder columnConstraints(Constraint... constraints) {
+            this.columnConstraints = Arrays.asList(constraints);
+            return this;
+        }
+
+        /**
+         * Sets the width constraints for columns from a list.
+         *
+         * @param constraints the column width constraints
+         * @return this builder
+         */
+        public ChildrenBuilder columnConstraints(List<Constraint> constraints) {
             this.columnConstraints = new ArrayList<>(constraints);
             return this;
         }
@@ -334,7 +696,7 @@ public final class Grid implements Widget {
          * @param constraints the row height constraints
          * @return this builder
          */
-        public Builder rowConstraints(Constraint... constraints) {
+        public ChildrenBuilder rowConstraints(Constraint... constraints) {
             this.rowConstraints = Arrays.asList(constraints);
             return this;
         }
@@ -345,7 +707,7 @@ public final class Grid implements Widget {
          * @param constraints the row height constraints
          * @return this builder
          */
-        public Builder rowConstraints(List<Constraint> constraints) {
+        public ChildrenBuilder rowConstraints(List<Constraint> constraints) {
             this.rowConstraints = new ArrayList<>(constraints);
             return this;
         }
@@ -359,7 +721,7 @@ public final class Grid implements Widget {
          * @param heights the row heights
          * @return this builder
          */
-        public Builder rowHeights(int... heights) {
+        public ChildrenBuilder rowHeights(int... heights) {
             this.rowHeights = heights.clone();
             return this;
         }
@@ -368,9 +730,27 @@ public final class Grid implements Widget {
          * Builds the {@link Grid} widget.
          *
          * @return a new Grid widget
+         * @throws LayoutException if rowCount is set and children exceed available cells
          */
         public Grid build() {
-            return new Grid(this);
+            // Validate children fit within grid when rowCount is set
+            if (rowCount != null) {
+                int maxCells = columnCount * rowCount;
+                if (children.size() > maxCells) {
+                    throw new LayoutException(String.format(
+                        "Grid has %d children but only %d cells (%d columns * %d rows)",
+                        children.size(), maxCells, columnCount, rowCount));
+                }
+            }
+
+            return new Grid(
+                listCopyOf(children), columnCount,
+                rowHeights != null ? rowHeights.clone() : null,
+                null, null,
+                horizontalGutter, verticalGutter, flex,
+                columnConstraints != null ? listCopyOf(columnConstraints) : null,
+                rowConstraints != null ? listCopyOf(rowConstraints) : null
+            );
         }
     }
 }

--- a/tamboui-core/src/main/java/dev/tamboui/layout/grid/GridArea.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/grid/GridArea.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.layout.grid;
+
+import dev.tamboui.layout.LayoutException;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Parses and validates CSS grid-template-areas style layout definitions.
+ * <p>
+ * Area names must be alphanumeric identifiers starting with a letter.
+ * Use "." for empty cells. Named areas must form contiguous rectangles.
+ * <pre>{@code
+ * GridArea areas = GridArea.parse("A A B", "A A C", "D D D");
+ * // A spans columns 0-1, rows 0-1
+ * // B spans column 2, row 0
+ * // C spans column 2, row 1
+ * // D spans columns 0-2, row 2
+ * }</pre>
+ */
+public final class GridArea {
+
+    /**
+     * Represents an empty cell in the area template.
+     */
+    public static final String EMPTY_CELL = ".";
+
+    private final int rows;
+    private final int columns;
+    private final Map<String, AreaBounds> areas;
+    private final String[][] grid;
+
+    private GridArea(int rows, int columns, Map<String, AreaBounds> areas, String[][] grid) {
+        this.rows = rows;
+        this.columns = columns;
+        this.areas = Collections.unmodifiableMap(areas);
+        this.grid = grid;
+    }
+
+    /**
+     * Parses area template strings into a GridArea.
+     * <p>
+     * Each string represents a row; tokens are space-separated area names.
+     * All rows must have the same number of tokens (columns).
+     * Named areas must form contiguous rectangles.
+     * Use "." for empty cells.
+     *
+     * @param rowTemplates the row templates (e.g., "A A B", "A A C")
+     * @return the parsed GridArea
+     * @throws LayoutException if the template is invalid
+     */
+    public static GridArea parse(String... rowTemplates) {
+        if (rowTemplates == null || rowTemplates.length == 0) {
+            throw new LayoutException("Grid area template cannot be empty");
+        }
+
+        // Parse into 2D grid
+        String[][] grid = new String[rowTemplates.length][];
+        int columnCount = -1;
+
+        for (int row = 0; row < rowTemplates.length; row++) {
+            String template = rowTemplates[row];
+            if (template == null || template.trim().isEmpty()) {
+                throw new LayoutException("Row " + row + " template cannot be empty");
+            }
+            String[] tokens = template.trim().split("\\s+");
+
+            if (columnCount == -1) {
+                columnCount = tokens.length;
+            } else if (tokens.length != columnCount) {
+                throw new LayoutException(String.format(
+                    "Row %d has %d columns but expected %d (all rows must have equal columns)",
+                    row, tokens.length, columnCount));
+            }
+
+            grid[row] = tokens;
+        }
+
+        // Validate area names and collect bounds
+        Map<String, AreaBounds> areas = collectAndValidateAreas(grid, rowTemplates.length, columnCount);
+
+        return new GridArea(rowTemplates.length, columnCount, areas, grid);
+    }
+
+    private static Map<String, AreaBounds> collectAndValidateAreas(
+            String[][] grid, int rows, int cols) {
+
+        Map<String, AreaBounds> areas = new LinkedHashMap<>();
+
+        for (int row = 0; row < rows; row++) {
+            for (int col = 0; col < cols; col++) {
+                String name = grid[row][col];
+
+                if (EMPTY_CELL.equals(name)) {
+                    continue;
+                }
+
+                // Validate name format (alphanumeric, starting with letter)
+                if (!isValidAreaName(name)) {
+                    throw new LayoutException(String.format(
+                        "Invalid area name '%s' at row %d, column %d. " +
+                        "Names must be alphanumeric and start with a letter.",
+                        name, row, col));
+                }
+
+                if (!areas.containsKey(name)) {
+                    // First occurrence - find the full rectangular extent
+                    AreaBounds bounds = findAreaBounds(grid, name, row, col, rows, cols);
+                    areas.put(name, bounds);
+                }
+            }
+        }
+
+        return areas;
+    }
+
+    private static AreaBounds findAreaBounds(String[][] grid, String name,
+            int startRow, int startCol, int totalRows, int totalCols) {
+
+        // Find the extent of this area
+        int endRow = startRow;
+        int endCol = startCol;
+
+        // Expand right
+        while (endCol + 1 < totalCols && name.equals(grid[startRow][endCol + 1])) {
+            endCol++;
+        }
+
+        // Expand down
+        while (endRow + 1 < totalRows) {
+            boolean fullRow = true;
+            for (int c = startCol; c <= endCol; c++) {
+                if (!name.equals(grid[endRow + 1][c])) {
+                    fullRow = false;
+                    break;
+                }
+            }
+            if (fullRow) {
+                endRow++;
+            } else {
+                break;
+            }
+        }
+
+        // Validate: all cells in the bounds must have this name
+        for (int r = startRow; r <= endRow; r++) {
+            for (int c = startCol; c <= endCol; c++) {
+                if (!name.equals(grid[r][c])) {
+                    throw new LayoutException(String.format(
+                        "Area '%s' is not a contiguous rectangle. " +
+                        "Cell at row %d, column %d has '%s' instead.",
+                        name, r, c, grid[r][c]));
+                }
+            }
+        }
+
+        // Validate: no other cells outside bounds have this name
+        for (int r = 0; r < totalRows; r++) {
+            for (int c = 0; c < totalCols; c++) {
+                if (name.equals(grid[r][c])) {
+                    boolean inBounds = r >= startRow && r <= endRow && c >= startCol && c <= endCol;
+                    if (!inBounds) {
+                        // Check if this cell is adjacent to the bounds (non-rectangular)
+                        // or completely separated (disconnected)
+                        boolean isAdjacent = isAdjacentToBounds(r, c, startRow, endRow, startCol, endCol);
+                        if (isAdjacent) {
+                            throw new LayoutException(String.format(
+                                "Area '%s' does not form a rectangle. " +
+                                "Cell at row %d, column %d extends beyond the rectangular bounds.",
+                                name, r, c));
+                        } else {
+                            throw new LayoutException(String.format(
+                                "Area '%s' is not contiguous. " +
+                                "Found at row %d, column %d which is disconnected from the main area.",
+                                name, r, c));
+                        }
+                    }
+                }
+            }
+        }
+
+        return new AreaBounds(startRow, startCol, endRow - startRow + 1, endCol - startCol + 1);
+    }
+
+    /**
+     * Checks if a cell at (r, c) is adjacent to the rectangular bounds.
+     * Adjacent means the cell is directly next to the bounds (touching an edge).
+     */
+    private static boolean isAdjacentToBounds(int r, int c,
+            int startRow, int endRow, int startCol, int endCol) {
+        // Cell is adjacent if it's within 1 row/column of the bounds
+        boolean rowAdjacent = r >= startRow - 1 && r <= endRow + 1;
+        boolean colAdjacent = c >= startCol - 1 && c <= endCol + 1;
+
+        // Must be adjacent in both dimensions, but at least one must be touching
+        boolean touchesRow = r >= startRow && r <= endRow;
+        boolean touchesCol = c >= startCol && c <= endCol;
+
+        // Adjacent if: within range on both axes AND touching on at least one axis
+        return rowAdjacent && colAdjacent && (touchesRow || touchesCol);
+    }
+
+    private static boolean isValidAreaName(String name) {
+        if (name == null || name.isEmpty()) {
+            return false;
+        }
+        char first = name.charAt(0);
+        if (!Character.isLetter(first)) {
+            return false;
+        }
+        for (int i = 1; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (!Character.isLetterOrDigit(c) && c != '_') {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the number of rows in the grid template.
+     *
+     * @return the row count
+     */
+    public int rows() {
+        return rows;
+    }
+
+    /**
+     * Returns the number of columns in the grid template.
+     *
+     * @return the column count
+     */
+    public int columns() {
+        return columns;
+    }
+
+    /**
+     * Returns the bounds for a named area.
+     *
+     * @param areaName the area name
+     * @return the bounds, or null if not found
+     */
+    public AreaBounds boundsFor(String areaName) {
+        return areas.get(areaName);
+    }
+
+    /**
+     * Returns all defined area names in declaration order.
+     *
+     * @return the set of area names
+     */
+    public Set<String> areaNames() {
+        return areas.keySet();
+    }
+
+    /**
+     * Returns the number of named areas.
+     *
+     * @return the area count
+     */
+    public int areaCount() {
+        return areas.size();
+    }
+
+    /**
+     * Returns the row templates that were used to create this GridArea.
+     * <p>
+     * Useful for passing to Grid.Builder.gridAreas().
+     *
+     * @return array of row template strings
+     */
+    public String[] toTemplates() {
+        String[] templates = new String[rows];
+        for (int r = 0; r < rows; r++) {
+            templates[r] = String.join(" ", grid[r]);
+        }
+        return templates;
+    }
+
+    /**
+     * Bounds of a named area within the grid.
+     */
+    public static final class AreaBounds {
+        private final int row;
+        private final int column;
+        private final int rowSpan;
+        private final int columnSpan;
+
+        /**
+         * Creates area bounds.
+         *
+         * @param row the start row (0-based)
+         * @param column the start column (0-based)
+         * @param rowSpan the number of rows spanned
+         * @param columnSpan the number of columns spanned
+         */
+        public AreaBounds(int row, int column, int rowSpan, int columnSpan) {
+            this.row = row;
+            this.column = column;
+            this.rowSpan = rowSpan;
+            this.columnSpan = columnSpan;
+        }
+
+        /**
+         * Returns the start row (0-based).
+         *
+         * @return the start row
+         */
+        public int row() {
+            return row;
+        }
+
+        /**
+         * Returns the start column (0-based).
+         *
+         * @return the start column
+         */
+        public int column() {
+            return column;
+        }
+
+        /**
+         * Returns the number of rows spanned.
+         *
+         * @return the row span
+         */
+        public int rowSpan() {
+            return rowSpan;
+        }
+
+        /**
+         * Returns the number of columns spanned.
+         *
+         * @return the column span
+         */
+        public int columnSpan() {
+            return columnSpan;
+        }
+
+        /**
+         * Returns the end row (exclusive).
+         *
+         * @return row + rowSpan
+         */
+        public int endRow() {
+            return row + rowSpan;
+        }
+
+        /**
+         * Returns the end column (exclusive).
+         *
+         * @return column + columnSpan
+         */
+        public int endColumn() {
+            return column + columnSpan;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("AreaBounds[row=%d, col=%d, rowSpan=%d, colSpan=%d]",
+                row, column, rowSpan, columnSpan);
+        }
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/layout/grid/GridAreaTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/layout/grid/GridAreaTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.layout.grid;
+
+import dev.tamboui.layout.LayoutException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the {@link GridArea} parser and validator.
+ */
+class GridAreaTest {
+
+    @Test
+    @DisplayName("parses simple 2x2 grid")
+    void parsesSimple2x2Grid() {
+        GridArea area = GridArea.parse("A B", "C D");
+
+        assertThat(area.rows()).isEqualTo(2);
+        assertThat(area.columns()).isEqualTo(2);
+        assertThat(area.areaNames()).containsExactly("A", "B", "C", "D");
+    }
+
+    @Test
+    @DisplayName("parses single cell grid")
+    void parsesSingleCellGrid() {
+        GridArea area = GridArea.parse("A");
+
+        assertThat(area.rows()).isEqualTo(1);
+        assertThat(area.columns()).isEqualTo(1);
+        assertThat(area.areaNames()).containsExactly("A");
+
+        GridArea.AreaBounds bounds = area.boundsFor("A");
+        assertThat(bounds.row()).isEqualTo(0);
+        assertThat(bounds.column()).isEqualTo(0);
+        assertThat(bounds.rowSpan()).isEqualTo(1);
+        assertThat(bounds.columnSpan()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("parses horizontally spanning area")
+    void parsesHorizontalSpan() {
+        GridArea area = GridArea.parse("A A B", "C D D");
+
+        assertThat(area.rows()).isEqualTo(2);
+        assertThat(area.columns()).isEqualTo(3);
+
+        GridArea.AreaBounds boundsA = area.boundsFor("A");
+        assertThat(boundsA.row()).isEqualTo(0);
+        assertThat(boundsA.column()).isEqualTo(0);
+        assertThat(boundsA.rowSpan()).isEqualTo(1);
+        assertThat(boundsA.columnSpan()).isEqualTo(2);
+
+        GridArea.AreaBounds boundsD = area.boundsFor("D");
+        assertThat(boundsD.row()).isEqualTo(1);
+        assertThat(boundsD.column()).isEqualTo(1);
+        assertThat(boundsD.rowSpan()).isEqualTo(1);
+        assertThat(boundsD.columnSpan()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("parses vertically spanning area")
+    void parsesVerticalSpan() {
+        GridArea area = GridArea.parse("A B", "A C");
+
+        GridArea.AreaBounds boundsA = area.boundsFor("A");
+        assertThat(boundsA.row()).isEqualTo(0);
+        assertThat(boundsA.column()).isEqualTo(0);
+        assertThat(boundsA.rowSpan()).isEqualTo(2);
+        assertThat(boundsA.columnSpan()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("parses 2x2 spanning area")
+    void parses2x2Span() {
+        GridArea area = GridArea.parse("A A B", "A A C", "D D D");
+
+        GridArea.AreaBounds boundsA = area.boundsFor("A");
+        assertThat(boundsA.row()).isEqualTo(0);
+        assertThat(boundsA.column()).isEqualTo(0);
+        assertThat(boundsA.rowSpan()).isEqualTo(2);
+        assertThat(boundsA.columnSpan()).isEqualTo(2);
+        assertThat(boundsA.endRow()).isEqualTo(2);
+        assertThat(boundsA.endColumn()).isEqualTo(2);
+
+        GridArea.AreaBounds boundsD = area.boundsFor("D");
+        assertThat(boundsD.row()).isEqualTo(2);
+        assertThat(boundsD.column()).isEqualTo(0);
+        assertThat(boundsD.rowSpan()).isEqualTo(1);
+        assertThat(boundsD.columnSpan()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("parses empty cells with dot notation")
+    void parsesEmptyCells() {
+        GridArea area = GridArea.parse("A . B", ". . .");
+
+        assertThat(area.rows()).isEqualTo(2);
+        assertThat(area.columns()).isEqualTo(3);
+        assertThat(area.areaNames()).containsExactly("A", "B");
+        assertThat(area.areaCount()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("parses multi-character area names")
+    void parsesMultiCharacterNames() {
+        GridArea area = GridArea.parse("header header header",
+                                       "nav main main",
+                                       "footer footer footer");
+
+        assertThat(area.areaNames()).containsExactly("header", "nav", "main", "footer");
+
+        GridArea.AreaBounds header = area.boundsFor("header");
+        assertThat(header.columnSpan()).isEqualTo(3);
+
+        GridArea.AreaBounds main = area.boundsFor("main");
+        assertThat(main.column()).isEqualTo(1);
+        assertThat(main.columnSpan()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("parses names with underscores and digits")
+    void parsesNamesWithUnderscoresAndDigits() {
+        GridArea area = GridArea.parse("area_1 area2");
+
+        assertThat(area.areaNames()).containsExactly("area_1", "area2");
+    }
+
+    @Test
+    @DisplayName("toTemplates returns original templates")
+    void toTemplatesReturnsOriginal() {
+        String[] templates = {"A A B", "C C D"};
+        GridArea area = GridArea.parse(templates);
+
+        assertThat(area.toTemplates()).containsExactly("A A B", "C C D");
+    }
+
+    @Test
+    @DisplayName("throws on empty template")
+    void throwsOnEmptyTemplate() {
+        assertThatThrownBy(() -> GridArea.parse())
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("cannot be empty");
+    }
+
+    @Test
+    @DisplayName("throws on null template array")
+    void throwsOnNullTemplateArray() {
+        assertThatThrownBy(() -> GridArea.parse((String[]) null))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("cannot be empty");
+    }
+
+    @Test
+    @DisplayName("throws on empty row template")
+    void throwsOnEmptyRowTemplate() {
+        assertThatThrownBy(() -> GridArea.parse("A B", ""))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Row 1 template cannot be empty");
+    }
+
+    @Test
+    @DisplayName("throws on unequal column counts")
+    void throwsOnUnequalColumnCounts() {
+        assertThatThrownBy(() -> GridArea.parse("A B", "A B C"))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Row 1 has 3 columns but expected 2");
+    }
+
+    @Test
+    @DisplayName("throws on invalid area name starting with digit")
+    void throwsOnInvalidNameStartingWithDigit() {
+        assertThatThrownBy(() -> GridArea.parse("1A B"))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Invalid area name '1A'")
+            .hasMessageContaining("row 0, column 0");
+    }
+
+    @Test
+    @DisplayName("throws on invalid area name with special characters")
+    void throwsOnInvalidNameWithSpecialChars() {
+        assertThatThrownBy(() -> GridArea.parse("A-B C"))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Invalid area name 'A-B'");
+    }
+
+    @Test
+    @DisplayName("throws on non-rectangular area (L-shape)")
+    void throwsOnNonRectangularArea() {
+        // L-shape: 'A' at (0,0), (0,1), (1,0) - adjacent but not a rectangle
+        assertThatThrownBy(() -> GridArea.parse("A A B", "A B B"))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Area 'A' does not form a rectangle");
+    }
+
+    @Test
+    @DisplayName("throws on disconnected area (gap between occurrences)")
+    void throwsOnDisconnectedArea() {
+        // 'A' at rows 0 and 2, separated by row 1 - disconnected
+        assertThatThrownBy(() -> GridArea.parse("A A B", "C C C", "A A D"))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Area 'A' is not contiguous")
+            .hasMessageContaining("disconnected");
+    }
+
+    @Test
+    @DisplayName("throws on disconnected area in same row")
+    void throwsOnDisconnectedAreaSameRow() {
+        // 'A' at cols 0 and 2, separated by col 1 - disconnected
+        assertThatThrownBy(() -> GridArea.parse("A B A"))
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("Area 'A' is not contiguous")
+            .hasMessageContaining("disconnected");
+    }
+
+    @Test
+    @DisplayName("boundsFor returns null for unknown area")
+    void boundsForReturnsNullForUnknown() {
+        GridArea area = GridArea.parse("A B");
+
+        assertThat(area.boundsFor("C")).isNull();
+        assertThat(area.boundsFor("unknown")).isNull();
+    }
+
+    @Test
+    @DisplayName("AreaBounds toString is readable")
+    void areaBoundsToString() {
+        GridArea area = GridArea.parse("A A", "A A");
+        GridArea.AreaBounds bounds = area.boundsFor("A");
+
+        assertThat(bounds.toString()).contains("row=0", "col=0", "rowSpan=2", "colSpan=2");
+    }
+
+    @Test
+    @DisplayName("handles extra whitespace in templates")
+    void handlesExtraWhitespace() {
+        GridArea area = GridArea.parse("  A   B  ", " C    D ");
+
+        assertThat(area.columns()).isEqualTo(2);
+        assertThat(area.areaNames()).containsExactly("A", "B", "C", "D");
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/layout/grid/GridTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/layout/grid/GridTest.java
@@ -8,6 +8,7 @@ import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Flex;
+import dev.tamboui.layout.LayoutException;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
 import dev.tamboui.widget.Widget;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for the {@link Grid} widget.
@@ -257,6 +259,7 @@ class GridTest {
         Buffer buffer = Buffer.empty(area);
 
         Grid.builder()
+            .children()
             .columnCount(2)
             .build()
             .render(area, buffer);
@@ -315,5 +318,230 @@ class GridTest {
             .render(area, buffer);
 
         BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "A");
+    }
+
+    // ==================== Area-based Grid Tests ====================
+
+    @Test
+    @DisplayName("area-based grid renders widgets in named areas")
+    void areaBasedGridRendersWidgets() {
+        Rect area = new Rect(0, 0, 20, 2);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A B", "C D")
+            .area("A", charWidget("A"))
+            .area("B", charWidget("B"))
+            .area("C", charWidget("C"))
+            .area("D", charWidget("D"))
+            .build()
+            .render(area, buffer);
+
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(0, 0, "A")
+            .hasSymbolAt(10, 0, "B")
+            .hasSymbolAt(0, 1, "C")
+            .hasSymbolAt(10, 1, "D");
+    }
+
+    @Test
+    @DisplayName("area-based grid with horizontal span")
+    void areaBasedGridWithHorizontalSpan() {
+        Rect area = new Rect(0, 0, 20, 2);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A A", "B C")
+            .area("A", fillingWidget("A"))
+            .area("B", charWidget("B"))
+            .area("C", charWidget("C"))
+            .build()
+            .render(area, buffer);
+
+        // A spans both columns in row 0
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(10, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(19, 0).symbol()).isEqualTo("A");
+
+        // B and C in row 1
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(0, 1, "B")
+            .hasSymbolAt(10, 1, "C");
+    }
+
+    @Test
+    @DisplayName("area-based grid with vertical span")
+    void areaBasedGridWithVerticalSpan() {
+        Rect area = new Rect(0, 0, 20, 2);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A B", "A C")
+            .area("A", fillingWidget("A"))
+            .area("B", charWidget("B"))
+            .area("C", charWidget("C"))
+            .build()
+            .render(area, buffer);
+
+        // A spans both rows in column 0
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(0, 1).symbol()).isEqualTo("A");
+
+        // B in row 0, C in row 1
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(10, 0, "B")
+            .hasSymbolAt(10, 1, "C");
+    }
+
+    @Test
+    @DisplayName("area-based grid with 2x2 span")
+    void areaBasedGridWith2x2Span() {
+        Rect area = new Rect(0, 0, 30, 3);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A A B", "A A C", "D D D")
+            .area("A", fillingWidget("A"))
+            .area("B", charWidget("B"))
+            .area("C", charWidget("C"))
+            .area("D", fillingWidget("D"))
+            .build()
+            .render(area, buffer);
+
+        // A spans 2x2 in top-left
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(9, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(0, 1).symbol()).isEqualTo("A");
+        assertThat(buffer.get(9, 1).symbol()).isEqualTo("A");
+
+        // B and C in right column
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(20, 0, "B")
+            .hasSymbolAt(20, 1, "C");
+
+        // D spans bottom row
+        assertThat(buffer.get(0, 2).symbol()).isEqualTo("D");
+        assertThat(buffer.get(15, 2).symbol()).isEqualTo("D");
+        assertThat(buffer.get(29, 2).symbol()).isEqualTo("D");
+    }
+
+    @Test
+    @DisplayName("area-based grid with gutters includes gutters in spans")
+    void areaBasedGridWithGutters() {
+        Rect area = new Rect(0, 0, 21, 3);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A A", "B C")
+            .area("A", fillingWidget("A"))
+            .area("B", charWidget("B"))
+            .area("C", charWidget("C"))
+            .horizontalGutter(1)
+            .verticalGutter(1)
+            .build()
+            .render(area, buffer);
+
+        // A spans both columns plus the gutter between them
+        // Width: 21 - 1 gutter = 20, 20/2 = 10 per col
+        // A should fill: cols 0-9, gutter at 10, cols 11-20, so A gets 0-20
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(10, 0).symbol()).isEqualTo("A"); // gutter is inside A's span
+        assertThat(buffer.get(20, 0).symbol()).isEqualTo("A");
+
+        // Row 1 is gutter (empty)
+        assertThat(buffer.get(0, 1).symbol()).isEqualTo(" ");
+
+        // B and C in row 2
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(0, 2, "B")
+            .hasSymbolAt(11, 2, "C");
+    }
+
+    @Test
+    @DisplayName("area-based grid with empty areas renders nothing")
+    void areaBasedGridWithEmptyAreas() {
+        Rect area = new Rect(0, 0, 20, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A B")
+            .area("A", charWidget("A"))
+            // B has no widget assigned - should be empty
+            .build()
+            .render(area, buffer);
+
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "A");
+        assertThat(buffer.get(10, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("area-based grid with dot notation for empty cells")
+    void areaBasedGridWithDotNotation() {
+        Rect area = new Rect(0, 0, 30, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        Grid.builder()
+            .gridAreas("A . B")
+            .area("A", charWidget("A"))
+            .area("B", charWidget("B"))
+            .build()
+            .render(area, buffer);
+
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(0, 0, "A")
+            .hasSymbolAt(20, 0, "B");
+        // Middle column is empty (dot notation)
+        assertThat(buffer.get(10, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("area-based grid throws on undefined area")
+    void areaBasedGridThrowsOnUndefinedArea() {
+        assertThatThrownBy(() ->
+            Grid.builder()
+                .gridAreas("A B")
+                .area("A", charWidget("A"))
+                .area("C", charWidget("C")) // C not defined in template
+                .build())
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("undefined area 'C'");
+    }
+
+    @Test
+    @DisplayName("children-based grid throws when too many children for fixed row count")
+    void childrenGridThrowsOnTooManyChildren() {
+        assertThatThrownBy(() ->
+            Grid.builder()
+                .children(charWidget("A"), charWidget("B"), charWidget("C"),
+                          charWidget("D"), charWidget("E"), charWidget("F"))
+                .columnCount(2)
+                .rowCount(2) // 2x2 = 4 cells, but 6 children
+                .build())
+            .isInstanceOf(LayoutException.class)
+            .hasMessageContaining("6 children")
+            .hasMessageContaining("4 cells");
+    }
+
+    @Test
+    @DisplayName("children-based grid allows many children when rowCount not set")
+    void childrenGridAllowsManyChildrenWithoutRowCount() {
+        Rect area = new Rect(0, 0, 20, 3);
+        Buffer buffer = Buffer.empty(area);
+
+        // 6 children with 2 columns = 3 rows auto-calculated
+        Grid.builder()
+            .children(charWidget("A"), charWidget("B"), charWidget("C"),
+                      charWidget("D"), charWidget("E"), charWidget("F"))
+            .columnCount(2)
+            .build()
+            .render(area, buffer);
+
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(0, 0, "A")
+            .hasSymbolAt(10, 0, "B")
+            .hasSymbolAt(0, 1, "C")
+            .hasSymbolAt(10, 1, "D")
+            .hasSymbolAt(0, 2, "E")
+            .hasSymbolAt(10, 2, "F");
     }
 }

--- a/tamboui-toolkit/demos/layout-demo/src/main/java/dev/tamboui/demo/LayoutDemo.java
+++ b/tamboui-toolkit/demos/layout-demo/src/main/java/dev/tamboui/demo/LayoutDemo.java
@@ -21,9 +21,9 @@ import static dev.tamboui.toolkit.Toolkit.*;
 
 /**
  * Demo showcasing dynamic layout switching between Flow, Dock, Grid,
- * and Columns using the Toolkit DSL.
+ * Columns, and Grid Areas using the Toolkit DSL.
  * <p>
- * Press 1-4 to switch layouts, +/- to adjust spacing.
+ * Press 1-5 to switch layouts, +/- to adjust spacing.
  */
 public class LayoutDemo {
 
@@ -44,7 +44,8 @@ public class LayoutDemo {
         COLUMNS("Columns"),
         GRID("Grid"),
         FLOW("Flow"),
-        DOCK("Dock");
+        DOCK("Dock"),
+        GRID_AREAS("Grid Areas");
 
         final String label;
 
@@ -88,6 +89,7 @@ public class LayoutDemo {
                     text(" [2] Grid ").fg(mode == LayoutMode.GRID ? Color.YELLOW : Color.DARK_GRAY),
                     text(" [3] Flow ").fg(mode == LayoutMode.FLOW ? Color.YELLOW : Color.DARK_GRAY),
                     text(" [4] Dock ").fg(mode == LayoutMode.DOCK ? Color.YELLOW : Color.DARK_GRAY),
+                    text(" [5] Grid Areas ").fg(mode == LayoutMode.GRID_AREAS ? Color.YELLOW : Color.DARK_GRAY),
                     spacer(),
                     text(" [+/-] Spacing:" + spacing + " ").dim(),
                     text(" [q] Quit ").dim()
@@ -116,6 +118,10 @@ public class LayoutDemo {
                     mode = LayoutMode.DOCK;
                     return EventResult.HANDLED;
                 }
+                if (event.isChar('5')) {
+                    mode = LayoutMode.GRID_AREAS;
+                    return EventResult.HANDLED;
+                }
                 if (event.isChar('+') || event.isChar('=')) {
                     spacing = Math.min(spacing + 1, 5);
                     return EventResult.HANDLED;
@@ -135,6 +141,7 @@ public class LayoutDemo {
             case GRID -> renderGrid();
             case FLOW -> renderFlow();
             case DOCK -> renderDock();
+            case GRID_AREAS -> renderGridAreas();
         };
     }
 
@@ -210,6 +217,54 @@ public class LayoutDemo {
             .bottomHeight(Constraint.length(4))
             .leftWidth(Constraint.length(22))
             .rightWidth(Constraint.length(22));
+    }
+
+    private Element renderGridAreas() {
+        // Holy grail layout: header spans full width, nav spans left side,
+        // main content takes center, footer spans full width
+        return grid()
+            .gridAreas("header header header",
+                       "nav    main   main",
+                       "nav    main   main",
+                       "footer footer footer")
+            .area("header", panel("Header",
+                row(
+                    text("  Dashboard").bold().yellow(),
+                    spacer(),
+                    text("User: demo  ").dim()
+                )
+            ).rounded().borderColor(Color.BLUE))
+            .area("nav", panel("Navigation",
+                column(
+                    text("  Overview").cyan(),
+                    text("  Reports").dim(),
+                    text("  Settings").dim(),
+                    text("  Help").dim()
+                )
+            ).rounded().borderColor(Color.GREEN))
+            .area("main", panel("Main Content",
+                column(
+                    text("  Welcome to the Grid Areas demo!").bold(),
+                    text(""),
+                    text("  This layout uses CSS grid-template-areas").dim(),
+                    text("  to define spanning regions:").dim(),
+                    text(""),
+                    text("    header header header").cyan(),
+                    text("    nav    main   main").cyan(),
+                    text("    nav    main   main").cyan(),
+                    text("    footer footer footer").cyan(),
+                    text(""),
+                    text("  Spacing: " + spacing).dim()
+                )
+            ).rounded().borderColor(Color.CYAN))
+            .area("footer", panel("Footer",
+                row(
+                    text("  Ready").green(),
+                    spacer(),
+                    text("Grid Areas Layout  ").dim()
+                )
+            ).rounded().borderColor(Color.DARK_GRAY))
+            .gutter(spacing);
     }
 
     private static Element card(String label, Color color) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GridAreaConverter.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GridAreaConverter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.layout.grid.GridArea;
+import dev.tamboui.style.PropertyConverter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts CSS grid-template-areas value to {@link GridArea}.
+ * <p>
+ * Supports two formats:
+ * <ul>
+ *   <li>Semicolon-separated rows: {@code "A A B; A A C; D D D"}</li>
+ *   <li>Quoted strings (CSS format): {@code "A A B" "A A C" "D D D"}</li>
+ * </ul>
+ * <p>
+ * Example CSS:
+ * <pre>
+ * .dashboard {
+ *     grid-template-areas: "header header header; nav main main; footer footer footer";
+ * }
+ * </pre>
+ */
+public final class GridAreaConverter implements PropertyConverter<GridArea> {
+
+    /**
+     * Singleton instance.
+     */
+    public static final GridAreaConverter INSTANCE = new GridAreaConverter();
+
+    private static final Pattern QUOTED_STRING_PATTERN = Pattern.compile("\"([^\"]+)\"");
+
+    private GridAreaConverter() {
+    }
+
+    @Override
+    public Optional<GridArea> convert(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return Optional.empty();
+        }
+
+        String trimmed = value.trim();
+        String[] rows;
+
+        if (trimmed.contains(";")) {
+            // Semicolon-separated format: "A A B; A A C"
+            rows = trimmed.split(";");
+        } else if (trimmed.contains("\"")) {
+            // Quoted string format: "A A B" "A A C"
+            rows = parseQuotedStrings(trimmed);
+        } else {
+            // Single row
+            rows = new String[] { trimmed };
+        }
+
+        // Trim each row
+        for (int i = 0; i < rows.length; i++) {
+            rows[i] = rows[i].trim();
+        }
+
+        // Remove empty rows
+        rows = filterEmptyRows(rows);
+
+        if (rows.length == 0) {
+            return Optional.empty();
+        }
+
+        try {
+            return Optional.of(GridArea.parse(rows));
+        } catch (Exception e) {
+            // Invalid template - return empty
+            return Optional.empty();
+        }
+    }
+
+    private String[] parseQuotedStrings(String value) {
+        List<String> rows = new ArrayList<>();
+        Matcher matcher = QUOTED_STRING_PATTERN.matcher(value);
+        while (matcher.find()) {
+            rows.add(matcher.group(1));
+        }
+        return rows.toArray(new String[0]);
+    }
+
+    private String[] filterEmptyRows(String[] rows) {
+        List<String> nonEmpty = new ArrayList<>();
+        for (String row : rows) {
+            if (row != null && !row.isEmpty()) {
+                nonEmpty.add(row);
+            }
+        }
+        return nonEmpty.toArray(new String[0]);
+    }
+}


### PR DESCRIPTION
As discussed, this adds the ability to define areas where to put widgets in the grid layout. The inspiration is CSS grid-template-area.

The API has been udpated so that you cannot use both `children` and `area` modes: you have to choose. It is possible to define the areas directly in CSS, however the components must be inserted using code.