### PR TITLE
fix: demos to use 21, filemanger 8

### DIFF
--- a/buildSrc/src/main/kotlin/dev.tamboui.demo-project.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.demo-project.gradle.kts
@@ -21,12 +21,12 @@ tasks.withType<JavaExec>().configureEach {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 22
+    options.release = 21
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_22
-    targetCompatibility = JavaVersion.VERSION_22
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 application {

--- a/demos/filemanager-demo/build.gradle.kts
+++ b/demos/filemanager-demo/build.gradle.kts
@@ -9,6 +9,12 @@ demo {
     tags = setOf("toolkit", "list", "panel", "text", "application", "mvc", "interactive")
 }
 
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     implementation(projects.tambouiToolkit)
     implementation(projects.tambouiImage)


### PR DESCRIPTION
fixing #218 so examples run with java 21 as they do work on 21 and when run together with java 22+ panama gets activated.

also noticed filemanger wasn't to java 8 although the one example we got to validate java8 works.

