### PR TITLE
Add Gradle plugin for reporting dependency updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     id("dev.tamboui.parent")
+    id("com.github.ben-manes.versions") version "0.53.0"
 }


### PR DESCRIPTION
Run as `./gradlew dependencyUpdates --no-parallel`

```
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.53.0
 - org.aesh:terminal-http:3.1
 - org.aesh:terminal-ssh:3.1
 - org.aesh:terminal-tty:3.1
 - org.asciidoctor:asciidoctorj:2.5.7

The following dependencies have later milestone versions:
 - com.github.oshi:oshi-core [6.9.2 -> 6.9.3]
     https://github.com/oshi/oshi
 - com.google.testing.compile:compile-testing [0.21.0 -> 0.23.0]
     http://github.com/google/compile-testing
 - info.picocli:picocli [4.7.6 -> 4.7.7]
     https://picocli.info
 - info.picocli:picocli-codegen [4.7.6 -> 4.7.7]
     https://picocli.info
 - io.netty:netty-all [4.1.81.Final -> 5.0.0.Alpha2]
     http://netty.io/
 - org.apache.sshd:sshd-core [2.14.0 -> 3.0.0-M2]
     https://www.apache.org/
 - org.apache.sshd:sshd-netty [2.14.0 -> 3.0.0-M2]
     https://www.apache.org/
 - org.assertj:assertj-core [3.27.6 -> 4.0.0-M1]
     https://assertj.github.io/doc/#assertj-core
 - org.graalvm.buildtools:junit-platform-native [0.11.1 -> 0.11.4]
     https://github.com/graalvm/native-build-tools
 - org.gradle:gradle-tooling-api [9.2.1 -> 9.5.0-milestone-3]
     https://gradle.org
 - org.jline:jline [3.25.1 -> 3.30.6]
     https://github.com/jline/jline3/jline
 - org.junit:junit-bom [5.14.1 -> 6.1.0-M1]
     https://junit.org/
 - org.junit.jupiter:junit-jupiter [5.14.1 -> 6.1.0-M1]
     https://junit.org/
 - org.junit.platform:junit-platform-launcher [1.14.1 -> 6.1.0-M1]
     https://junit.org/

Failed to compare versions for the following dependencies because they were declared without version:
 - org.junit.platform:junit-platform-console
 - org.junit.platform:junit-platform-reporting

Gradle release-candidate updates:Generated report file build/dependencyUpdates/report.txt
 - Gradle: [9.2.1 -> 9.3.1 -> 9.4.0-rc-1]
```