### PR TITLE
fix: revert to jline that does not break native-image

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jline = "3.30.6"
+jline = "3.25.1"
 aesh-terminal = "3.2"
 junit = "5.14.3"
 assertj = "3.27.6"


### PR DESCRIPTION
fixes #276 

might be some way to configure native-image a way to not fail but my attempts weren't successful so suggesting to push this in until we figure out what causes it.