### PR TITLE
feat: add synchronized output (Mode 2026) to prevent screen tearing

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jline = "3.25.1"
-aesh-terminal = "3.2"
+aesh-terminal = "3.5"
 junit = "5.14.3"
 assertj = "3.27.7"
 native-build-tools = "0.11.4"

--- a/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
+++ b/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
@@ -121,7 +121,7 @@ public class AeshBackend extends AbstractBackend {
     @Override
     public Position getCursorPosition() throws IOException {
         try {
-            Point point = connection.getCursorPosition();
+            Point point = connection.terminal().getCursorPosition();
             if (point != null) {
                 return new Position(point.x(), point.y());
             }
@@ -187,6 +187,16 @@ public class AeshBackend extends AbstractBackend {
         outputBuffer.append(CSI).append("?1000l");
         flush();
         mouseEnabled = false;
+    }
+
+    @Override
+    public void beginSynchronizedUpdate() throws IOException {
+        outputBuffer.append(MODE_2026_BSU);
+    }
+
+    @Override
+    public void endSynchronizedUpdate() throws IOException {
+        outputBuffer.append(MODE_2026_ESU);
     }
 
     @Override

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Backend.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Backend.java
@@ -17,6 +17,11 @@ import dev.tamboui.layout.Size;
  */
 public interface Backend extends AutoCloseable {
 
+    /** Mode 2026 Begin Synchronized Update escape sequence. */
+    String MODE_2026_BSU = "\033[?2026h";
+    /** Mode 2026 End Synchronized Update escape sequence. */
+    String MODE_2026_ESU = "\033[?2026l";
+
     /**
      * Draws the given cell updates to the terminal using a Data-Oriented Design approach.
      * <p>
@@ -125,6 +130,34 @@ public interface Backend extends AutoCloseable {
      */
     default void disableMouseCapture() throws IOException {
         // Optional: not all backends support mouse
+    }
+
+    /**
+     * Begins a synchronized update (Mode 2026 BSU).
+     * <p>
+     * When supported, the terminal buffers all subsequent output until
+     * {@link #endSynchronizedUpdate()} is called, then renders everything
+     * in a single frame. This prevents screen tearing during redraws.
+     * <p>
+     * Terminals that do not support Mode 2026 safely ignore the escape sequence.
+     *
+     * @throws IOException if the operation fails
+     */
+    default void beginSynchronizedUpdate() throws IOException {
+        // Optional: not all backends support synchronized output
+    }
+
+    /**
+     * Ends a synchronized update (Mode 2026 ESU).
+     * <p>
+     * Writes the ESU sequence to the output buffer. The caller is responsible
+     * for flushing, since not all terminals support Mode 2026 and the flush
+     * must happen unconditionally.
+     *
+     * @throws IOException if the operation fails
+     */
+    default void endSynchronizedUpdate() throws IOException {
+        // Optional: not all backends support synchronized output
     }
 
     /**

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -135,36 +135,46 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
 
                 // Calculate diff and draw (zero-allocation DoD variant)
                 previousBuffer.diff(currentBuffer, diffResult);
-                if (!diffResult.isEmpty()) {
-                    backend.draw(diffResult);
-                }
-                diffResult.clear();  // Clear after use to release Cell refs for GC
 
-                // Handle cursor
-                if (frame.isCursorVisible()) {
-                    frame.cursorPosition().ifPresent(pos -> {
-                        try {
-                            backend.setCursorPosition(pos);
-                            if (hiddenCursor) {
-                                backend.showCursor();
-                                hiddenCursor = false;
-                            }
-                        } catch (IOException e) {
-                            throw new RuntimeIOException(
-                                    String.format("Failed to set cursor position to %s: %s", pos, e.getMessage()), e);
-                        }
-                    });
-                } else if (!hiddenCursor) {
-                    try {
-                        backend.hideCursor();
-                        hiddenCursor = true;
-                    } catch (IOException e) {
-                        throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
+                // Wrap rendering in synchronized update (Mode 2026) to prevent tearing.
+                // BSU, draw data, and ESU are all written to the output buffer and
+                // flushed together in a single syscall for atomic rendering.
+                backend.beginSynchronizedUpdate();
+                try {
+                    if (!diffResult.isEmpty()) {
+                        backend.draw(diffResult);
                     }
-                }
 
-                // Flush output
-                backend.flush();
+                    // Handle cursor
+                    if (frame.isCursorVisible()) {
+                        frame.cursorPosition().ifPresent(pos -> {
+                            try {
+                                backend.setCursorPosition(pos);
+                                if (hiddenCursor) {
+                                    backend.showCursor();
+                                    hiddenCursor = false;
+                                }
+                            } catch (IOException e) {
+                                throw new RuntimeIOException(
+                                        String.format("Failed to set cursor position to %s: %s", pos, e.getMessage()),
+                                        e);
+                            }
+                        });
+                    } else if (!hiddenCursor) {
+                        try {
+                            backend.hideCursor();
+                            hiddenCursor = true;
+                        } catch (IOException e) {
+                            throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
+                        }
+                    }
+                } finally {
+                    diffResult.clear();  // Release Cell refs for GC even on error
+                    // Write ESU before flushing so BSU + draw + ESU are sent atomically.
+                    // Done in finally to avoid leaving the terminal in a stuck buffering state.
+                    backend.endSynchronizedUpdate();
+                    backend.flush();
+                }
 
                 // Swap buffers
                 Buffer temp = previousBuffer;

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/SynchronizedOutputTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/SynchronizedOutputTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.terminal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.buffer.DiffResult;
+import dev.tamboui.layout.Position;
+import dev.tamboui.layout.Size;
+import dev.tamboui.style.Style;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Terminal.draw() wraps rendering with Mode 2026
+ * synchronized output (BSU/ESU) and flushes in the correct order.
+ */
+class SynchronizedOutputTest {
+
+    @Test
+    void drawEmitsBeginBeforeDrawAndEndBeforeFlush() {
+        RecordingBackend backend = new RecordingBackend(40, 10);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame -> {
+            frame.buffer().setString(0, 0, "Hello", Style.EMPTY);
+        });
+
+        List<String> calls = backend.calls();
+
+        // BSU + draw + ESU are written to the buffer, then flushed atomically
+        assertThat(calls).containsSubsequence(
+                "beginSynchronizedUpdate",
+                "draw",
+                "endSynchronizedUpdate",
+                "flush");
+    }
+
+    @Test
+    void drawEmitsBeginAndEndEvenWithNoDiff() {
+        RecordingBackend backend = new RecordingBackend(40, 10);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        // First draw to populate the buffer
+        terminal.draw(frame -> {
+            frame.buffer().setString(0, 0, "Static", Style.EMPTY);
+        });
+
+        backend.clearCalls();
+
+        // Second draw with same content — no diff, but BSU/ESU should still be emitted
+        terminal.draw(frame -> {
+            frame.buffer().setString(0, 0, "Static", Style.EMPTY);
+        });
+
+        List<String> calls = backend.calls();
+
+        assertThat(calls).containsSubsequence(
+                "beginSynchronizedUpdate",
+                "endSynchronizedUpdate",
+                "flush");
+        // No "draw" call since there's no diff
+        assertThat(calls).doesNotContain("draw");
+    }
+
+    /**
+     * A minimal backend that records the order of synchronized output
+     * and flush calls for assertion.
+     */
+    private static class RecordingBackend implements Backend {
+
+        private final int width;
+        private final int height;
+        private final List<String> calls = new ArrayList<>();
+
+        RecordingBackend(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+
+        List<String> calls() {
+            return Collections.unmodifiableList(calls);
+        }
+
+        void clearCalls() {
+            calls.clear();
+        }
+
+        @Override
+        public void beginSynchronizedUpdate() throws IOException {
+            calls.add("beginSynchronizedUpdate");
+        }
+
+        @Override
+        public void endSynchronizedUpdate() throws IOException {
+            calls.add("endSynchronizedUpdate");
+        }
+
+        @Override
+        public void draw(DiffResult diff) throws IOException {
+            calls.add("draw");
+        }
+
+        @Override
+        public void flush() throws IOException {
+            calls.add("flush");
+        }
+
+        @Override
+        public void clear() throws IOException {
+        }
+
+        @Override
+        public Size size() throws IOException {
+            return new Size(width, height);
+        }
+
+        @Override
+        public void showCursor() throws IOException {
+        }
+
+        @Override
+        public void hideCursor() throws IOException {
+        }
+
+        @Override
+        public Position getCursorPosition() throws IOException {
+            return Position.ORIGIN;
+        }
+
+        @Override
+        public void setCursorPosition(Position position) throws IOException {
+        }
+
+        @Override
+        public void enterAlternateScreen() throws IOException {
+        }
+
+        @Override
+        public void leaveAlternateScreen() throws IOException {
+        }
+
+        @Override
+        public void enableRawMode() throws IOException {
+        }
+
+        @Override
+        public void disableRawMode() throws IOException {
+        }
+
+        @Override
+        public void onResize(Runnable handler) {
+        }
+
+        @Override
+        public int read(int timeoutMs) throws IOException {
+            return -2;
+        }
+
+        @Override
+        public int peek(int timeoutMs) throws IOException {
+            return -2;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -157,6 +157,16 @@ public class JLineBackend extends AbstractBackend {
     }
 
     @Override
+    public void beginSynchronizedUpdate() throws IOException {
+        writer.print(MODE_2026_BSU);
+    }
+
+    @Override
+    public void endSynchronizedUpdate() throws IOException {
+        writer.print(MODE_2026_ESU);
+    }
+
+    @Override
     public void scrollUp(int lines) throws IOException {
         writer.print(CSI + lines + "S");
         writer.flush();

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -167,6 +167,16 @@ public class PanamaBackend extends AbstractBackend {
     }
 
     @Override
+    public void beginSynchronizedUpdate() throws IOException {
+        outputBuffer.appendAscii(MODE_2026_BSU);
+    }
+
+    @Override
+    public void endSynchronizedUpdate() throws IOException {
+        outputBuffer.appendAscii(MODE_2026_ESU);
+    }
+
+    @Override
     public void scrollUp(int lines) throws IOException {
         outputBuffer.csi().appendInt(lines).append((byte) 'S');
         flush();


### PR DESCRIPTION
Upgrade aesh-terminal to 3.3 and wrap Terminal.draw() with Mode 2026 BSU/ESU sequences so the terminal buffers all frame output and renders it atomically. This eliminates visible tearing on supported terminals (Kitty, Ghostty, WezTerm, Foot, Contour, iTerm2, Mintty) with no impact on unsupported ones which safely ignore the escape sequences.

ref; https://aeshell.github.io/docs/readline/synchronized-output/