### PR TITLE
fix(toolkit): ignore key events in TreeElement when not focused

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TreeElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TreeElement.java
@@ -757,7 +757,7 @@ public final class TreeElement<T> extends StyledElement<TreeElement<T>> {
             return result;
         }
 
-        if (lastFlatEntries.isEmpty()) {
+        if (!focused || lastFlatEntries.isEmpty()) {
             return EventResult.UNHANDLED;
         }
 


### PR DESCRIPTION
## Summary
- `TreeElement.handleKeyEvent()` did not check the `focused` parameter, consuming arrow key events even when another widget had focus
- Added `!focused` early-return so TreeElement only handles navigation keys when it is the focused element

## Test plan
- [ ] Open a layout with TreeElement and other focusable widgets (e.g. TextArea, FormField)
- [ ] Verify arrow keys only navigate the tree when it has focus
- [ ] Verify arrow keys work normally in other widgets when tree is not focused