### PR TITLE
Comment out misleading attribute which Gradle already sets.

### DIFF
--- a/docs/src/docs/asciidoc/_attributes.adoc
+++ b/docs/src/docs/asciidoc/_attributes.adoc
@@ -1,6 +1,6 @@
 // Shared attributes for TamboUI documentation
 :project-name: TamboUI
-:project-version: 0.1.0-SNAPSHOT
+// :project-version: set by Gradle
 :github-repo: tamboui/tamboui
 :github-url: https://github.com/{github-repo}
 

--- a/docs/src/docs/asciidoc/_attributes.adoc
+++ b/docs/src/docs/asciidoc/_attributes.adoc
@@ -1,6 +1,6 @@
 // Shared attributes for TamboUI documentation
 :project-name: TamboUI
-// :project-version: set by Gradle
+:project-version: LATEST
 :github-repo: tamboui/tamboui
 :github-url: https://github.com/{github-repo}
 


### PR DESCRIPTION
As per #243 version is already passed as a parameter.

dev.tamboui.docs.gradle.kts line 136

```java
attributes(
        mapOf(
            // ...
            "project-version" to project.version,
            "project-name" to "TamboUI",
            // ...
        )
    )
```