### PR TITLE
dev.tamboui.tui.Keys class is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,14 @@ public class HelloWorldTuiDemo {
     public static void main(String[] args) throws Exception {
         try (var tui = TuiRunner.create()) {
             tui.run(
-                (event, runner) -> {
-                    if (event instanceof KeyEvent && ((KeyEvent) event).isQuit()) {
-                        runner.quit();
-                        return false;
-                    }
-                    return false;
-                },
+                (event, runner) ->
+                    switch (event) {
+                        case KeyEvent k when k.isQuit() -> {
+                            runner.quit();
+                            yield false;
+                        }
+                        default -> false;
+                    },
                 frame -> {
                     var paragraph = Paragraph.builder()
                         .text(Text.from("Hello, TamboUI! Press 'q' to quit."))

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -152,13 +152,14 @@ public class HelloTuiRunner {
     public static void main(String[] args) throws Exception {
         try (var tui = TuiRunner.create()) {
             tui.run(
-                (event, runner) -> {
-                    if (event instanceof KeyEvent && ((KeyEvent) event).isQuit()) {
-                        runner.quit();
-                        return false;
-                    }
-                    return false;
-                },
+                (event, runner) ->
+                    switch (event) {
+                        case KeyEvent k when k.isQuit() -> {
+                            runner.quit();
+                            yield false;
+                        }
+                        default -> false;
+                    },
                 frame -> {
                     var paragraph = Paragraph.builder()
                         .text(Text.from("Hello, TamboUI! Press 'q' to quit."))


### PR DESCRIPTION
- `dev.tamboui.tui.Keys` class is deprecated and should be replaced with `dev.tamboui.tui.event.KeyEvent`.
- Fix #180