### PR TITLE
Consolidate schedulers

### DIFF
--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -390,6 +390,57 @@ runner.scheduleRepeating(() -> {
 
 This explicit approach gives you control - you can do background work in the scheduled action and only post the UI update portion to the render thread.
 
+==== Scheduler Management
+
+Each runner maintains a single shared scheduler that handles both internal tasks (tick events, resize detection) and user-scheduled actions.
+By default, this scheduler is created internally when the runner starts and shut down when the runner closes.
+
+===== External Scheduler Injection
+
+For integration with frameworks that provide their own thread pools, you can inject an external scheduler via configuration:
+
+[source,java]
+----
+ScheduledExecutorService myScheduler = Executors.newSingleThreadScheduledExecutor();
+
+var config = TuiConfig.builder()
+    .scheduler(myScheduler)  // Use externally-managed scheduler
+    .build();
+
+try (var tui = TuiRunner.create(config)) {
+    tui.run(handler, renderer);
+}
+
+// myScheduler is NOT shut down when TuiRunner closes - caller retains ownership
+myScheduler.shutdown();
+----
+
+===== Closing Semantics
+
+When closing runners:
+
+* **Internally-created scheduler**: Shut down automatically when the runner closes
+* **Externally-provided scheduler**: NOT shut down - the caller retains ownership and is responsible for its lifecycle
+
+This allows frameworks to manage scheduler lifecycles independently of individual runner instances.
+
+===== Multiple Runners
+
+When using multiple runners in a single application (e.g., multiple `InlineTuiRunner` instances for different inline displays), there are two approaches:
+
+[cols="1,2",options="header"]
+|===
+|Approach |Behavior
+
+|Default (no external scheduler)
+|Each runner creates and owns its own scheduler. Closing one runner shuts down only its scheduler.
+
+|Shared external scheduler
+|All runners share the provided scheduler. Runners do not shut it down; the caller manages its lifecycle.
+|===
+
+For multiple runners that should share a scheduler, provide an externally-managed scheduler via config to avoid premature shutdown when one runner closes.
+
 === Semantic Key Checks
 
 `KeyEvent` provides semantic methods that respect the configured bindings:

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/Schedulers.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/Schedulers.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Utility for creating and resolving schedulers used by TUI runners.
+ * <p>
+ * This utility creates single-threaded daemon schedulers suitable for
+ * tick events, resize handling, and user-scheduled actions.
+ * <p>
+ * When an external scheduler is provided, this utility validates it is
+ * usable (not shut down) before returning it.
+ */
+final class Schedulers {
+
+    private static final String THREAD_NAME_PREFIX = "tamboui-scheduler-";
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger(1);
+
+    private Schedulers() {
+        // Utility class
+    }
+
+    /**
+     * Result of scheduler resolution containing the scheduler and ownership flag.
+     */
+    static final class Scheduler {
+        private final ScheduledExecutorService scheduler;
+        private final boolean owned;
+
+        Scheduler(ScheduledExecutorService scheduler, boolean owned) {
+            this.scheduler = scheduler;
+            this.owned = owned;
+        }
+
+        /**
+         * Returns the scheduler to use.
+         *
+         * @return the scheduler
+         */
+        ScheduledExecutorService scheduler() {
+            return scheduler;
+        }
+
+        /**
+         * Returns true if the scheduler was created by this utility and should be shut down on close.
+         *
+         * @return true if owned
+         */
+        boolean owned() {
+            return owned;
+        }
+    }
+
+    /**
+     * Resolves the scheduler to use based on the provided external scheduler.
+     * <p>
+     * If the external scheduler is null, creates a new internal scheduler.
+     * If the external scheduler is shut down, throws an exception.
+     * Otherwise, uses the provided scheduler with owned=false.
+     *
+     * @param external the externally-provided scheduler, or null to create a new one
+     * @return the scheduler result containing the scheduler and ownership flag
+     * @throws IllegalStateException if the external scheduler is shut down
+     */
+    static Scheduler resolve(ScheduledExecutorService external) {
+        if (external == null) {
+            return new Scheduler(create(), true);
+        }
+        if (external.isShutdown()) {
+            throw new IllegalStateException("Externally-provided scheduler is shut down");
+        }
+        return new Scheduler(external, false);
+    }
+
+    /**
+     * Creates a new default scheduler.
+     *
+     * @return a new scheduler
+     */
+    static ScheduledExecutorService create() {
+        return new ScheduledThreadPoolExecutor(1, r -> {
+            Thread t = new Thread(r, THREAD_NAME_PREFIX + THREAD_COUNTER.getAndIncrement());
+            t.setDaemon(true);
+            return t;
+        });
+    }
+}


### PR DESCRIPTION
This commit fixes the issue that we could create multiple schedulers in a application. There wasn't either a consistency between how the schedulers were created in the toolkit and TUI helpers.

Now both use the same pattern, shared code, and we also let the user inject an external scheduler, which will be useful when integrating with frameworks like Micronaut, Quarkus or Spring Boot.