### PR TITLE
Track snippet sources to trigger documentation rebuilds

### DIFF
--- a/buildSrc/src/main/kotlin/dev.tamboui.docs.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.docs.gradle.kts
@@ -86,6 +86,8 @@ tasks.asciidoctor {
     inputs.files(copyCasts)
     inputs.files(copyScreenshots)
     inputs.files(javadoc)
+    // Track snippet source files so changes trigger doc rebuild
+    inputs.dir(project.file("src/snippets/java"))
     // Ensure code snippets compile before building docs
     dependsOn(snippetsClasses)
 


### PR DESCRIPTION
I've come across a problem described here https://github.com/orgs/tamboui/discussions/257
Asciidoctor couldn't see changes made to the snippets.