### PR TITLE
fix: prevent auto-focus from overriding explicit focus clear (Escape)

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
@@ -160,9 +160,10 @@ public final class InlineToolkitRunner implements AutoCloseable {
                 }
 
                 // Auto-focus first focusable element if nothing is focused or focus is stale
+                // (but not if focus was explicitly cleared, e.g. via Escape)
                 String currentFocus = focusManager.focusedId();
                 List<String> focusOrder = focusManager.focusOrder();
-                if (!focusOrder.isEmpty()) {
+                if (!focusOrder.isEmpty() && !focusManager.isFocusExplicitlyCleared()) {
                     if (currentFocus == null || !focusOrder.contains(currentFocus)) {
                         focusManager.setFocus(focusOrder.get(0));
                     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
@@ -160,9 +160,10 @@ public final class ToolkitRunner implements AutoCloseable {
                 }
 
                 // Auto-focus first focusable element if nothing is focused or focus is stale
+                // (but not if focus was explicitly cleared, e.g. via Escape)
                 String currentFocus = focusManager.focusedId();
                 List<String> focusOrder = focusManager.focusOrder();
-                if (!focusOrder.isEmpty()) {
+                if (!focusOrder.isEmpty() && !focusManager.isFocusExplicitlyCleared()) {
                     if (currentFocus == null || !focusOrder.contains(currentFocus)) {
                         focusManager.setFocus(focusOrder.get(0));
                     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/focus/FocusManager.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/focus/FocusManager.java
@@ -26,6 +26,7 @@ public final class FocusManager {
     }
 
     private String focusedId;
+    private boolean focusExplicitlyCleared;
     private final List<String> focusOrder = new ArrayList<>();
     private final Map<String, Rect> focusableAreas = new LinkedHashMap<>();
 
@@ -55,13 +56,32 @@ public final class FocusManager {
      */
     public void setFocus(String elementId) {
         this.focusedId = elementId;
+        if (elementId != null) {
+            this.focusExplicitlyCleared = false;
+        }
     }
 
     /**
      * Clears the current focus.
+     * <p>
+     * After calling this method, auto-focus will not re-focus the first
+     * element until focus is explicitly set again (e.g., via Tab, click,
+     * or {@link #setFocus(String)}).
      */
     public void clearFocus() {
         this.focusedId = null;
+        this.focusExplicitlyCleared = true;
+    }
+
+    /**
+     * Returns whether focus was explicitly cleared (e.g., via Escape).
+     * <p>
+     * When true, auto-focus logic should not re-focus the first element.
+     *
+     * @return true if focus was explicitly cleared
+     */
+    public boolean isFocusExplicitlyCleared() {
+        return focusExplicitlyCleared;
     }
 
     /**
@@ -83,7 +103,8 @@ public final class FocusManager {
             focusableAreas.put(elementId, area);
 
             // Auto-focus first focusable element if nothing is focused
-            if (isFirst && focusedId == null) {
+            // (but not if focus was explicitly cleared, e.g. via Escape)
+            if (isFirst && focusedId == null && !focusExplicitlyCleared) {
                 focusedId = elementId;
             }
         }
@@ -107,6 +128,8 @@ public final class FocusManager {
         if (focusOrder.isEmpty()) {
             return false;
         }
+
+        focusExplicitlyCleared = false;
 
         if (focusedId == null) {
             focusedId = focusOrder.get(0);
@@ -137,6 +160,8 @@ public final class FocusManager {
         if (focusOrder.isEmpty()) {
             return false;
         }
+
+        focusExplicitlyCleared = false;
 
         if (focusedId == null) {
             focusedId = focusOrder.get(focusOrder.size() - 1);
@@ -169,6 +194,7 @@ public final class FocusManager {
         for (Map.Entry<String, Rect> entry : focusableAreas.entrySet()) {
             if (entry.getValue().contains(x, y)) {
                 focusedId = entry.getKey();
+                focusExplicitlyCleared = false;
                 return true;
             }
         }


### PR DESCRIPTION
## Summary

When pressing **Escape** in a focused input field, `clearFocus()` correctly sets `focusedId` to `null`. However, on the very next render cycle, two auto-focus mechanisms immediately re-focus the first focusable element:

1. `FocusManager.registerFocusable()` — auto-focuses the first element when `focusedId == null`
2. `ToolkitRunner.run()` / `InlineToolkitRunner.run()` — explicitly sets focus to the first element when `currentFocus == null`

This makes it impossible to fully clear focus via Escape — the focus always snaps back to the first focusable element.

## Solution

Add a `focusExplicitlyCleared` flag to `FocusManager` that tracks whether focus was intentionally removed:

- **Set** by `clearFocus()` (Escape key, clicking outside focusable elements)
- **Reset** by any explicit focus action: `setFocus()`, `focusNext()`, `focusPrevious()`, `focusAt()` (Tab, Shift+Tab, mouse click on element)
- **Checked** in `registerFocusable()` and both runner render callbacks — auto-focus is skipped when the flag is set

## Changed files

- `FocusManager.java` — new `focusExplicitlyCleared` flag with getter, integrated into all focus mutation methods
- `ToolkitRunner.java` — check `isFocusExplicitlyCleared()` before auto-focusing
- `InlineToolkitRunner.java` — same check

## Test plan

- [x] Existing `tamboui-toolkit` tests pass (`./gradlew :tamboui-toolkit:test`)
- [x] Manual: Focus a text input → press Escape → verify no element is focused
- [x] Manual: After Escape clear, press Tab → verify focus returns to first element
- [x] Manual: After Escape clear, click on an input → verify it gets focused