### PR TITLE
feat: filtering honor tags + use markup

### DIFF
--- a/buildSrc/src/main/java/dev/tamboui/build/GenerateDemoManifestTask.java
+++ b/buildSrc/src/main/java/dev/tamboui/build/GenerateDemoManifestTask.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Task to generate a JSON manifest file listing all demos with their main classes.
@@ -33,13 +34,15 @@ public abstract class GenerateDemoManifestTask extends DefaultTask {
         private final String description;
         private final String module;
         private final String mainClass;
+        private final Set<String> tags;
 
-        public DemoEntry(String id, String displayName, String description, String module, String mainClass) {
+        public DemoEntry(String id, String displayName, String description, String module, String mainClass, Set<String> tags) {
             this.id = id;
             this.displayName = displayName;
             this.description = description;
             this.module = module;
             this.mainClass = mainClass;
+            this.tags = tags;
         }
 
         public String getId() {
@@ -60,6 +63,10 @@ public abstract class GenerateDemoManifestTask extends DefaultTask {
 
         public String getMainClass() {
             return mainClass;
+        }
+
+        public Set<String> getTags() {
+            return tags;
         }
     }
 
@@ -99,11 +106,22 @@ public abstract class GenerateDemoManifestTask extends DefaultTask {
             sb.append("      \"displayName\": ").append(jsonString(demo.getDisplayName())).append(",\n");
             sb.append("      \"description\": ").append(jsonString(demo.getDescription())).append(",\n");
             sb.append("      \"module\": ").append(jsonString(demo.getModule())).append(",\n");
-            sb.append("      \"mainClass\": ").append(jsonString(demo.getMainClass())).append("\n");
+            sb.append("      \"mainClass\": ").append(jsonString(demo.getMainClass())).append(",\n");
+            sb.append("      \"tags\": ");
+            boolean firstTag = true;
+            sb.append("\"");
+            for (String tag : demo.getTags()) {
+                if (!firstTag) {
+                    sb.append(", ");
+                }
+                firstTag = false;
+                sb.append(tag);
+            }
+            sb.append("\"\n");
             sb.append("    }");
         }
 
-        sb.append("\n  ]\n");
+        sb.append("\"\n  ]\n");
         sb.append("}");
         return sb.toString();
     }

--- a/buildSrc/src/main/kotlin/dev.tamboui.demo-aggregator.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.demo-aggregator.gradle.kts
@@ -37,7 +37,8 @@ data class DemoInfo(
     var displayName: String = "",
     var description: String = "",
     var module: String = "",
-    var mainClass: String = ""
+    var mainClass: String = "",
+    var tags: Set<String> = emptySet()
 )
 
 // Map to collect demo info during configuration
@@ -73,6 +74,7 @@ rootProject.allprojects {
                     demoInfo.description = ext?.description?.orNull ?: ""
                     demoInfo.module = ext?.module?.orNull ?: "Other"
                     demoInfo.mainClass = app?.mainClass?.orNull ?: ""
+                    demoInfo.tags = ext?.tags?.orNull ?: emptySet()
                 }
             }
         }
@@ -92,7 +94,8 @@ val generateDemoManifest = tasks.register<GenerateDemoManifestTask>("generateDem
                     info.displayName,
                     info.description,
                     info.module,
-                    info.mainClass
+                    info.mainClass,
+                    info.tags
                 )
             }
     })


### PR DESCRIPTION
builds ontop of #197 

include tags in demo manifest so it can be used in filter.

also added a bit of markup to make it easier to spot the demo names:

<img width="1094" height="308" alt="2026-02-15_12-08-57" src="https://github.com/user-attachments/assets/f7e05508-ecb9-478a-b475-fd74feb1f7a4" />
