### PR TITLE
Remove default implementation for preferred width/height

### DIFF
--- a/demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java
+++ b/demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java
@@ -126,6 +126,16 @@ public class ErrorHandlingDemo {
             }
 
             @Override
+            public int preferredWidth() {
+                return 0;
+            }
+
+            @Override
+            public int preferredHeight() {
+                return 0;
+            }
+
+            @Override
             public String id() {
                 return "faulty-panel";
             }

--- a/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerView.java
+++ b/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerView.java
@@ -158,6 +158,16 @@ public class FileManagerView implements Element {
                 .onCancel(manager::dismissDialog);
     }
 
+    @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
     /**
      * Returns the layout constraint for this element.
      * @return the constraint
@@ -229,6 +239,16 @@ public class FileManagerView implements Element {
                 browser.setVisibleRows(area.height());
                 // Now render the file list with correct visible count
                 fileList(browser, active).render(frame, area, ctx);
+            }
+
+            @Override
+            public int preferredWidth() {
+                return 0;
+            }
+
+            @Override
+            public int preferredHeight() {
+                return 0;
             }
 
             @Override
@@ -362,6 +382,16 @@ public class FileManagerView implements Element {
                 } else {
                     renderTextFile(frame, renderArea, file);
                 }
+            }
+
+            @Override
+            public int preferredWidth() {
+                return 0;
+            }
+
+            @Override
+            public int preferredHeight() {
+                return 0;
             }
 
             @Override

--- a/tamboui-core/src/main/java/dev/tamboui/layout/dock/Dock.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/dock/Dock.java
@@ -123,8 +123,8 @@ public final class Dock implements Widget {
             if (center != null || (left == null && right == null)) {
                 hConstraints.add(Constraint.fill());
             } else if (left != null && right != null) {
-                // No center, but both sides present — add fill for the gap
-                hConstraints.add(Constraint.fill());
+                // No center, both sides present — zero-width gap so sides share space
+                hConstraints.add(Constraint.length(0));
             } else {
                 hConstraints.add(Constraint.fill());
             }

--- a/tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java
+++ b/tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java
@@ -149,6 +149,16 @@ public class CssDemo implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     public Constraint constraint() {
         return Constraint.fill();
     }

--- a/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java
+++ b/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java
@@ -393,6 +393,16 @@ public class CustomComponentDemo implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     public Constraint constraint() {
         return Constraint.fill();
     }

--- a/tamboui-toolkit/demos/jtop-demo/src/main/java/dev/tamboui/demo/SystemMonitor.java
+++ b/tamboui-toolkit/demos/jtop-demo/src/main/java/dev/tamboui/demo/SystemMonitor.java
@@ -462,6 +462,16 @@ final class SystemMonitor implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     public Constraint constraint() {
         return Constraint.fill();
     }

--- a/tamboui-toolkit/demos/layout-demo/src/main/java/dev/tamboui/demo/LayoutDemo.java
+++ b/tamboui-toolkit/demos/layout-demo/src/main/java/dev/tamboui/demo/LayoutDemo.java
@@ -165,7 +165,7 @@ public class LayoutDemo {
         // Row-first with per-column width constraints (narrow, wide, medium)
         return grid(makeCards())
             .gridSize(3)
-            .gridColumns(Constraint.length(14), Constraint.fill(), Constraint.length(20))
+            .gridColumns(Constraint.length(14), Constraint.fill(), Constraint.length(22))
             .gutter(spacing);
     }
 
@@ -177,7 +177,7 @@ public class LayoutDemo {
     }
 
     private Element renderDock() {
-        return dock()
+        return dock().fill()
             .top(panel("Header",
                 text("  Menu Bar — File  Edit  View  Help").fg(Color.WHITE)
             ).rounded().borderColor(Color.BLUE))

--- a/tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java
+++ b/tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java
@@ -269,6 +269,16 @@ public class RichTextDemo implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     public Constraint constraint() {
         return Constraint.fill();
     }

--- a/tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java
+++ b/tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java
@@ -184,6 +184,16 @@ public class TextAreaDemo implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     public Constraint constraint() {
         return Constraint.fill();
     }

--- a/tamboui-toolkit/demos/toolkit-demo/src/main/java/dev/tamboui/demo/FloatingPanelsArea.java
+++ b/tamboui-toolkit/demos/toolkit-demo/src/main/java/dev/tamboui/demo/FloatingPanelsArea.java
@@ -132,6 +132,16 @@ final class FloatingPanelsArea implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     public Constraint constraint() {
         return Constraint.fill();
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/component/Component.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/component/Component.java
@@ -50,6 +50,16 @@ public abstract class Component<T extends Component<T>> extends StyledElement<T>
     protected Component() {
     }
 
+    @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
     private ActionHandler actionHandler;
     private RenderContext currentRenderContext;
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/Element.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/element/Element.java
@@ -48,9 +48,7 @@ public interface Element {
      *
      * @return the preferred width, or 0 if not applicable
      */
-    default int preferredWidth() {
-        return 0;
-    }
+    int preferredWidth();
 
     /**
      * Returns the preferred height of this element in cells.
@@ -58,9 +56,7 @@ public interface Element {
      *
      * @return the preferred height, or 0 if not applicable
      */
-    default int preferredHeight() {
-        return 0;
-    }
+    int preferredHeight();
 
     /**
      * Returns the preferred height of this element given an available width and render context.

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -131,6 +131,21 @@ public final class Column extends ContainerElement<Column> {
     }
 
     @Override
+    public int preferredHeight() {
+        if (children.isEmpty()) {
+            return 0;
+        }
+        // Vertical layout: sum of children heights + spacing
+        int effectiveSpacing = this.spacing != null ? this.spacing : 0;
+        int totalSpacing = effectiveSpacing * Math.max(0, children.size() - 1);
+        int totalHeight = 0;
+        for (Element child : children) {
+            totalHeight += child.preferredHeight();
+        }
+        return totalHeight + totalSpacing;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (children.isEmpty() || availableWidth <= 0) {
             return 0;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ColumnsElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ColumnsElement.java
@@ -219,6 +219,32 @@ public final class ColumnsElement extends ContainerElement<ColumnsElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        if (children.isEmpty()) {
+            return 0;
+        }
+
+        int cols = columnCount != null ? columnCount : children.size();
+        cols = Math.min(cols, children.size());
+        int rows = (children.size() + cols - 1) / cols;
+
+        // For each row, compute max child height
+        int totalHeight = 0;
+        for (int row = 0; row < rows; row++) {
+            int rowHeight = 1;
+            for (int col = 0; col < cols; col++) {
+                int childIndex = row * cols + col;
+                if (childIndex < children.size()) {
+                    rowHeight = Math.max(rowHeight, children.get(childIndex).preferredHeight());
+                }
+            }
+            totalHeight += rowHeight;
+        }
+
+        return totalHeight;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (children.isEmpty() || availableWidth <= 0) {
             return 0;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/DialogElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/DialogElement.java
@@ -358,6 +358,11 @@ public final class DialogElement extends ContainerElement<DialogElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        return calculateHeight();
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ErrorPlaceholder.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ErrorPlaceholder.java
@@ -64,6 +64,28 @@ public final class ErrorPlaceholder implements Element {
     }
 
     @Override
+    public int preferredWidth() {
+        // Title + error message + borders
+        String titleText = elementId != null ? " Error: " + elementId + " " : " Error ";
+        String message = cause.getClass().getSimpleName();
+        if (cause.getMessage() != null) {
+            String shortMessage = cause.getMessage();
+            if (shortMessage.length() > 30) {
+                shortMessage = shortMessage.substring(0, 27) + "...";
+            }
+            message = message + ": " + shortMessage;
+        }
+        // "! " prefix + message inside borders
+        return Math.max(titleText.length(), message.length() + 2) + 2;
+    }
+
+    @Override
+    public int preferredHeight() {
+        // Border top + content line + border bottom
+        return 3;
+    }
+
+    @Override
     public void render(Frame frame, Rect area, RenderContext context) {
         if (area.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/FlowElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/FlowElement.java
@@ -158,6 +158,22 @@ public final class FlowElement extends ContainerElement<FlowElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        if (children.isEmpty()) {
+            return 0;
+        }
+        // Without available width, assume single row (max height of children)
+        int maxHeight = 1;
+        for (Element child : children) {
+            maxHeight = Math.max(maxHeight, child.preferredHeight());
+        }
+        if (margin != null) {
+            maxHeight += margin.verticalTotal();
+        }
+        return maxHeight;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (children.isEmpty() || availableWidth <= 0) {
             return 0;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GenericWidgetElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GenericWidgetElement.java
@@ -98,6 +98,16 @@ public final class GenericWidgetElement<T extends Widget> extends StyledElement<
     }
 
     @Override
+    public int preferredWidth() {
+        return 0;
+    }
+
+    @Override
+    public int preferredHeight() {
+        return 0;
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         frame.renderWidget(widget, area);
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GridElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/GridElement.java
@@ -337,6 +337,44 @@ public final class GridElement extends ContainerElement<GridElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        if (children.isEmpty()) {
+            return 0;
+        }
+
+        int cols = resolveColumns(children.size());
+        int rows = resolveRows(children.size(), cols);
+        int vGutter = this.gutter != null ? this.gutter.vertical() : 0;
+
+        int totalHeight = 0;
+        if (gridRows != null && !gridRows.isEmpty()) {
+            for (int r = 0; r < rows; r++) {
+                Constraint constraint = gridRows.get(r % gridRows.size());
+                totalHeight += constraintHint(constraint);
+            }
+        } else {
+            for (int row = 0; row < rows; row++) {
+                int rowHeight = 1;
+                for (int col = 0; col < cols; col++) {
+                    int childIndex = row * cols + col;
+                    if (childIndex < children.size()) {
+                        rowHeight = Math.max(rowHeight, children.get(childIndex).preferredHeight());
+                    }
+                }
+                totalHeight += rowHeight;
+            }
+        }
+
+        totalHeight += vGutter * (rows - 1);
+
+        if (margin != null) {
+            totalHeight += margin.verticalTotal();
+        }
+
+        return totalHeight;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (children.isEmpty() || availableWidth <= 0) {
             return 0;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/InlineScopeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/InlineScopeElement.java
@@ -167,6 +167,32 @@ public final class InlineScopeElement extends ContainerElement<InlineScopeElemen
     }
 
     @Override
+    public int preferredWidth() {
+        if (!visible || children.isEmpty()) {
+            return 0;
+        }
+        // Vertical layout: max width of children
+        int maxWidth = 0;
+        for (Element child : children) {
+            maxWidth = Math.max(maxWidth, child.preferredWidth());
+        }
+        return maxWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        if (!visible || children.isEmpty()) {
+            return 0;
+        }
+        // Sum heights of all children
+        int totalHeight = 0;
+        for (Element child : children) {
+            totalHeight += child.preferredHeight();
+        }
+        return totalHeight;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (!visible || children.isEmpty() || availableWidth <= 0) {
             return 0;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -443,6 +443,40 @@ public final class Panel extends ContainerElement<Panel> {
     }
 
     @Override
+    public int preferredHeight() {
+        // Border overhead: 2 rows for top and bottom
+        int height = 2;
+
+        // Padding overhead
+        if (padding != null) {
+            height += padding.verticalTotal();
+        }
+
+        if (children.isEmpty()) {
+            return height;
+        }
+
+        Direction effectiveDirection = this.direction != null ? this.direction : Direction.VERTICAL;
+        int effectiveSpacing = this.spacing != null ? this.spacing : 0;
+
+        if (effectiveDirection == Direction.VERTICAL) {
+            int totalSpacing = effectiveSpacing * Math.max(0, children.size() - 1);
+            for (Element child : children) {
+                height += child.preferredHeight();
+            }
+            height += totalSpacing;
+        } else {
+            int maxChildHeight = 1;
+            for (Element child : children) {
+                maxChildHeight = Math.max(maxChildHeight, child.preferredHeight());
+            }
+            height += maxChildHeight;
+        }
+
+        return height;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (availableWidth <= 0) {
             return 2; // Just borders

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Row.java
@@ -136,6 +136,19 @@ public final class Row extends ContainerElement<Row> {
     }
 
     @Override
+    public int preferredHeight() {
+        if (children.isEmpty()) {
+            return 1;
+        }
+        // Horizontal layout: max height of children
+        int maxHeight = 1;
+        for (Element child : children) {
+            maxHeight = Math.max(maxHeight, child.preferredHeight());
+        }
+        return maxHeight;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         if (children.isEmpty() || availableWidth <= 0) {
             return 1;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/StackElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/StackElement.java
@@ -134,6 +134,18 @@ public final class StackElement extends ContainerElement<StackElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        int maxHeight = 0;
+        for (Element child : children) {
+            maxHeight = Math.max(maxHeight, child.preferredHeight());
+        }
+        if (margin != null) {
+            maxHeight += margin.verticalTotal();
+        }
+        return maxHeight;
+    }
+
+    @Override
     public int preferredHeight(int availableWidth, RenderContext context) {
         int maxHeight = 0;
         for (Element child : children) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TabsElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TabsElement.java
@@ -250,6 +250,12 @@ public final class TabsElement extends StyledElement<TabsElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        // Tabs are 1 row, or 3 with borders (top + content + bottom)
+        return (borderType != null || title != null) ? 3 : 1;
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (area.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TreeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TreeElement.java
@@ -529,6 +529,73 @@ public final class TreeElement<T> extends StyledElement<TreeElement<T>> {
     }
 
     @Override
+    public int preferredWidth() {
+        if (roots.isEmpty()) {
+            return 0;
+        }
+
+        // Calculate max label width across all visible nodes
+        int maxWidth = 0;
+        for (TreeNode<T> root : roots) {
+            maxWidth = Math.max(maxWidth, computeMaxLabelWidth(root, 0));
+        }
+
+        // Add highlight symbol width
+        String effectiveSymbol = highlightSymbol != null ? highlightSymbol : DEFAULT_HIGHLIGHT_SYMBOL;
+        maxWidth += effectiveSymbol.length();
+
+        // Add border width if present
+        if (title != null || borderType != null) {
+            maxWidth += 2;
+        }
+
+        return maxWidth;
+    }
+
+    @Override
+    public int preferredHeight() {
+        if (roots.isEmpty()) {
+            return 0;
+        }
+
+        // Count visible nodes
+        int count = 0;
+        for (TreeNode<T> root : roots) {
+            count += countVisibleNodes(root);
+        }
+
+        // Add border height if present
+        if (title != null || borderType != null) {
+            count += 2;
+        }
+
+        return count;
+    }
+
+    private int computeMaxLabelWidth(TreeNode<T> node, int depth) {
+        int indentW = indentWidth >= 0 ? indentWidth : guideStyle.space().length();
+        int labelWidth = node.label() != null ? node.label().length() : 0;
+        int width = depth * indentW + labelWidth;
+
+        if (node.isExpanded() && !node.isLeaf()) {
+            for (TreeNode<T> child : node.children()) {
+                width = Math.max(width, computeMaxLabelWidth(child, depth + 1));
+            }
+        }
+        return width;
+    }
+
+    private int countVisibleNodes(TreeNode<T> node) {
+        int count = 1;
+        if (node.isExpanded() && !node.isLeaf()) {
+            for (TreeNode<T> child : node.children()) {
+                count += countVisibleNodes(child);
+            }
+        }
+        return count;
+    }
+
+    @Override
     public Map<String, String> styleAttributes() {
         Map<String, String> attrs = new LinkedHashMap<>(super.styleAttributes());
         if (title != null) {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/WaveTextElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/WaveTextElement.java
@@ -216,6 +216,11 @@ public final class WaveTextElement extends StyledElement<WaveTextElement> {
     }
 
     @Override
+    public int preferredHeight() {
+        return 1;
+    }
+
+    @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (area.isEmpty() || text == null || text.isEmpty()) {
             return;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
@@ -166,6 +166,16 @@ class FaultTolerantRenderingTest {
             }
 
             @Override
+            public int preferredWidth() {
+                return 0;
+            }
+
+            @Override
+            public int preferredHeight() {
+                return 0;
+            }
+
+            @Override
             public String id() {
                 return "faulty-element";
             }
@@ -177,6 +187,16 @@ class FaultTolerantRenderingTest {
             @Override
             public void render(Frame frame, Rect area, RenderContext context) {
                 rendered.set(true);
+            }
+
+            @Override
+            public int preferredWidth() {
+                return 0;
+            }
+
+            @Override
+            public int preferredHeight() {
+                return 0;
             }
 
             @Override

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
@@ -16,6 +16,7 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 
+import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -206,5 +207,72 @@ class ColumnTest {
             .margin(2);
 
         assertThat(column).isInstanceOf(Column.class);
+    }
+
+    @Test
+    @DisplayName("Column renders children vertically")
+    void rendersChildrenVertically() {
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        column(text("AAA"), text("BBB"), text("CCC"))
+            .render(frame, area, RenderContext.empty());
+
+        assertThat(buffer).hasContent(
+            "AAA       ",
+            "BBB       ",
+            "CCC       "
+        );
+    }
+
+    @Test
+    @DisplayName("Column renders with spacing between children")
+    void rendersWithSpacing() {
+        Rect area = new Rect(0, 0, 5, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        column(text("A"), text("B"), text("C"))
+            .spacing(1)
+            .render(frame, area, RenderContext.empty());
+
+        assertThat(buffer).hasContent(
+            "A    ",
+            "     ",
+            "B    ",
+            "     ",
+            "C    "
+        );
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns sum of children heights")
+    void preferredHeight_sumsChildren() {
+        Column column = column(text("A"), text("B"), text("C"));
+        // 3 text elements, each height 1
+        assertThat(column.preferredHeight()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() includes spacing")
+    void preferredHeight_withSpacing() {
+        Column column = column(text("A"), text("B"), text("C")).spacing(2);
+        // 3 texts (height 1 each) + 2 gaps of 2 = 3 + 4 = 7
+        assertThat(column.preferredHeight()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 0 for empty column")
+    void preferredHeight_emptyColumn() {
+        Column column = column();
+        assertThat(column.preferredHeight()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() with single child")
+    void preferredHeight_singleChild() {
+        Column column = column(text("A"));
+        assertThat(column.preferredHeight()).isEqualTo(1);
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DockTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DockTest.java
@@ -153,6 +153,89 @@ class DockTest {
         assertThat(d).isInstanceOf(DockElement.class);
     }
 
+    @Test
+    @DisplayName("left and right panels without explicit width split 50/50")
+    void leftRightPanelsSplit5050() {
+        Rect area = new Rect(0, 0, 40, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        dock()
+            .left(panel("Left", tree()))
+            .right(panel("Right", list()))
+            .render(frame, area, RenderContext.empty());
+
+        // Left panel occupies x=0..19 (20 cols), right panel occupies x=20..39 (20 cols)
+        // Left panel borders
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "┌");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(19, 0, "┐");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 4, "└");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(19, 4, "┘");
+
+        // Right panel borders
+        BufferAssertions.assertThat(buffer).hasSymbolAt(20, 0, "┌");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(39, 0, "┐");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(20, 4, "└");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(39, 4, "┘");
+    }
+
+    @Test
+    @DisplayName("left and right panels split 30/70 with percentage constraints")
+    void leftRightPanelsSplit3070() {
+        Rect area = new Rect(0, 0, 40, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        dock()
+            .left(panel("Left", tree()))
+            .right(panel("Right", list()))
+            .leftWidth(Constraint.percentage(30))
+            .rightWidth(Constraint.percentage(70))
+            .render(frame, area, RenderContext.empty());
+
+        // 30% of 40 = 12 cols (x=0..11), 70% of 40 = 28 cols (x=12..39)
+        // Left panel borders
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "┌");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(11, 0, "┐");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 4, "└");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(11, 4, "┘");
+
+        // Right panel borders
+        BufferAssertions.assertThat(buffer).hasSymbolAt(12, 0, "┌");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(39, 0, "┐");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(12, 4, "└");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(39, 4, "┘");
+    }
+
+    @Test
+    @DisplayName("left and right panels split 30/70 with fill weights")
+    void leftRightPanelsSplit3070WithWeights() {
+        Rect area = new Rect(0, 0, 40, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        dock()
+            .left(panel("Left", tree()))
+            .right(panel("Right", list()))
+            .leftWidth(Constraint.fill(3))
+            .rightWidth(Constraint.fill(7))
+            .render(frame, area, RenderContext.empty());
+
+        // fill(3) + fill(7) = weight 10 total, 40 cols
+        // Left: 3/10 * 40 = 12 cols (x=0..11), Right: 7/10 * 40 = 28 cols (x=12..39)
+        // Left panel borders
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "┌");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(11, 0, "┐");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 4, "└");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(11, 4, "┘");
+
+        // Right panel borders
+        BufferAssertions.assertThat(buffer).hasSymbolAt(12, 0, "┌");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(39, 0, "┐");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(12, 4, "└");
+        BufferAssertions.assertThat(buffer).hasSymbolAt(39, 4, "┘");
+    }
+
     // ==================== CSS property tests ====================
 
     @Nested

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
@@ -7,6 +7,7 @@ package dev.tamboui.toolkit.elements;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
@@ -101,5 +102,51 @@ class ErrorPlaceholderTest {
         ErrorPlaceholder placeholder = ErrorPlaceholder.from(new RuntimeException("Error"));
 
         assertThat(placeholder.id()).isNull();
+    }
+
+    @Test
+    @DisplayName("preferredWidth() accounts for title and message")
+    void preferredWidth() {
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(
+                new RuntimeException("Short"),
+                "my-long-widget-id"
+        );
+
+        // Width should accommodate the wider of title/message + border (2)
+        int width = placeholder.preferredWidth();
+        assertThat(width).isGreaterThan(2);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 3 (borders + content)")
+    void preferredHeight() {
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(new RuntimeException("Error"));
+
+        assertThat(placeholder.preferredHeight()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("renders border around error content")
+    void rendersBorderAroundContent() {
+        Rect area = new Rect(0, 0, 30, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        RenderContext context = RenderContext.empty();
+
+        ErrorPlaceholder placeholder = ErrorPlaceholder.from(
+                new RuntimeException("Oops"),
+                "widget-x"
+        );
+
+        placeholder.render(frame, area, context);
+
+        // Top-left border corner
+        BufferAssertions.assertThat(buffer).at(0, 0).hasSymbol("┌");
+        // Top-right border corner
+        BufferAssertions.assertThat(buffer).at(29, 0).hasSymbol("┐");
+        // Bottom-left border corner
+        BufferAssertions.assertThat(buffer).at(0, 2).hasSymbol("└");
+        // Bottom-right border corner
+        BufferAssertions.assertThat(buffer).at(29, 2).hasSymbol("┘");
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FlowTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FlowTest.java
@@ -208,4 +208,37 @@ class FlowTest {
                 .hasSymbolAt(2, 0, "C");
         }
     }
+
+    @Test
+    @DisplayName("preferredHeight returns max child height")
+    void preferredHeight() {
+        FlowElement f = flow(text("A"), text("B"), text("C"));
+        // All height 1
+        assertThat(f.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("preferredHeight returns 0 for empty flow")
+    void preferredHeightEmpty() {
+        FlowElement f = flow();
+        assertThat(f.preferredHeight()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight includes margin")
+    void preferredHeightWithMargin() {
+        FlowElement f = flow(text("A")).margin(new Margin(2, 0, 3, 0));
+        // 1 + 2 + 3 = 6
+        assertThat(f.preferredHeight()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("preferredHeight with available width wraps items")
+    void preferredHeightWithWidth() {
+        // "AB"(2) + "CD"(2) = 4, fits in 5
+        // "EF"(2) wraps to row 2
+        FlowElement f = flow(text("AB"), text("CD"), text("EF"));
+        int height = f.preferredHeight(5, RenderContext.empty());
+        assertThat(height).isEqualTo(2);
+    }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
@@ -287,6 +287,25 @@ class GenericWidgetElementTest {
     }
 
     @Nested
+    @DisplayName("Preferred size")
+    class PreferredSizeTests {
+
+        @Test
+        @DisplayName("preferredWidth returns 0 (widget size unknown)")
+        void preferredWidth() {
+            Widget testWidget = (area, buffer) -> {};
+            assertThat(widget(testWidget).preferredWidth()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("preferredHeight returns 0 (widget size unknown)")
+        void preferredHeight() {
+            Widget testWidget = (area, buffer) -> {};
+            assertThat(widget(testWidget).preferredHeight()).isEqualTo(0);
+        }
+    }
+
+    @Nested
     @DisplayName("CSS support")
     class CssSupportTests {
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
@@ -7,8 +7,12 @@ package dev.tamboui.toolkit.elements;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.RenderContext;
 
+import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -128,5 +132,61 @@ class InlineScopeElementTest {
         outerScope.hide();
         int heightOuterHidden = outerScope.preferredHeight(80, RenderContext.empty());
         assertThat(heightOuterHidden).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("visible scope renders children vertically")
+    void visibleScopeRendersChildren() {
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        new InlineScopeElement(
+            text("AAA"),
+            text("BBB"),
+            text("CCC")
+        ).render(frame, area, RenderContext.empty());
+
+        assertThat(buffer).hasContent(
+            "AAA       ",
+            "BBB       ",
+            "CCC       "
+        );
+    }
+
+    @Test
+    @DisplayName("hidden scope renders nothing")
+    void hiddenScopeRendersNothing() {
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        new InlineScopeElement(
+            text("AAA"),
+            text("BBB"),
+            text("CCC")
+        ).visible(false).render(frame, area, RenderContext.empty());
+
+        assertThat(buffer).isEqualTo(Buffer.empty(area));
+    }
+
+    @Test
+    @DisplayName("preferredWidth returns max child width when visible")
+    void preferredWidthReturnsMaxChildWidth() {
+        InlineScopeElement scope = new InlineScopeElement(
+            text("A"),
+            text("BBB"),
+            text("CC")
+        );
+        assertThat(scope.preferredWidth()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("preferredWidth returns 0 when hidden")
+    void preferredWidthReturnsZeroWhenHidden() {
+        InlineScopeElement scope = new InlineScopeElement(
+            text("Hello")
+        ).visible(false);
+        assertThat(scope.preferredWidth()).isEqualTo(0);
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowTest.java
@@ -16,6 +16,7 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 
+import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -195,5 +196,52 @@ class RowTest {
             .margin(2);
 
         assertThat(row).isInstanceOf(Row.class);
+    }
+
+    @Test
+    @DisplayName("Row renders children horizontally")
+    void rendersChildrenHorizontally() {
+        Rect area = new Rect(0, 0, 10, 1);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        row(text("AB"), text("CD"), text("EF"))
+            .render(frame, area, RenderContext.empty());
+
+        assertThat(buffer).hasContent(
+            "ABCDEF    "
+        );
+    }
+
+    @Test
+    @DisplayName("Row renders with spacing between children")
+    void rendersWithSpacing() {
+        Rect area = new Rect(0, 0, 10, 1);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        row(text("A"), text("B"), text("C"))
+            .spacing(2)
+            .render(frame, area, RenderContext.empty());
+
+        assertThat(buffer).hasContent(
+            "A  B  C   "
+        );
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns max of children heights")
+    void preferredHeight_maxOfChildren() {
+        Row row = row(text("A"), text("B"), text("C"));
+        // All height 1
+        assertThat(row.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 1 for empty row")
+    void preferredHeight_emptyRow() {
+        Row row = row();
+        // Minimum height for a row is 1
+        assertThat(row.preferredHeight()).isEqualTo(1);
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/StackTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/StackTest.java
@@ -173,4 +173,27 @@ class StackTest {
             BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "X");
         }
     }
+
+    @Test
+    @DisplayName("preferredHeight returns max of all children")
+    void preferredHeight() {
+        StackElement s = stack(text("A"), text("B"), text("C"));
+        // All height 1
+        assertThat(s.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("preferredHeight returns 0 for empty stack")
+    void preferredHeightEmpty() {
+        StackElement s = stack();
+        assertThat(s.preferredHeight()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight includes margin")
+    void preferredHeightWithMargin() {
+        StackElement s = stack(text("A")).margin(new Margin(2, 0, 3, 0));
+        // 1 + 2 + 3 = 6
+        assertThat(s.preferredHeight()).isEqualTo(6);
+    }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TabsElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TabsElementTest.java
@@ -384,4 +384,51 @@ class TabsElementTest {
 
         assertThat(tabsElement.preferredWidth()).isEqualTo(12); // "Home" + " | " + "About" = 4 + 3 + 5 = 12
     }
+
+    @Test
+    @DisplayName("preferredHeight() returns 1 without borders")
+    void preferredHeight_noBorder() {
+        TabsElement element = tabs("A", "B", "C");
+        assertThat(element.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 3 with borders")
+    void preferredHeight_withBorder() {
+        TabsElement element = tabs("A", "B", "C").rounded();
+        assertThat(element.preferredHeight()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 3 with title")
+    void preferredHeight_withTitle() {
+        TabsElement element = tabs("A", "B", "C").title("Nav");
+        assertThat(element.preferredHeight()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 1 for tabs without border")
+    void preferredHeight_noBorderNoTitle() {
+        TabsElement element = tabs("A");
+        assertThat(element.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("tabs render at preferred size with correct content")
+    void rendersAtPreferredSize() {
+        TabsElement element = tabs("A", "B").divider("|").selected(0);
+
+        int w = element.preferredWidth();
+        int h = element.preferredHeight();
+        Rect area = new Rect(0, 0, w, h);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        element.render(frame, area, RenderContext.empty());
+
+        // "A|B" = 3 chars wide, 1 row
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("|");
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo("B");
+    }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TreeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TreeElementTest.java
@@ -693,6 +693,88 @@ class TreeElementTest {
         );
     }
 
+    // ═══════════════════════════════════════════════════════════════
+    // preferredWidth / preferredHeight tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Test
+    @DisplayName("preferredWidth returns 0 for empty tree")
+    void preferredWidth_emptyTree() {
+        TreeElement<Void> element = tree();
+        assertThat(element.preferredWidth()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight returns 0 for empty tree")
+    void preferredHeight_emptyTree() {
+        TreeElement<Void> element = tree();
+        assertThat(element.preferredHeight()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("preferredHeight counts visible nodes")
+    void preferredHeight_visibleNodes() {
+        TreeNode<Void> root = TreeNode.<Void>of("Root")
+                .add(TreeNode.of("Child 1"))
+                .add(TreeNode.of("Child 2"))
+                .expanded();
+
+        TreeElement<Void> element = tree(root);
+        // Root + 2 children = 3
+        assertThat(element.preferredHeight()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("preferredHeight excludes collapsed children")
+    void preferredHeight_collapsedChildren() {
+        TreeNode<Void> root = TreeNode.<Void>of("Root")
+                .add(TreeNode.of("Child 1"))
+                .add(TreeNode.of("Child 2"));
+        // Root is collapsed by default
+
+        TreeElement<Void> element = tree(root);
+        // Only root visible
+        assertThat(element.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("preferredHeight includes border overhead")
+    void preferredHeight_withBorder() {
+        TreeNode<Void> root = TreeNode.<Void>of("Root").leaf();
+
+        TreeElement<Void> element = tree(root).title("Tree").rounded();
+        // 1 (root) + 2 (borders) = 3
+        assertThat(element.preferredHeight()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("preferredWidth includes highlight symbol and borders")
+    void preferredWidth_withBorder() {
+        TreeNode<Void> root = TreeNode.<Void>of("Root").leaf();
+
+        TreeElement<Void> element = tree(root).highlightSymbol(">> ").rounded();
+        // "Root" = 4, highlight ">> " = 3, borders = 2 → 4 + 3 + 2 = 9
+        assertThat(element.preferredWidth()).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("preferredWidth accounts for deepest indented node")
+    void preferredWidth_deepNesting() {
+        TreeNode<Void> root = TreeNode.<Void>of("A")
+                .add(TreeNode.<Void>of("BB")
+                        .add(TreeNode.<Void>of("CCC").leaf())
+                        .expanded())
+                .expanded();
+
+        TreeElement<Void> element = tree(root).highlightSymbol("");
+        // Default indent width = 4 (from GuideStyle.UNICODE "└── ")
+        // Depth 0: "A" = 1
+        // Depth 1: 4 + "BB" = 6
+        // Depth 2: 8 + "CCC" = 11
+        // Max = 11 (no borders, no highlight)
+        assertThat(element.preferredWidth()).isEqualTo(11);
+    }
+
     @Test
     @DisplayName("Custom nodeRenderer with explicit width constraint")
     void nodeRendererWithWidth() {

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/WaveTextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/WaveTextElementTest.java
@@ -14,6 +14,7 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widgets.wavetext.WaveTextState;
 
+import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -162,5 +163,30 @@ class WaveTextElementTest {
     void invertedShorthandMethod() {
         WaveTextElement element = waveText("Test").inverted();
         assertThat(element).isNotNull();
+    }
+
+    @Test
+    @DisplayName("preferredHeight() returns 1")
+    void preferredHeight() {
+        WaveTextElement element = waveText("Loading...");
+        assertThat(element.preferredHeight()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("renders text characters to buffer")
+    void rendersTextCharacters() {
+        Rect area = new Rect(0, 0, 10, 1);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        waveText("Hello")
+            .render(frame, area, RenderContext.empty());
+
+        // Wave text renders the text content - characters should be present
+        assertThat(buffer).hasSymbolAt(0, 0, "H");
+        assertThat(buffer).hasSymbolAt(1, 0, "e");
+        assertThat(buffer).hasSymbolAt(2, 0, "l");
+        assertThat(buffer).hasSymbolAt(3, 0, "l");
+        assertThat(buffer).hasSymbolAt(4, 0, "o");
     }
 }

--- a/tamboui-widgets/src/main/java11/module-info.java
+++ b/tamboui-widgets/src/main/java11/module-info.java
@@ -28,4 +28,5 @@ module dev.tamboui.widgets {
     exports dev.tamboui.widgets.tree;
     exports dev.tamboui.widgets.spinner;
     exports dev.tamboui.widgets.toggle;
+    exports dev.tamboui.widgets.wavetext;
 }


### PR DESCRIPTION
This commit removes the default implementation for preferred width and height in elements. It's currently too easy to forget to implement it, which causes all sorts of layout bugs (empty elements).

Therefore, this also fixes a number of missing implementations, and adds tests for these.

Note: there is a behavior change in `dock` now that we fixed the implementation. Since it now implements the preferred height, in order to fill the available space, you have to call `fill()` explicitly (defaults to `fit` as intended).

NB: This fixes a bug which appeared after simply updating to a newer SNAPSHOT version where the default layout strategy changed to `fit`