### PR TITLE
feat(toolkit): add native SelectState support to FormFieldElement

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -57,6 +57,7 @@ import dev.tamboui.widgets.form.FormState;
 import dev.tamboui.widgets.form.SelectFieldState;
 import dev.tamboui.widgets.input.TextAreaState;
 import dev.tamboui.widgets.input.TextInputState;
+import dev.tamboui.widgets.select.SelectState;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
 import dev.tamboui.widgets.spinner.SpinnerStyle;
 import dev.tamboui.widgets.tree.TreeNode;
@@ -1017,6 +1018,20 @@ public final class Toolkit {
      * @return a new form field element
      */
     public static FormFieldElement formField(String label, SelectFieldState state) {
+        return new FormFieldElement(label, state);
+    }
+
+    /**
+     * Creates a form field with a label and a {@link SelectState} reference.
+     * <p>
+     * Unlike the {@link SelectFieldState} overload, this keeps a direct reference
+     * to the original state, enabling true two-way binding.
+     *
+     * @param label the field label
+     * @param state the select state (direct reference)
+     * @return a new form field element
+     */
+    public static FormFieldElement formField(String label, SelectState state) {
         return new FormFieldElement(label, state);
     }
 


### PR DESCRIPTION
## Summary

`FormFieldElement` only accepts `SelectFieldState`, forcing consumers to copy `SelectState` into `SelectFieldState` and breaking two-way binding. `TextInputState` already works as a direct reference — this makes `SelectState` symmetric.

- Add `selectStateRef` field and `SelectState` constructor to `FormFieldElement`
- Prefer `selectStateRef` in `handleSelectFieldKey()` and `renderSelect()`
- Add `Toolkit.formField(String, SelectState)` factory method
- Fully backward-compatible, no existing API changes

## Motivation

When using `FormFieldElement` with a standalone `SelectState` (outside of `FormState`), the only option is to copy into a `SelectFieldState`:

```java
// Copies state — UI changes don't reach the original SelectState
SelectFieldState copy = new SelectFieldState(ss.options(), ss.selectedIndex());
var element = Toolkit.formField("", copy);
```

With this change:

```java
// Direct reference — true two-way binding
var element = Toolkit.formField("", selectState);
```

## Changes

| File | Change |
|---|---|
| `FormFieldElement.java` | New `selectStateRef` field, new constructor, updated `handleSelectFieldKey()` and `renderSelect()` |
| `Toolkit.java` | New `formField(String, SelectState)` factory method |

## Test plan

- [ ] Existing tests remain green
- [ ] Create `FormFieldElement` with `SelectState`, verify `selectNext()`/`selectPrevious()` modifies the original state
- [ ] Create `FormFieldElement` with `SelectFieldState`, verify existing behavior unchanged
- [ ] Verify rendering uses original `SelectState` (no copy in `renderSelect()`)