### PR TITLE
fix: Fix solver to not fail by default

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/layout/cassowary/LayoutSolver.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/cassowary/LayoutSolver.java
@@ -32,6 +32,7 @@ public final class LayoutSolver {
     // Constraint strengths matching ratatui's hierarchy (higher = more important)
     // These ensure consistent priority ordering for constraint resolution
     private static final Strength LENGTH_SIZE_EQ = Strength.create(10, 0, 0);      // Fixed length
+    private static final Strength MIN_SIZE_GEQ = Strength.create(10, 0, 0);       // Min floor (strong, not required)
     private static final Strength PERCENTAGE_SIZE_EQ = Strength.STRONG;             // Percentage
     private static final Strength RATIO_SIZE_EQ = Strength.create(
             Fraction.of(1, 10), Fraction.ZERO, Fraction.ZERO);                      // Ratio
@@ -165,10 +166,11 @@ public final class LayoutSolver {
                     .equalTo(target, RATIO_SIZE_EQ));
 
         } else if (c instanceof Constraint.Min) {
-            // Minimum: size >= value (hard constraint)
+            // Minimum: size >= value (strong but not required, to degrade gracefully
+            // when multiple Min constraints exceed available space)
             int value = ((Constraint.Min) c).value();
             dest.add(Expression.variable(size)
-                    .greaterThanOrEqual(value, Strength.REQUIRED));
+                    .greaterThanOrEqual(value, MIN_SIZE_GEQ));
             // Min tries to GROW to fill available space (like Fill)
             dest.add(Expression.variable(size)
                     .equalTo(available, FILL_GROW));

--- a/tamboui-core/src/main/java/dev/tamboui/layout/cassowary/Solver.java
+++ b/tamboui-core/src/main/java/dev/tamboui/layout/cassowary/Solver.java
@@ -83,10 +83,31 @@ public final class Solver {
     // Artificial objective for handling infeasibility
     private Row artificial;
 
+    private static final boolean DEFAULT_STRICT = Boolean.getBoolean("tamboui.solver.strict");
+
+    // Strongest non-required strength, used to soften unsatisfiable REQUIRED constraints in lenient mode
+    private static final Strength SOFTENED_REQUIRED = Strength.create(999, 999, 999);
+
+    private final boolean strict;
+
     /**
-     * Creates a new empty solver.
+     * Creates a new empty solver in lenient mode (default).
+     * In lenient mode, unsatisfiable REQUIRED constraints are automatically
+     * softened instead of throwing. Set the system property
+     * {@code tamboui.solver.strict} to {@code true} to disable this behavior.
      */
     public Solver() {
+        this(DEFAULT_STRICT);
+    }
+
+    /**
+     * Creates a new solver with the specified strictness mode.
+     *
+     * @param strict if true, unsatisfiable REQUIRED constraints throw;
+     *               if false, they are softened automatically
+     */
+    Solver(boolean strict) {
+        this.strict = strict;
         this.constraints = new LinkedHashMap<>();
         this.vars = new LinkedHashMap<>();
         this.rows = new LinkedHashMap<>();
@@ -101,10 +122,20 @@ public final class Solver {
      *
      * @param constraint the constraint to add
      * @throws DuplicateConstraintException     if the constraint already exists
-     * @throws UnsatisfiableConstraintException if required and unsatisfiable
+     * @throws UnsatisfiableConstraintException if required, unsatisfiable, and solver is in strict mode
      */
     public void addConstraint(CassowaryConstraint constraint) {
-        addConstraintInternal(constraint);
+        if (!tryAddConstraint(constraint) && constraint.isRequired()) {
+            if (strict) {
+                throw new UnsatisfiableConstraintException(constraint);
+            }
+            // Lenient mode: soften the constraint and retry
+            CassowaryConstraint softened = new CassowaryConstraint(
+                    constraint.expression(), constraint.relation(), SOFTENED_REQUIRED);
+            if (!tryAddConstraint(softened)) {
+                throw new UnsatisfiableConstraintException(constraint);
+            }
+        }
         optimize(objective);
     }
 
@@ -121,7 +152,14 @@ public final class Solver {
         }
     }
 
-    private void addConstraintInternal(CassowaryConstraint constraint) {
+    /**
+     * Tries to add a constraint to the solver.
+     *
+     * @param constraint the constraint to add
+     * @return true if the constraint was added successfully, false if unsatisfiable
+     * @throws DuplicateConstraintException if the constraint already exists
+     */
+    private boolean tryAddConstraint(CassowaryConstraint constraint) {
         if (constraints.containsKey(constraint)) {
             throw new DuplicateConstraintException(constraint);
         }
@@ -132,7 +170,7 @@ public final class Solver {
 
         if (subject == null && allDummies(row)) {
             if (!row.constant().isZero()) {
-                throw new UnsatisfiableConstraintException(constraint);
+                return false;
             }
             // The row is trivially satisfied
             subject = tag.marker;
@@ -140,7 +178,7 @@ public final class Solver {
 
         if (subject == null) {
             if (!addWithArtificialVariable(row)) {
-                throw new UnsatisfiableConstraintException(constraint);
+                return false;
             }
         } else {
             row.solveFor(subject);
@@ -149,6 +187,7 @@ public final class Solver {
         }
 
         constraints.put(constraint, tag);
+        return true;
     }
 
     /**

--- a/tamboui-core/src/test/java/dev/tamboui/layout/cassowary/LayoutSolverTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/layout/cassowary/LayoutSolverTest.java
@@ -178,4 +178,43 @@ class LayoutSolverTest {
             assertThat(size).isGreaterThanOrEqualTo(0);
         }
     }
+
+    @Test
+    @DisplayName("Multiple min constraints exceeding available space degrade gracefully")
+    void minConstraints_exceedingAvailable_degradesGracefully() {
+        LayoutSolver solver = new LayoutSolver();
+        List<Constraint> constraints = Arrays.asList(
+                Constraint.min(2),
+                Constraint.min(2)
+        );
+
+        // Combined minimum is 4, but only 3 available — should not throw
+        int[] sizes = solver.solve(constraints, 3, 0, Flex.START);
+
+        assertThat(sizes).hasSize(2);
+        for (int size : sizes) {
+            assertThat(size).isGreaterThanOrEqualTo(0);
+        }
+        assertThat(sizes[0] + sizes[1]).isLessThanOrEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("Three min constraints exceeding available space share space proportionally")
+    void threeMinConstraints_exceedingAvailable_shareProportionally() {
+        LayoutSolver solver = new LayoutSolver();
+        List<Constraint> constraints = Arrays.asList(
+                Constraint.min(5),
+                Constraint.min(5),
+                Constraint.min(5)
+        );
+
+        // Combined minimum is 15, but only 10 available — should not throw
+        int[] sizes = solver.solve(constraints, 10, 0, Flex.START);
+
+        assertThat(sizes).hasSize(3);
+        for (int size : sizes) {
+            assertThat(size).isGreaterThanOrEqualTo(0);
+        }
+        assertThat(sizes[0] + sizes[1] + sizes[2]).isLessThanOrEqualTo(10);
+    }
 }

--- a/tamboui-core/src/test/java/dev/tamboui/layout/cassowary/SolverTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/layout/cassowary/SolverTest.java
@@ -108,9 +108,9 @@ class SolverTest {
     }
 
     @Test
-    @DisplayName("Unsatisfiable required constraint throws exception")
+    @DisplayName("Unsatisfiable required constraint throws exception in strict mode")
     void unsatisfiableThrows() {
-        Solver solver = new Solver();
+        Solver solver = new Solver(true);
         Variable x = new Variable("x");
 
         solver.addConstraint(
@@ -246,6 +246,28 @@ class SolverTest {
         solver.reset();
         solver.updateVariables();
         assertThat(solver.valueOf(x)).isEqualTo(Fraction.ZERO);
+    }
+
+    @Test
+    @DisplayName("Lenient mode softens unsatisfiable required constraints instead of throwing")
+    void lenientMode_softensUnsatisfiableRequired() {
+        Solver solver = new Solver();
+        Variable x = new Variable("x");
+
+        // x == 100 (required)
+        solver.addConstraint(
+                Expression.variable(x)
+                        .equalTo(100, Strength.REQUIRED));
+
+        // x == 200 (required, conflicting) — lenient mode should soften, not throw
+        solver.addConstraint(
+                Expression.variable(x)
+                        .equalTo(200, Strength.REQUIRED));
+
+        solver.updateVariables();
+
+        // First REQUIRED constraint wins; softened second is overridden
+        assertThat(solver.valueOf(x)).isEqualTo(Fraction.of(100));
     }
 
     @Test

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Column.java
@@ -240,6 +240,9 @@ public final class Column extends ContainerElement<Column> {
             }
         }
 
+        // Defensive cap: ensure total of Min constraints doesn't exceed available height
+        capMinConstraints(constraints, effectiveArea.height(), effectiveSpacing);
+
         // Build layout - only apply flex if explicitly set
         Layout layout = Layout.vertical()
             .constraints(constraints.toArray(new Constraint[0]));
@@ -261,6 +264,35 @@ public final class Column extends ContainerElement<Column> {
             Rect childArea = areas.get(i);
             context.renderChild(child, frame, childArea);
             childIndex++;
+        }
+    }
+
+    /**
+     * Caps Min constraints so their sum does not exceed the distributable height.
+     * When multiple children have Min constraints whose total exceeds available space,
+     * they are proportionally scaled down to fit.
+     */
+    private static void capMinConstraints(List<Constraint> constraints, int availableHeight, int spacing) {
+        int totalMin = 0;
+        int fixedSpace = 0;
+        for (Constraint c : constraints) {
+            if (c instanceof Constraint.Min) {
+                totalMin += ((Constraint.Min) c).value();
+            } else if (c instanceof Constraint.Length) {
+                fixedSpace += ((Constraint.Length) c).value();
+            }
+        }
+
+        int distributableForMins = Math.max(0, availableHeight - fixedSpace);
+        if (totalMin > distributableForMins && totalMin > 0) {
+            for (int i = 0; i < constraints.size(); i++) {
+                Constraint c = constraints.get(i);
+                if (c instanceof Constraint.Min) {
+                    int original = ((Constraint.Min) c).value();
+                    int scaled = (int) ((long) original * distributableForMins / totalMin);
+                    constraints.set(i, Constraint.min(Math.max(0, scaled)));
+                }
+            }
         }
     }
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
@@ -13,7 +13,6 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.layout.cassowary.UnsatisfiableConstraintException;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
@@ -22,7 +21,6 @@ import dev.tamboui.toolkit.element.RenderContext;
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for Column.
@@ -333,24 +331,24 @@ class ColumnTest {
         }
 
         @Test
-        @DisplayName("Two WRAP_CHARACTER texts whose combined minimum exceeds available height")
+        @DisplayName("Two WRAP_CHARACTER texts whose combined minimum exceeds available height degrade gracefully")
         void twoWrapTexts_combinedMinExceedsAvailableHeight() {
             // Each text needs 2 rows at width 6 (12 chars each), so the combined minimum
             // is 4 rows, but only 3 rows are available.
-            // The per-element cap (Math.min(preferredHeight, available)) gives each text
-            // Constraint.min(2), which is individually valid but jointly infeasible:
-            //   size[0] >= 2  AND  size[1] >= 2  AND  size[0] + size[1] <= 3
-            // The Cassowary solver therefore throws UnsatisfiableConstraintException.
+            // Both the Column (proportional Min capping) and the solver (non-required Min
+            // strength) ensure graceful degradation instead of throwing.
             Rect area = new Rect(0, 0, 6, 3);
             Buffer buffer = Buffer.empty(area);
             Frame frame = Frame.forTesting(buffer);
 
-            assertThatThrownBy(() ->
-                column(
-                    text("AAAAAABBBBBB").overflow(Overflow.WRAP_CHARACTER),
-                    text("CCCCCCDDDDDD").overflow(Overflow.WRAP_CHARACTER)
-                ).render(frame, area, RenderContext.empty())
-            ).isInstanceOf(UnsatisfiableConstraintException.class);
+            // Should NOT throw — degrades gracefully
+            column(
+                text("AAAAAABBBBBB").overflow(Overflow.WRAP_CHARACTER),
+                text("CCCCCCDDDDDD").overflow(Overflow.WRAP_CHARACTER)
+            ).render(frame, area, RenderContext.empty());
+
+            // Both texts should get some space rendered
+            assertThat(buffer).isNotNull();
         }
 
         @Test


### PR DESCRIPTION
This commit fixes a bug introduced in #267, where a column could define multiple min constraints which, when summed up, could exceed the available space. Technically speaking this commit fixes it in 3 complementary ways:

1. a fix in the column code itself, to not exceed the available height. This works, but doesn't prevent the solver from failing in other cases
2. fix the solver, so that min constraints are not using a strong constraint (required). This also fixes the same problem, but doesn't prevent the solver from failing in other cases
3. add a lenient mode to the solver, enabled by default, which soften required constraints whenever constraints cannot be solved.

The lenient mode can be overridden by a system property, when debugging a layout is needed. All 3 fixes combined should make our solver more usable.