### PR TITLE
Add semantic color system with CSS-first theming and fluent Color API

### DIFF
--- a/docs/video/themes-demo.tape
+++ b/docs/video/themes-demo.tape
@@ -1,0 +1,13 @@
+Source shared_.tape
+
+# Setup
+Hide
+Type jbang themes-demo
+Enter
+Sleep 3
+Show
+
+# Recording - showcase themes scrolling
+Screenshot screenshots/themes-demo.svg
+Sleep 5
+

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -64,6 +64,9 @@
     "css-no-toolkit-demo": {
       "script-ref": "tamboui-css/demos/css-no-toolkit-demo/src/main/java/dev/tamboui/demo/CssNoToolkitDemo.java"
     },
+    "themes-demo": {
+      "script-ref": "tamboui-css/demos/themes-demo/src/main/java/dev/tamboui/demo/ThemesDemo.java"
+    },
     "image-demo": {
       "script-ref": "tamboui-image/demos/image-demo/src/main/java/dev/tamboui/demo/ImageDemo.java"
     },

--- a/tamboui-core/src/main/java/dev/tamboui/style/Color.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Color.java
@@ -503,6 +503,86 @@ public interface Color {
     }
 
     /**
+     * Converts this color to a hex string.
+     *
+     * @return hex string in format {@code #rrggbb}
+     */
+    default String toHex() {
+        Rgb rgb = toRgb();
+        return String.format("#%02x%02x%02x", rgb.r(), rgb.g(), rgb.b());
+    }
+
+    /**
+     * Lightens this color by increasing lightness in HSL space.
+     *
+     * @param amount the amount to lighten (0.0 = no change, 1.0 = fully light)
+     * @return lightened color
+     */
+    default Color lighten(float amount) {
+        return ColorSpace.lighten(this, amount);
+    }
+
+    /**
+     * Darkens this color by decreasing lightness in HSL space.
+     *
+     * @param amount the amount to darken (0.0 = no change, 1.0 = fully dark)
+     * @return darkened color
+     */
+    default Color darken(float amount) {
+        return ColorSpace.darken(this, amount);
+    }
+
+    /**
+     * Adjusts saturation (color vibrancy).
+     *
+     * @param factor multiplication factor (&lt; 1.0 desaturates toward gray, &gt; 1.0 saturates)
+     * @return color with adjusted saturation
+     */
+    default Color adjustSaturation(float factor) {
+        return ColorSpace.adjustSaturation(this, factor);
+    }
+
+    /**
+     * Rotates hue on the color wheel.
+     * Useful for generating complementary (180°) or analogous (±30°) colors.
+     *
+     * @param degrees rotation in degrees (-360 to 360)
+     * @return color with rotated hue
+     */
+    default Color rotateHue(float degrees) {
+        return ColorSpace.rotateHue(this, degrees);
+    }
+
+    /**
+     * Mixes this color with another color.
+     *
+     * @param other the color to mix with
+     * @param ratio mixing ratio (0.0 = all this color, 1.0 = all other color)
+     * @return blended color
+     */
+    default Color mix(Color other, float ratio) {
+        return ColorSpace.mix(this, other, ratio);
+    }
+
+    /**
+     * Converts this color to HSL components.
+     *
+     * @return array [h, s, l] where h is 0-360 degrees, s and l are 0-100 percent
+     */
+    default float[] toHsl() {
+        return ColorSpace.toHsl(this);
+    }
+
+    /**
+     * Converts this color to HSV components.
+     *
+     * @return array [h, s, v] where h is 0-360 degrees, s and v are 0-100 percent
+     */
+    default float[] toHsv() {
+        return ColorSpace.toHsv(this);
+    }
+
+    /**
      * Converts an ANSI color to RGB using standard terminal colors.
      *
      * @param ansi the ANSI color

--- a/tamboui-core/src/main/java/dev/tamboui/style/ColorSpace.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/ColorSpace.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.style;
+
+/**
+ * Color space conversion and manipulation utilities.
+ *
+ * <p>Provides HSL/HSV color space conversions and color manipulation methods
+ * like lighten, darken, rotate hue, and mix colors.</p>
+ *
+ * <p>Inspired by Textual's Color class and TFxColorSpace.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * // Convert to HSL
+ * float[] hsl = ColorSpace.toHsl(Color.rgb(255, 0, 0));
+ * // hsl = [0.0, 100.0, 50.0] - red in HSL
+ *
+ * // Create from HSL
+ * Color color = ColorSpace.fromHsl(120, 100, 50);  // Green
+ *
+ * // Lighten a color
+ * Color lighter = ColorSpace.lighten(Color.rgb(100, 100, 100), 0.2f);
+ *
+ * // Rotate hue for complementary color
+ * Color complementary = ColorSpace.rotateHue(primaryColor, 180);
+ * }</pre>
+ */
+public final class ColorSpace {
+
+    private ColorSpace() {
+        // Utility class
+    }
+
+    // ===== Color Space Conversion =====
+
+    /**
+     * Converts RGB color to HSL (Hue, Saturation, Lightness) components.
+     *
+     * @param color the color to convert
+     * @return array [h, s, l] where h is 0-360 degrees, s and l are 0-100 percent
+     */
+    public static float[] toHsl(Color color) {
+        int[] rgb = toRgbComponents(color);
+        return rgbToHsl(color.toRgb().r(), color.toRgb().g(), color.toRgb().b());
+    }
+
+    /**
+     * Creates a color from HSL components.
+     *
+     * @param h hue in degrees (0-360)
+     * @param s saturation percent (0-100)
+     * @param l lightness percent (0-100)
+     * @return RGB color
+     */
+    public static Color fromHsl(float h, float s, float l) {
+        int[] rgb = hslToRgb(h, s, l);
+        return Color.rgb(rgb[0], rgb[1], rgb[2]);
+    }
+
+    /**
+     * Converts RGB color to HSV (Hue, Saturation, Value) components.
+     *
+     * @param color the color to convert
+     * @return array [h, s, v] where h is 0-360 degrees, s and v are 0-100 percent
+     */
+    public static float[] toHsv(Color color) {
+        int[] rgb = toRgbComponents(color);
+        return rgbToHsv(rgb[0], rgb[1], rgb[2]);
+    }
+
+    /**
+     * Creates a color from HSV components.
+     *
+     * @param h hue in degrees (0-360)
+     * @param s saturation percent (0-100)
+     * @param v value/brightness percent (0-100)
+     * @return RGB color
+     */
+    public static Color fromHsv(float h, float s, float v) {
+        int[] rgb = hsvToRgb(h, s, v);
+        return Color.rgb(rgb[0], rgb[1], rgb[2]);
+    }
+
+    // ===== Color Manipulation =====
+
+    /**
+     * Lightens a color by increasing lightness in HSL space.
+     *
+     * @param color the base color
+     * @param amount the amount to lighten (0.0 = no change, 1.0 = fully light)
+     * @return lightened color
+     */
+    public static Color lighten(Color color, float amount) {
+        float[] hsl = toHsl(color);
+        float newLightness = Math.min(100f, hsl[2] + amount * 100f);
+        return fromHsl(hsl[0], hsl[1], newLightness);
+    }
+
+    /**
+     * Darkens a color by decreasing lightness in HSL space.
+     *
+     * @param color the base color
+     * @param amount the amount to darken (0.0 = no change, 1.0 = fully dark)
+     * @return darkened color
+     */
+    public static Color darken(Color color, float amount) {
+        float[] hsl = toHsl(color);
+        float newLightness = Math.max(0f, hsl[2] - amount * 100f);
+        return fromHsl(hsl[0], hsl[1], newLightness);
+    }
+
+    /**
+     * Adjusts saturation (color vibrancy).
+     *
+     * @param color the base color
+     * @param factor multiplication factor (&lt; 1.0 desaturates toward gray, &gt; 1.0 saturates)
+     * @return color with adjusted saturation
+     */
+    public static Color adjustSaturation(Color color, float factor) {
+        float[] hsl = toHsl(color);
+        float newSaturation = Math.max(0f, Math.min(100f, hsl[1] * factor));
+        return fromHsl(hsl[0], newSaturation, hsl[2]);
+    }
+
+    /**
+     * Rotates hue on the color wheel.
+     * Useful for generating complementary (180°) or analogous (±30°) colors.
+     *
+     * @param color the base color
+     * @param degrees rotation in degrees (-360 to 360)
+     * @return color with rotated hue
+     */
+    public static Color rotateHue(Color color, float degrees) {
+        float[] hsl = toHsl(color);
+        float newHue = (hsl[0] + degrees) % 360f;
+        if (newHue < 0f) {
+            newHue += 360f;
+        }
+        return fromHsl(newHue, hsl[1], hsl[2]);
+    }
+
+    /**
+     * Mixes two colors.
+     *
+     * @param color1 first color
+     * @param color2 second color
+     * @param ratio mixing ratio (0.0 = all color1, 1.0 = all color2)
+     * @return blended color
+     */
+    public static Color mix(Color color1, Color color2, float ratio) {
+        int[] rgb1 = toRgbComponents(color1);
+        int[] rgb2 = toRgbComponents(color2);
+
+        int r = Math.round(rgb1[0] + (rgb2[0] - rgb1[0]) * ratio);
+        int g = Math.round(rgb1[1] + (rgb2[1] - rgb1[1]) * ratio);
+        int b = Math.round(rgb1[2] + (rgb2[2] - rgb1[2]) * ratio);
+
+        return Color.rgb(r, g, b);
+    }
+
+    /**
+     * Blends two colors with alpha control (like Textual's Color.blend).
+     *
+     * @param base the base color
+     * @param overlay the overlay color
+     * @param ratio blend ratio (0.0 to 1.0)
+     * @param alpha final alpha value (0.0 to 1.0)
+     * @return blended color
+     */
+    public static Color blend(Color base, Color overlay, float ratio, float alpha) {
+        // For now, just delegate to mix since TamboUI Color doesn't have alpha channel
+        // In the future, this could be extended to support alpha blending
+        return mix(base, overlay, ratio);
+    }
+
+    // ===== Internal Conversion Helpers =====
+
+    /**
+     * Converts a color to RGB components [r, g, b].
+     */
+    private static int[] toRgbComponents(Color color) {
+        if (color instanceof Color.Reset) {
+            return new int[]{0, 0, 0};
+        }
+        Color.Rgb rgb = color.toRgb();
+        return new int[]{rgb.r(), rgb.g(), rgb.b()};
+    }
+
+    /**
+     * Converts RGB to HSL.
+     * Algorithm from https://en.wikipedia.org/wiki/HSL_and_HSV
+     */
+    private static float[] rgbToHsl(int r, int g, int b) {
+        float rf = r / 255.0f;
+        float gf = g / 255.0f;
+        float bf = b / 255.0f;
+
+        float max = Math.max(rf, Math.max(gf, bf));
+        float min = Math.min(rf, Math.min(gf, bf));
+        float delta = max - min;
+
+        // Lightness
+        float l = (max + min) / 2.0f;
+
+        // Saturation
+        float s;
+        if (delta == 0.0f) {
+            s = 0.0f;
+        } else {
+            s = delta / (1.0f - Math.abs(2.0f * l - 1.0f));
+        }
+
+        // Hue
+        float h;
+        if (delta == 0.0f) {
+            h = 0.0f;
+        } else if (max == rf) {
+            h = 60.0f * (((gf - bf) / delta) % 6.0f);
+        } else if (max == gf) {
+            h = 60.0f * ((bf - rf) / delta + 2.0f);
+        } else {
+            h = 60.0f * ((rf - gf) / delta + 4.0f);
+        }
+
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+
+        return new float[]{h, s * 100.0f, l * 100.0f};
+    }
+
+    /**
+     * Converts HSL to RGB.
+     * Algorithm from https://en.wikipedia.org/wiki/HSL_and_HSV
+     */
+    private static int[] hslToRgb(float h, float s, float l) {
+        h = h % 360.0f;
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+        s = s / 100.0f;
+        l = l / 100.0f;
+
+        float c = (1.0f - Math.abs(2.0f * l - 1.0f)) * s;
+        float x = c * (1.0f - Math.abs((h / 60.0f) % 2.0f - 1.0f));
+        float m = l - c / 2.0f;
+
+        float r, g, b;
+        if (h < 60.0f) {
+            r = c;
+            g = x;
+            b = 0.0f;
+        } else if (h < 120.0f) {
+            r = x;
+            g = c;
+            b = 0.0f;
+        } else if (h < 180.0f) {
+            r = 0.0f;
+            g = c;
+            b = x;
+        } else if (h < 240.0f) {
+            r = 0.0f;
+            g = x;
+            b = c;
+        } else if (h < 300.0f) {
+            r = x;
+            g = 0.0f;
+            b = c;
+        } else {
+            r = c;
+            g = 0.0f;
+            b = x;
+        }
+
+        return new int[]{
+            Math.round((r + m) * 255.0f),
+            Math.round((g + m) * 255.0f),
+            Math.round((b + m) * 255.0f)
+        };
+    }
+
+    /**
+     * Converts RGB to HSV.
+     */
+    private static float[] rgbToHsv(int r, int g, int b) {
+        float rf = r / 255.0f;
+        float gf = g / 255.0f;
+        float bf = b / 255.0f;
+
+        float max = Math.max(rf, Math.max(gf, bf));
+        float min = Math.min(rf, Math.min(gf, bf));
+        float delta = max - min;
+
+        // Hue
+        float h;
+        if (delta == 0.0f) {
+            h = 0.0f;
+        } else if (max == rf) {
+            h = 60.0f * (((gf - bf) / delta) % 6.0f);
+        } else if (max == gf) {
+            h = 60.0f * ((bf - rf) / delta + 2.0f);
+        } else {
+            h = 60.0f * ((rf - gf) / delta + 4.0f);
+        }
+
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+
+        // Saturation
+        float s = max == 0.0f ? 0.0f : delta / max;
+
+        // Value
+        float v = max;
+
+        return new float[]{h, s * 100.0f, v * 100.0f};
+    }
+
+    /**
+     * Converts HSV to RGB.
+     */
+    private static int[] hsvToRgb(float h, float s, float v) {
+        h = h % 360.0f;
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+        s = s / 100.0f;
+        v = v / 100.0f;
+
+        float c = v * s;
+        float x = c * (1.0f - Math.abs((h / 60.0f) % 2.0f - 1.0f));
+        float m = v - c;
+
+        float r, g, b;
+        if (h < 60.0f) {
+            r = c;
+            g = x;
+            b = 0.0f;
+        } else if (h < 120.0f) {
+            r = x;
+            g = c;
+            b = 0.0f;
+        } else if (h < 180.0f) {
+            r = 0.0f;
+            g = c;
+            b = x;
+        } else if (h < 240.0f) {
+            r = 0.0f;
+            g = x;
+            b = c;
+        } else if (h < 300.0f) {
+            r = x;
+            g = 0.0f;
+            b = c;
+        } else {
+            r = c;
+            g = 0.0f;
+            b = x;
+        }
+
+        return new int[]{
+            Math.round((r + m) * 255.0f),
+            Math.round((g + m) * 255.0f),
+            Math.round((b + m) * 255.0f)
+        };
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/style/ColorSpaceTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/style/ColorSpaceTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.style;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+class ColorSpaceTest {
+
+    @Test
+    void rgbToHslRoundTrip() {
+        Color red = Color.rgb(255, 0, 0);
+
+        float[] hsl = ColorSpace.toHsl(red);
+        Color converted = ColorSpace.fromHsl(hsl[0], hsl[1], hsl[2]);
+
+        assertThat(converted.toRgb()).isEqualTo(red.toRgb());
+    }
+
+    @Test
+    void rgbToHsvRoundTrip() {
+        Color green = Color.rgb(0, 255, 0);
+
+        float[] hsv = ColorSpace.toHsv(green);
+        Color converted = ColorSpace.fromHsv(hsv[0], hsv[1], hsv[2]);
+
+        assertThat(converted.toRgb()).isEqualTo(green.toRgb());
+    }
+
+    @Test
+    void toHslConvertsRedCorrectly() {
+        Color red = Color.rgb(255, 0, 0);
+
+        float[] hsl = ColorSpace.toHsl(red);
+
+        assertThat(hsl[0]).isCloseTo(0f, within(1f));      // Hue ~0°
+        assertThat(hsl[1]).isCloseTo(100f, within(1f));    // Saturation 100%
+        assertThat(hsl[2]).isCloseTo(50f, within(1f));     // Lightness 50%
+    }
+
+    @Test
+    void toHslConvertsGrayCorrectly() {
+        Color gray = Color.rgb(128, 128, 128);
+
+        float[] hsl = ColorSpace.toHsl(gray);
+
+        assertThat(hsl[0]).isCloseTo(0f, within(1f));      // Hue ~0° (undefined for gray)
+        assertThat(hsl[1]).isCloseTo(0f, within(1f));      // Saturation 0% (no color)
+        assertThat(hsl[2]).isCloseTo(50f, within(1f));     // Lightness 50%
+    }
+
+    @Test
+    void lightenMakesColorBrighter() {
+        Color dark = Color.rgb(50, 50, 50);
+
+        Color lighter = ColorSpace.lighten(dark, 0.2f);
+
+        float[] hslOriginal = ColorSpace.toHsl(dark);
+        float[] hslLighter = ColorSpace.toHsl(lighter);
+
+        assertThat(hslLighter[2]).isGreaterThan(hslOriginal[2]);  // Lightness increased
+    }
+
+    @Test
+    void darkenMakesColorDarker() {
+        Color light = Color.rgb(200, 200, 200);
+
+        Color darker = ColorSpace.darken(light, 0.2f);
+
+        float[] hslOriginal = ColorSpace.toHsl(light);
+        float[] hslDarker = ColorSpace.toHsl(darker);
+
+        assertThat(hslDarker[2]).isLessThan(hslOriginal[2]);  // Lightness decreased
+    }
+
+    @Test
+    void adjustSaturationDesaturates() {
+        Color vibrant = Color.rgb(255, 0, 0);  // Pure red
+
+        Color muted = ColorSpace.adjustSaturation(vibrant, 0.5f);
+
+        float[] hslOriginal = ColorSpace.toHsl(vibrant);
+        float[] hslMuted = ColorSpace.toHsl(muted);
+
+        assertThat(hslMuted[1]).isLessThan(hslOriginal[1]);  // Saturation decreased
+    }
+
+    @Test
+    void rotateHueCreatesComplementaryColor() {
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color complementary = ColorSpace.rotateHue(blue, 180);
+
+        float[] hslBlue = ColorSpace.toHsl(blue);
+        float[] hslComp = ColorSpace.toHsl(complementary);
+
+        // Hue should be rotated by 180°
+        float expectedHue = (hslBlue[0] + 180) % 360;
+        assertThat(hslComp[0]).isCloseTo(expectedHue, within(1f));
+    }
+
+    @Test
+    void rotateHueHandlesNegativeDegrees() {
+        Color red = Color.rgb(255, 0, 0);
+
+        Color rotated = ColorSpace.rotateHue(red, -30);
+
+        float[] hslRotated = ColorSpace.toHsl(rotated);
+
+        // Should wrap around (0 - 30 = 330)
+        assertThat(hslRotated[0]).isCloseTo(330f, within(1f));
+    }
+
+    @Test
+    void mixBlendsTwoColors() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color mixed = ColorSpace.mix(red, blue, 0.5f);
+
+        Color.Rgb rgb = mixed.toRgb();
+
+        // 50/50 mix should be purple-ish
+        assertThat(rgb.r()).isCloseTo(127, within(1));
+        assertThat(rgb.g()).isCloseTo(0, within(1));
+        assertThat(rgb.b()).isCloseTo(127, within(1));
+    }
+
+    @Test
+    void mixRatioZeroReturnsFirstColor() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color result = ColorSpace.mix(red, blue, 0.0f);
+
+        assertThat(result.toRgb()).isEqualTo(red.toRgb());
+    }
+
+    @Test
+    void mixRatioOneReturnsSecondColor() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color result = ColorSpace.mix(red, blue, 1.0f);
+
+        assertThat(result.toRgb()).isEqualTo(blue.toRgb());
+    }
+
+    @Test
+    void fromHslCreatesCorrectRgb() {
+        // Create pure red from HSL (0°, 100%, 50%)
+        Color red = ColorSpace.fromHsl(0, 100, 50);
+
+        Color.Rgb rgb = red.toRgb();
+        assertThat(rgb.r()).isCloseTo(255, within(1));
+        assertThat(rgb.g()).isCloseTo(0, within(1));
+        assertThat(rgb.b()).isCloseTo(0, within(1));
+    }
+
+    @Test
+    void fromHsvCreatesCorrectRgb() {
+        // Create pure green from HSV (120°, 100%, 100%)
+        Color green = ColorSpace.fromHsv(120, 100, 100);
+
+        Color.Rgb rgb = green.toRgb();
+        assertThat(rgb.r()).isCloseTo(0, within(1));
+        assertThat(rgb.g()).isCloseTo(255, within(1));
+        assertThat(rgb.b()).isCloseTo(0, within(1));
+    }
+
+    @Test
+    void blendDelegatesToMix() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color mixed = ColorSpace.mix(red, blue, 0.5f);
+        Color blended = ColorSpace.blend(red, blue, 0.5f, 1.0f);
+
+        // Should produce same result since alpha is ignored for now
+        assertThat(blended.toRgb()).isEqualTo(mixed.toRgb());
+    }
+
+    // ===== Fluent API Tests =====
+
+    @Test
+    void fluentToHexConvertsColorCorrectly() {
+        Color red = Color.rgb(255, 0, 0);
+        assertThat(red.toHex()).isEqualTo("#ff0000");
+
+        Color custom = Color.rgb(58, 150, 221);
+        assertThat(custom.toHex()).isEqualTo("#3a96dd");
+    }
+
+    @Test
+    void fluentLightenDelegatesToStaticMethod() {
+        Color dark = Color.rgb(50, 50, 50);
+
+        Color lighterFluent = dark.lighten(0.2f);
+        Color lighterStatic = ColorSpace.lighten(dark, 0.2f);
+
+        assertThat(lighterFluent.toRgb()).isEqualTo(lighterStatic.toRgb());
+    }
+
+    @Test
+    void fluentDarkenDelegatesToStaticMethod() {
+        Color light = Color.rgb(200, 200, 200);
+
+        Color darkerFluent = light.darken(0.2f);
+        Color darkerStatic = ColorSpace.darken(light, 0.2f);
+
+        assertThat(darkerFluent.toRgb()).isEqualTo(darkerStatic.toRgb());
+    }
+
+    @Test
+    void fluentRotateHueDelegatesToStaticMethod() {
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color rotatedFluent = blue.rotateHue(180);
+        Color rotatedStatic = ColorSpace.rotateHue(blue, 180);
+
+        assertThat(rotatedFluent.toRgb()).isEqualTo(rotatedStatic.toRgb());
+    }
+
+    @Test
+    void fluentMixDelegatesToStaticMethod() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+
+        Color mixedFluent = red.mix(blue, 0.5f);
+        Color mixedStatic = ColorSpace.mix(red, blue, 0.5f);
+
+        assertThat(mixedFluent.toRgb()).isEqualTo(mixedStatic.toRgb());
+    }
+
+    @Test
+    void fluentAdjustSaturationDelegatesToStaticMethod() {
+        Color vibrant = Color.rgb(255, 0, 0);
+
+        Color mutedFluent = vibrant.adjustSaturation(0.5f);
+        Color mutedStatic = ColorSpace.adjustSaturation(vibrant, 0.5f);
+
+        assertThat(mutedFluent.toRgb()).isEqualTo(mutedStatic.toRgb());
+    }
+
+    @Test
+    void fluentToHslDelegatesToStaticMethod() {
+        Color red = Color.rgb(255, 0, 0);
+
+        float[] hslFluent = red.toHsl();
+        float[] hslStatic = ColorSpace.toHsl(red);
+
+        assertThat(hslFluent).isEqualTo(hslStatic);
+    }
+
+    @Test
+    void fluentToHsvDelegatesToStaticMethod() {
+        Color green = Color.rgb(0, 255, 0);
+
+        float[] hsvFluent = green.toHsv();
+        float[] hsvStatic = ColorSpace.toHsv(green);
+
+        assertThat(hsvFluent).isEqualTo(hsvStatic);
+    }
+
+    @Test
+    void fluentApiCanChainOperations() {
+        Color base = Color.rgb(100, 150, 200);
+
+        // Chain: lighten → rotate hue → mix with white
+        Color result = base
+            .lighten(0.1f)
+            .rotateHue(30)
+            .mix(Color.rgb(255, 255, 255), 0.3f);
+
+        assertThat(result).isNotNull();
+        assertThat(result.toRgb()).isNotEqualTo(base.toRgb());
+    }
+}

--- a/tamboui-css/demos/themes-demo/build.gradle.kts
+++ b/tamboui-css/demos/themes-demo/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Demo showcasing semantic color system across multiple themes"
+
+demo {
+    displayName = "Themes Showcase"
+    tags = setOf("css", "themes", "semantic-colors", "markup", "design-tokens")
+}
+
+dependencies {
+    implementation(projects.tambouiCss)
+    implementation(projects.tambouiToolkit)
+    implementation(projects.tambouiJline3Backend)
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.ThemesDemo")
+}

--- a/tamboui-css/demos/themes-demo/src/main/java/dev/tamboui/demo/ThemesDemo.java
+++ b/tamboui-css/demos/themes-demo/src/main/java/dev/tamboui/demo/ThemesDemo.java
@@ -1,0 +1,253 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS dev.tamboui:tamboui-toolkit:LATEST
+//DEPS dev.tamboui:tamboui-jline3-backend:LATEST
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.markup.CssMarkupBridge;
+import dev.tamboui.css.theme.ThemePropertyNames;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.MarkupParser;
+import dev.tamboui.text.Text;
+import dev.tamboui.toolkit.app.InlineApp;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.element.Size;
+import dev.tamboui.widgets.paragraph.Paragraph;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+/**
+ * Demonstrates TamboUI's semantic color system across multiple themes.
+ *
+ * <p>Shows how the same semantic color names (primary, error, etc.)
+ * are resolved to different values depending on the active theme, enabling
+ * theme-independent application development.</p>
+ *
+ * <p>Similar to Clique's ThemeShowcase but using TamboUI's CSS-based semantic tokens.</p>
+ */
+public class ThemesDemo extends InlineApp {
+
+    /**
+     * List of theme names to showcase.
+     */
+    private static final String[] THEME_NAMES = {
+        "catppuccin-mocha",
+        "dracula",
+        "gruvbox-dark",
+        "nord",
+        "tokyo-night",
+        "dark",
+        "light"
+    };
+
+    private StyleEngine engine;
+    private CssMarkupBridge bridge;
+    private MarkupParser.StyleResolver resolver;
+
+    /**
+     * Creates a new themes demo application.
+     */
+    public ThemesDemo() {
+        super();
+    }
+
+    /**
+     * Main entry point for the themes demo.
+     *
+     * @param args command line arguments (unused)
+     * @throws Exception if the application fails to start
+     */
+    public static void main(String[] args) throws Exception {
+        new ThemesDemo().run();
+    }
+
+    @Override
+    protected void onStart() {
+        // Load all themes
+        engine = StyleEngine.create();
+        int loadedCount = 0;
+
+        for (String themeName : THEME_NAMES) {
+            String path = "/themes/" + themeName + ".tcss";
+            try {
+                engine.loadStylesheet(themeName, path);
+                loadedCount++;
+            } catch (Exception e) {
+                println(text("Warning: Failed to load theme " + themeName + ": " + e.getMessage()));
+            }
+        }
+
+        // Create markup bridge
+        bridge = new CssMarkupBridge(engine);
+        resolver = bridge.createResolver();
+
+        // Print header
+        println(text(""));
+        println(text("=".repeat(70)));
+        println(text("TamboUI Semantic Color System Showcase"));
+        println(text("=".repeat(70)));
+        println(text(""));
+        println(text("Demonstrating theme independence using semantic color names."));
+        println(text("The same markup code renders with different colors per theme."));
+        println(text(""));
+        println(text("Loaded " + loadedCount + " themes successfully."));
+        println(text(""));
+
+        // Showcase each theme
+        for (String themeName : THEME_NAMES) {
+            if (!engine.getStylesheetNames().contains(themeName)) {
+                continue; // Skip themes that failed to load
+            }
+            showcaseTheme(themeName);
+        }
+
+        // Print footer
+        println(text("=".repeat(70)));
+        println(text("Key takeaway: Applications use semantic names ([primary], [error], etc.)"));
+        println(text("and get appropriate colors for the active theme automatically."));
+        println(text("=".repeat(70)));
+        println(text(""));
+
+        // Quit when done
+        quit();
+    }
+
+    private void showcaseTheme(String themeName) {
+        // Activate theme
+        engine.setActiveStylesheet(themeName);
+
+        // Display theme name
+        String formattedName = formatThemeName(themeName);
+        println(text("-".repeat(70)));
+        println(text("Theme: " + formattedName));
+        println(text("-".repeat(70)));
+
+        // Show core brand colors WITH ACTUAL THEMED RENDERING
+        println(text("  Core Brand Colors:"));
+        printColorSample("    ", ThemePropertyNames.PRIMARY, "Primary");
+        printColorSample("    ", ThemePropertyNames.SECONDARY, "Secondary");
+        printColorSample("    ", ThemePropertyNames.ACCENT, "Accent");
+
+        // Show feedback colors WITH ACTUAL THEMED RENDERING
+        println(text("  Feedback Colors:"));
+        printColorSample("    ", ThemePropertyNames.ERROR, "Error");
+        printColorSample("    ", ThemePropertyNames.WARNING, "Warning");
+        printColorSample("    ", ThemePropertyNames.SUCCESS, "Success");
+        printColorSample("    ", ThemePropertyNames.INFO, "Info");
+
+        // Show practical usage examples - SAME MARKUP, DIFFERENT COLORS!
+        println(text("  Usage Examples:"));
+        println(row(
+            text("    "),
+            markupText("[" + ThemePropertyNames.SUCCESS + "]✓ Success message[/]"),
+            text("  "),
+            markupText("[" + ThemePropertyNames.ERROR + "]✗ Error message[/]"),
+            text("  "),
+            markupText("[" + ThemePropertyNames.WARNING + "]⚠ Warning[/]")
+        ));
+
+        // Show text variants
+        println(text("  Text Variants:"));
+        println(row(
+            text("    "),
+            markupText("[" + ThemePropertyNames.TEXT + "]Normal text[/]"),
+            text("  "),
+            markupText("[" + ThemePropertyNames.TEXT_MUTED + "]Muted text[/]"),
+            text("  "),
+            markupText("[" + ThemePropertyNames.TEXT_DISABLED + "]Disabled text[/]")
+        ));
+
+        println(text(""));
+    }
+
+    private void printColorSample(String indent, String colorName, String label) {
+        // Print colored bullet and label with hex value
+        String markup = "[" + colorName + "]● " + label + "[/]";
+        String hexValue = " (" + getColorValue(colorName) + ")";
+        println(
+            markupText(indent + markup + hexValue)
+        );
+    }
+
+    private Element markupText(String markup) {
+        Text parsedText = MarkupParser.parse(markup, resolver);
+        return new MarkupElement(parsedText);
+    }
+
+    /**
+     * Custom element that renders pre-styled Text from MarkupParser.
+     */
+    private static class MarkupElement implements Element {
+        private final Text styledText;
+
+        MarkupElement(Text styledText) {
+            this.styledText = styledText;
+        }
+
+        @Override
+        public Size preferredSize(int availableWidth, int availableHeight, RenderContext context) {
+            int width = styledText.lines().stream()
+                    .mapToInt(Line::width)
+                    .max()
+                    .orElse(0);
+            int height = styledText.lines().size();
+            return Size.of(width, height);
+        }
+
+        @Override
+        public void render(Frame frame, Rect area, RenderContext context) {
+            Paragraph paragraph = Paragraph.builder()
+                    .text(styledText)
+                    .build();
+            frame.renderWidget(paragraph, area);
+        }
+    }
+
+    private String formatThemeName(String name) {
+        // Convert "catppuccin-mocha" -> "Catppuccin Mocha"
+        StringBuilder result = new StringBuilder();
+        boolean capitalizeNext = true;
+        for (char c : name.toCharArray()) {
+            if (c == '-') {
+                result.append(' ');
+                capitalizeNext = true;
+            } else if (capitalizeNext) {
+                result.append(Character.toUpperCase(c));
+                capitalizeNext = false;
+            } else {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+
+    private String getColorValue(String variableName) {
+        // Parse the variable to get its color value
+        String variableRef = "$" + variableName;
+        return engine.parseColor(variableRef)
+                .map(color -> {
+                    var rgb = color.toRgb();
+                    return String.format("#%02x%02x%02x", rgb.r(), rgb.g(), rgb.b());
+                })
+                .orElse("N/A");
+    }
+
+    @Override
+    protected Element render() {
+        // No UI to render - we just print output and quit
+        return column();
+    }
+
+    @Override
+    protected int height() {
+        // Minimal height since we're just printing
+        return 1;
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/markup/CssMarkupBridge.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/markup/CssMarkupBridge.java
@@ -1,0 +1,78 @@
+package dev.tamboui.css.markup;
+
+import java.util.Optional;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.MarkupParser;
+
+/**
+ * Bridges CSS variables to MarkupParser StyleResolver.
+ * Enables using CSS-defined design tokens in markup text.
+ *
+ * <p>This allows semantic color names defined in theme .tcss files to be used
+ * in markup strings. For example, if a theme defines {@code $primary: #cba6f7;},
+ * you can use {@code [primary]text[/]} in markup.</p>
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * StyleEngine engine = new StyleEngine();
+ * engine.loadStylesheet("catppuccin-mocha", "/themes/catppuccin-mocha.tcss");
+ * engine.setActiveStylesheet("catppuccin-mocha");
+ *
+ * CssMarkupBridge bridge = new CssMarkupBridge(engine);
+ * Text text = MarkupParser.parse("[primary]Title[/]", bridge.createResolver());
+ * }</pre>
+ *
+ * <p>Background colors use MarkupParser's existing "on" syntax:</p>
+ * <pre>{@code
+ * [text on primary]Highlighted text[/]
+ * [white on error]Alert![/]
+ * }</pre>
+ */
+public class CssMarkupBridge {
+
+    private final StyleEngine styleEngine;
+
+    /**
+     * Creates a new CSS-to-Markup bridge.
+     *
+     * @param styleEngine the style engine containing loaded themes
+     */
+    public CssMarkupBridge(StyleEngine styleEngine) {
+        this.styleEngine = styleEngine;
+    }
+
+    /**
+     * Creates a StyleResolver that resolves color names from CSS variables.
+     *
+     * <p>Resolution order:</p>
+     * <ol>
+     *   <li>Check if tag name is a CSS variable (e.g., "primary")</li>
+     *   <li>Return null to fall back to built-in MarkupParser styles</li>
+     * </ol>
+     *
+     * <p>Note: Background colors use MarkupParser's "on" syntax.
+     * The parser handles the "on" keyword automatically, calling this resolver
+     * for both foreground and background colors separately.</p>
+     *
+     * @return a StyleResolver that resolves CSS variable names to colors
+     */
+    public MarkupParser.StyleResolver createResolver() {
+        return tagName -> {
+            // Try to parse as a CSS variable reference
+            // The StyleEngine will resolve $tagName to its value and parse it as a color
+            String variableRef = "$" + tagName;
+            Optional<Color> color = styleEngine.parseColor(variableRef);
+
+            if (!color.isPresent()) {
+                return null;  // Not a CSS variable, use built-in styles
+            }
+
+            // Return Style with foreground color
+            // MarkupParser handles "on" keyword for background
+            return Style.EMPTY.fg(color.get());
+        };
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/theme/Theme.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/theme/Theme.java
@@ -1,0 +1,743 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.theme;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.model.Stylesheet;
+import dev.tamboui.css.parser.CssParser;
+import dev.tamboui.style.Color;
+
+/**
+ * Immutable theme representation with semantic color tokens.
+ *
+ * <p>Can be built programmatically or parsed from CSS:</p>
+ * <pre>{@code
+ * // Build programmatically
+ * Theme theme = Theme.builder()
+ *     .name("my-theme")
+ *     .dark(true)
+ *     .primary("#3498DB")
+ *     .error("#E74C3C")
+ *     .build();
+ *
+ * // Parse from CSS
+ * Theme existing = Theme.from(cssString);
+ *
+ * // Generate CSS
+ * String css = theme.toCss();
+ *
+ * // Load into StyleEngine
+ * engine.addStylesheet("my-theme", theme.toCss());
+ * }</pre>
+ *
+ * <p><b>Important:</b> Theme only stores explicitly defined variables.
+ * It does NOT auto-generate missing semantic colors in the constructor.
+ * Use the {@link #generate()} method to create a complete color palette from minimal input.</p>
+ */
+public final class Theme {
+    private final String name;
+    private final boolean dark;
+    private final float luminositySpread;
+    private final Map<String, String> variables;
+    private final StyleEngine styleEngine;
+
+    private Theme(String name, boolean dark, float luminositySpread, Map<String, String> variables) {
+        this.name = name;
+        this.dark = dark;
+        this.luminositySpread = luminositySpread;
+        this.variables = Collections.unmodifiableMap(new LinkedHashMap<>(variables));
+        this.styleEngine = StyleEngine.create();
+    }
+
+    // ===== Factory Methods =====
+
+    /**
+     * Creates a new theme builder.
+     *
+     * @return new builder instance
+     */
+    public static ThemeBuilder builder() {
+        return new ThemeBuilder();
+    }
+
+    /**
+     * Parses a theme from CSS content.
+     *
+     * @param cssContent the CSS/TCSS content
+     * @return parsed theme
+     */
+    public static Theme from(String cssContent) {
+        Stylesheet stylesheet = CssParser.parse(cssContent);
+        return fromStylesheet("parsed-theme", stylesheet);
+    }
+
+    /**
+     * Creates a theme from a Stylesheet.
+     *
+     * @param name the theme name
+     * @param stylesheet the stylesheet
+     * @return theme with variables from stylesheet
+     */
+    public static Theme fromStylesheet(String name, Stylesheet stylesheet) {
+        boolean dark = inferDarkMode(stylesheet);
+        float luminositySpread = 0.15f;  // Default value (Textual's default)
+        return new Theme(name, dark, luminositySpread, stylesheet.variables());
+    }
+
+    /**
+     * Infers whether theme is dark based on background/text colors.
+     * Heuristic: if background is darker than text, it's a dark theme.
+     */
+    private static boolean inferDarkMode(Stylesheet stylesheet) {
+        Optional<String> bg = stylesheet.resolveVariable(ThemePropertyNames.BACKGROUND);
+        Optional<String> text = stylesheet.resolveVariable(ThemePropertyNames.TEXT);
+
+        if (bg.isPresent() && text.isPresent()) {
+            StyleEngine engine = StyleEngine.create();
+            Optional<Color> bgColor = engine.parseColor(bg.get());
+            Optional<Color> textColor = engine.parseColor(text.get());
+
+            if (bgColor.isPresent() && textColor.isPresent()) {
+                double bgLightness = getLightness(bgColor.get());
+                double textLightness = getLightness(textColor.get());
+                return bgLightness < textLightness;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Calculates perceived lightness of a color (0.0 = black, 1.0 = white).
+     * Uses standard relative luminance formula.
+     */
+    private static double getLightness(Color color) {
+        Color.Rgb rgb = color.toRgb();
+        double r = rgb.r() / 255.0;
+        double g = rgb.g() / 255.0;
+        double b = rgb.b() / 255.0;
+
+        // Relative luminance
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    }
+
+    // ===== Accessors =====
+
+    /**
+     * Returns the theme name.
+     *
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns whether this is a dark theme.
+     * Can be used to determine appropriate contrast colors.
+     *
+     * @return true if dark theme, false if light theme
+     */
+    public boolean isDark() {
+        return dark;
+    }
+
+    /**
+     * Returns all variables in this theme.
+     * The returned map is unmodifiable.
+     *
+     * @return unmodifiable map of variable name → value
+     */
+    public Map<String, String> getVariables() {
+        return variables;
+    }
+
+    /**
+     * Gets a variable value by name.
+     *
+     * @param name the variable name (without $)
+     * @return variable value if present
+     */
+    public Optional<String> getVariable(String name) {
+        return Optional.ofNullable(variables.get(name));
+    }
+
+    // ===== Type-Safe Semantic Token Getters =====
+
+    /**
+     * Gets the primary color, if defined.
+     *
+     * @return primary color or empty if not defined
+     */
+    public Optional<Color> getPrimary() {
+        return getColorVariable(ThemePropertyNames.PRIMARY);
+    }
+
+    /**
+     * Gets the secondary color, if defined.
+     *
+     * @return secondary color or empty if not defined
+     */
+    public Optional<Color> getSecondary() {
+        return getColorVariable(ThemePropertyNames.SECONDARY);
+    }
+
+    /**
+     * Gets the accent color, if defined.
+     *
+     * @return accent color or empty if not defined
+     */
+    public Optional<Color> getAccent() {
+        return getColorVariable(ThemePropertyNames.ACCENT);
+    }
+
+    /**
+     * Gets the error color, if defined.
+     *
+     * @return error color or empty if not defined
+     */
+    public Optional<Color> getError() {
+        return getColorVariable(ThemePropertyNames.ERROR);
+    }
+
+    /**
+     * Gets the warning color, if defined.
+     *
+     * @return warning color or empty if not defined
+     */
+    public Optional<Color> getWarning() {
+        return getColorVariable(ThemePropertyNames.WARNING);
+    }
+
+    /**
+     * Gets the success color, if defined.
+     *
+     * @return success color or empty if not defined
+     */
+    public Optional<Color> getSuccess() {
+        return getColorVariable(ThemePropertyNames.SUCCESS);
+    }
+
+    /**
+     * Gets the info color, if defined.
+     *
+     * @return info color or empty if not defined
+     */
+    public Optional<Color> getInfo() {
+        return getColorVariable(ThemePropertyNames.INFO);
+    }
+
+    /**
+     * Gets the background color, if defined.
+     *
+     * @return background color or empty if not defined
+     */
+    public Optional<Color> getBackground() {
+        return getColorVariable(ThemePropertyNames.BACKGROUND);
+    }
+
+    /**
+     * Gets the surface color, if defined.
+     *
+     * @return surface color or empty if not defined
+     */
+    public Optional<Color> getSurface() {
+        return getColorVariable(ThemePropertyNames.SURFACE);
+    }
+
+    /**
+     * Gets the surface variant color, if defined.
+     *
+     * @return surface variant color or empty if not defined
+     */
+    public Optional<Color> getSurfaceVariant() {
+        return getColorVariable(ThemePropertyNames.SURFACE_VARIANT);
+    }
+
+    /**
+     * Gets the text color, if defined.
+     *
+     * @return text color or empty if not defined
+     */
+    public Optional<Color> getText() {
+        return getColorVariable(ThemePropertyNames.TEXT);
+    }
+
+    /**
+     * Gets the muted text color, if defined.
+     *
+     * @return muted text color or empty if not defined
+     */
+    public Optional<Color> getTextMuted() {
+        return getColorVariable(ThemePropertyNames.TEXT_MUTED);
+    }
+
+    /**
+     * Gets the disabled text color, if defined.
+     *
+     * @return disabled text color or empty if not defined
+     */
+    public Optional<Color> getTextDisabled() {
+        return getColorVariable(ThemePropertyNames.TEXT_DISABLED);
+    }
+
+    /**
+     * Gets the border color, if defined.
+     *
+     * @return border color or empty if not defined
+     */
+    public Optional<Color> getBorder() {
+        return getColorVariable(ThemePropertyNames.BORDER);
+    }
+
+    /**
+     * Helper to get and parse a color variable.
+     */
+    private Optional<Color> getColorVariable(String name) {
+        return getVariable(name)
+                .flatMap(value -> styleEngine.parseColor(value));
+    }
+
+    // ===== Palette Generation =====
+
+    /**
+     * Generates a complete color palette from the theme's base colors.
+     *
+     * <p>Inspired by Textual's ColorSystem.generate(). Creates a full palette including:</p>
+     * <ul>
+     *   <li>Lightened variants (primary-lighten-1, primary-lighten-2, primary-lighten-3)</li>
+     *   <li>Darkened variants (primary-darken-1, primary-darken-2, primary-darken-3)</li>
+     *   <li>Derived colors (if secondary/error/warning not defined, derive from primary)</li>
+     *   <li>Muted variants (primary-muted, secondary-muted, error-muted)</li>
+     * </ul>
+     *
+     * <p>Example:</p>
+     * <pre>{@code
+     * Theme theme = Theme.builder()
+     *     .dark(true)
+     *     .primary("#3498DB")
+     *     .luminositySpread(0.15f)
+     *     .build();
+     *
+     * Map<String, String> palette = theme.generate();
+     * // Contains: primary, primary-lighten-1, primary-darken-1,
+     * //           secondary (derived), error (derived), etc.
+     * }</pre>
+     *
+     * @return map of color name → hex value for complete palette
+     * @throws IllegalStateException if primary color is not defined
+     */
+    public Map<String, String> generate() {
+        Map<String, String> palette = new LinkedHashMap<>();
+
+        // Get base colors with fallbacks
+        Color primary = getPrimary().orElseThrow(() ->
+            new IllegalStateException("Primary color required for palette generation"));
+        Color secondary = getSecondary().orElse(primary);
+        Color accent = getAccent().orElse(primary);
+        Color error = getError().orElse(primary.rotateHue(180));  // Complementary
+        Color warning = getWarning().orElse(primary.rotateHue(30));  // Analogous
+        Color success = getSuccess().orElse(primary.rotateHue(-30));  // Analogous
+
+        // Generate shades for each color (-3, -2, -1, 0, +1, +2, +3)
+        generateShades(palette, ThemePropertyNames.PRIMARY, primary);
+        generateShades(palette, ThemePropertyNames.SECONDARY, secondary);
+        generateShades(palette, ThemePropertyNames.ACCENT, accent);
+        generateShades(palette, ThemePropertyNames.ERROR, error);
+        generateShades(palette, ThemePropertyNames.WARNING, warning);
+        generateShades(palette, ThemePropertyNames.SUCCESS, success);
+
+        // Generate muted variants
+        Color background = getBackground().orElse(dark ?
+            Color.rgb(18, 18, 18) : Color.rgb(255, 255, 255));
+        palette.put(ThemePropertyNames.PRIMARY + "-muted",
+            primary.mix(background, 0.7f).toHex());
+        palette.put(ThemePropertyNames.SECONDARY + "-muted",
+            secondary.mix(background, 0.7f).toHex());
+        palette.put(ThemePropertyNames.ERROR + "-muted",
+            error.mix(background, 0.7f).toHex());
+
+        return palette;
+    }
+
+    private void generateShades(Map<String, String> palette, String name, Color baseColor) {
+        float step = luminositySpread / 2.0f;  // Each shade is half the spread
+
+        palette.put(name, baseColor.toHex());
+
+        for (int i = 1; i <= 3; i++) {
+            float delta = step * i;
+            palette.put(name + "-lighten-" + i, baseColor.lighten(delta).toHex());
+            palette.put(name + "-darken-" + i, baseColor.darken(delta).toHex());
+        }
+    }
+
+    // ===== CSS Generation =====
+
+    /**
+     * Generates CSS content that can be loaded into StyleEngine.
+     *
+     * <p>Output format:</p>
+     * <pre>{@code
+     * /* Theme: my-theme (dark) *‍/
+     * $primary: #3498DB;
+     * $error: #E74C3C;
+     * ...
+     * }</pre>
+     *
+     * <p><b>Important:</b> Only generates variables that were explicitly
+     * defined. Does NOT auto-generate missing semantic tokens.</p>
+     *
+     * @return CSS content
+     */
+    public String toCss() {
+        StringBuilder sb = new StringBuilder();
+
+        // Add header comment with theme metadata
+        sb.append("/* Theme: ").append(name);
+        if (dark) {
+            sb.append(" (dark)");
+        } else {
+            sb.append(" (light)");
+        }
+        sb.append(" */\n\n");
+
+        // Generate variable declarations in definition order
+        for (Map.Entry<String, String> entry : variables.entrySet()) {
+            sb.append("$")
+                    .append(entry.getKey())
+                    .append(": ")
+                    .append(entry.getValue())
+                    .append(";\n");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Converts this theme to a Stylesheet object.
+     *
+     * @return stylesheet representation
+     */
+    public Stylesheet toStylesheet() {
+        return CssParser.parse(toCss());
+    }
+
+    // ===== Builder =====
+
+    /**
+     * Fluent builder for creating themes programmatically.
+     *
+     * <p>Example:</p>
+     * <pre>{@code
+     * Theme theme = Theme.builder()
+     *     .name("gruvbox-dark")
+     *     .dark(true)
+     *     .primary("#D3869B")
+     *     .secondary("#83A598")
+     *     .warning("#FABD2F")
+     *     .error("#FB4934")
+     *     .success("#B8BB26")
+     *     .background("#282828")
+     *     .text("#EBDBB2")
+     *     .variable("border-radius", "4")
+     *     .build();
+     * }</pre>
+     *
+     * <p><b>Note:</b> Only the colors you explicitly set are stored.
+     * Missing colors will return {@code Optional.empty()} from the corresponding
+     * getters.</p>
+     */
+    public static final class ThemeBuilder {
+        private final Map<String, String> variables;
+        private String themeName;
+        private boolean dark;
+        private float luminositySpread;
+
+        private ThemeBuilder() {
+            this.variables = new LinkedHashMap<>();
+            this.themeName = "default-theme";
+            this.dark = false;
+            this.luminositySpread = 0.15f;  // Textual's default
+        }
+
+        /**
+         * Sets the theme name.
+         *
+         * @param name the theme name
+         * @return this builder
+         */
+        public ThemeBuilder name(String name) {
+            this.themeName = name;
+            return this;
+        }
+
+        /**
+         * Sets whether this is a dark theme.
+         * Used for appropriate contrast and surface color selection.
+         *
+         * @param dark true for dark theme, false for light theme
+         * @return this builder
+         */
+        public ThemeBuilder dark(boolean dark) {
+            this.dark = dark;
+            return this;
+        }
+
+        /**
+         * Sets the luminosity spread for shade generation.
+         * Controls how much lighter/darker the shade variants are when using {@link #generate()}.
+         * Textual uses 0.15 as default.
+         *
+         * @param spread the spread value (typically 0.1 to 0.3)
+         * @return this builder
+         */
+        public ThemeBuilder luminositySpread(float spread) {
+            this.luminositySpread = spread;
+            return this;
+        }
+
+        // ===== Semantic Color Setters =====
+
+        /**
+         * Sets the primary color.
+         *
+         * @param colorValue color value (hex, rgb, named color)
+         * @return this builder
+         */
+        public ThemeBuilder primary(String colorValue) {
+            variables.put(ThemePropertyNames.PRIMARY, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the secondary color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder secondary(String colorValue) {
+            variables.put(ThemePropertyNames.SECONDARY, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the accent color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder accent(String colorValue) {
+            variables.put(ThemePropertyNames.ACCENT, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the error color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder error(String colorValue) {
+            variables.put(ThemePropertyNames.ERROR, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the warning color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder warning(String colorValue) {
+            variables.put(ThemePropertyNames.WARNING, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the success color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder success(String colorValue) {
+            variables.put(ThemePropertyNames.SUCCESS, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the info color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder info(String colorValue) {
+            variables.put(ThemePropertyNames.INFO, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the background color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder background(String colorValue) {
+            variables.put(ThemePropertyNames.BACKGROUND, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the surface color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder surface(String colorValue) {
+            variables.put(ThemePropertyNames.SURFACE, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the surface variant color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder surfaceVariant(String colorValue) {
+            variables.put(ThemePropertyNames.SURFACE_VARIANT, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the surface dim color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder surfaceDim(String colorValue) {
+            variables.put(ThemePropertyNames.SURFACE_DIM, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the text color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder text(String colorValue) {
+            variables.put(ThemePropertyNames.TEXT, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the muted text color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder textMuted(String colorValue) {
+            variables.put(ThemePropertyNames.TEXT_MUTED, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the disabled text color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder textDisabled(String colorValue) {
+            variables.put(ThemePropertyNames.TEXT_DISABLED, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the text-on-primary color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder textOnPrimary(String colorValue) {
+            variables.put(ThemePropertyNames.TEXT_ON_PRIMARY, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the border color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder border(String colorValue) {
+            variables.put(ThemePropertyNames.BORDER, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the border focus color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder borderFocus(String colorValue) {
+            variables.put(ThemePropertyNames.BORDER_FOCUS, colorValue);
+            return this;
+        }
+
+        /**
+         * Sets the border muted color.
+         *
+         * @param colorValue color value
+         * @return this builder
+         */
+        public ThemeBuilder borderMuted(String colorValue) {
+            variables.put(ThemePropertyNames.BORDER_MUTED, colorValue);
+            return this;
+        }
+
+        // ===== Generic Variable Support =====
+
+        /**
+         * Sets a custom variable.
+         *
+         * @param name variable name (without $)
+         * @param value variable value
+         * @return this builder
+         */
+        public ThemeBuilder variable(String name, String value) {
+            if (value != null) {
+                variables.put(name, value);
+            }
+            return this;
+        }
+
+        /**
+         * Adds multiple variables.
+         *
+         * @param variables map of variable name → value
+         * @return this builder
+         */
+        public ThemeBuilder variables(Map<String, String> variables) {
+            this.variables.putAll(variables);
+            return this;
+        }
+
+        /**
+         * Builds the immutable Theme.
+         *
+         * @return new Theme instance
+         */
+        public Theme build() {
+            return new Theme(themeName, dark, luminositySpread, variables);
+        }
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemePropertyNames.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemePropertyNames.java
@@ -1,0 +1,142 @@
+package dev.tamboui.css.theme;
+
+/**
+ * Documents the standard semantic design tokens that themes should define.
+ * This is documentation only - actual values are defined in .tcss theme files.
+ *
+ * <p>All theme .tcss files should define these variables for consistency.
+ * Applications should use these semantic names instead of hardcoded colors
+ * to ensure theme independence.</p>
+ *
+ * <p>Usage example:</p>
+ * <pre>{@code
+ * // In markup
+ * Text.from("[" + SemanticTokens.PRIMARY + "]Title[/]")
+ *
+ * // In CSS
+ * Panel { border-color: $primary; }
+ * }</pre>
+ */
+public final class ThemePropertyNames {
+
+    // Prevent instantiation - documentation only
+    private ThemePropertyNames() {}
+
+    // ===== Core Brand Colors =====
+
+    /**
+     * Primary brand color.
+     * Used for main actions, key UI elements, and brand identity.
+     */
+    public static final String PRIMARY = "primary";
+
+    /**
+     * Secondary accent color.
+     * Used for supporting UI elements and secondary actions.
+     */
+    public static final String SECONDARY = "secondary";
+
+    /**
+     * Accent/highlight color.
+     * Used for emphasis, highlights, and special callouts.
+     */
+    public static final String ACCENT = "accent";
+
+    // ===== Feedback Colors =====
+
+    /**
+     * Error state color.
+     * Used for error messages, validation failures, and destructive actions.
+     */
+    public static final String ERROR = "error";
+
+    /**
+     * Warning state color.
+     * Used for warnings, cautions, and important notices.
+     */
+    public static final String WARNING = "warning";
+
+    /**
+     * Success state color.
+     * Used for success messages, confirmations, and positive feedback.
+     */
+    public static final String SUCCESS = "success";
+
+    /**
+     * Informational state color.
+     * Used for info messages, tips, and neutral notifications.
+     */
+    public static final String INFO = "info";
+
+    // ===== Surface Colors =====
+
+    /**
+     * Main background color.
+     * Used for the primary application background.
+     */
+    public static final String BACKGROUND = "background";
+
+    /**
+     * Elevated surface color.
+     * Used for panels, cards, and elevated UI elements.
+     */
+    public static final String SURFACE = "surface";
+
+    /**
+     * Alternative surface color.
+     * Used for secondary panels and nested surfaces.
+     */
+    public static final String SURFACE_VARIANT = "surface-variant";
+
+    /**
+     * Dimmed surface color.
+     * Used for disabled surfaces and subtle backgrounds.
+     */
+    public static final String SURFACE_DIM = "surface-dim";
+
+    // ===== Text Colors =====
+
+    /**
+     * Primary text color.
+     * Used for main body text and headings.
+     */
+    public static final String TEXT = "text";
+
+    /**
+     * Muted text color.
+     * Used for secondary text, descriptions, and less important content.
+     */
+    public static final String TEXT_MUTED = "text-muted";
+
+    /**
+     * Disabled text color.
+     * Used for disabled or inactive text.
+     */
+    public static final String TEXT_DISABLED = "text-disabled";
+
+    /**
+     * Text color for use on primary color backgrounds.
+     * Ensures proper contrast when text appears on primary-colored surfaces.
+     */
+    public static final String TEXT_ON_PRIMARY = "text-on-primary";
+
+    // ===== Border Colors =====
+
+    /**
+     * Default border color.
+     * Used for standard borders, dividers, and outlines.
+     */
+    public static final String BORDER = "border";
+
+    /**
+     * Focused element border color.
+     * Used to indicate keyboard focus and active selection.
+     */
+    public static final String BORDER_FOCUS = "border-focus";
+
+    /**
+     * Subtle border color.
+     * Used for subtle dividers and low-emphasis borders.
+     */
+    public static final String BORDER_MUTED = "border-muted";
+}

--- a/tamboui-css/src/main/resources/themes/catppuccin-mocha.tcss
+++ b/tamboui-css/src/main/resources/themes/catppuccin-mocha.tcss
@@ -1,0 +1,39 @@
+/* ===================================================================
+ * Catppuccin Mocha Theme
+ * A soothing pastel theme with warm, muted colors
+ * https://github.com/catppuccin/catppuccin
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #cba6f7;      /* Mauve - Primary brand color */
+$secondary: #89b4fa;    /* Blue - Secondary accent */
+$accent: #f5c2e7;       /* Pink - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #f38ba8;        /* Red - Error states */
+$warning: #f9e2af;      /* Yellow - Warning states */
+$success: #a6e3a1;      /* Green - Success states */
+$info: #89dceb;         /* Sky - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #1e1e2e;   /* Base - Main background */
+$surface: #313244;      /* Surface0 - Elevated surface */
+$surface-variant: #45475a;  /* Surface1 - Alternative surface */
+$surface-dim: #585b70;  /* Surface2 - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #cdd6f4;         /* Text - Primary text color */
+$text-muted: #a6adc8;   /* Subtext0 - Muted text */
+$text-disabled: #9399b2;  /* Overlay2 - Disabled text */
+$text-on-primary: #1e1e2e;  /* Base - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #6c7086;       /* Overlay0 - Default borders */
+$border-focus: #cba6f7; /* Mauve - Focused element borders */
+$border-muted: #585b70; /* Surface2 - Subtle borders */
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/main/resources/themes/dark.tcss
+++ b/tamboui-css/src/main/resources/themes/dark.tcss
@@ -1,0 +1,45 @@
+/* ===================================================================
+ * Dark Theme
+ * A classic dark theme with high contrast
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #00ffff;      /* Cyan - Primary brand color */
+$secondary: #0080ff;    /* Blue - Secondary accent */
+$accent: #00ffff;       /* Cyan - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #ff6b6b;        /* Light Red - Error states */
+$warning: #ffeb3b;      /* Light Yellow - Warning states */
+$success: #4caf50;      /* Light Green - Success states */
+$info: #00bcd4;         /* Light Cyan - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #000000;   /* Black - Main background */
+$surface: #1a1a1a;      /* Dark Gray - Elevated surface */
+$surface-variant: #333333;  /* Medium Gray - Alternative surface */
+$surface-dim: #0d0d0d;  /* Very Dark Gray - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #ffffff;         /* White - Primary text color */
+$text-muted: #999999;   /* Gray - Muted text */
+$text-disabled: #666666;  /* Dark Gray - Disabled text */
+$text-on-primary: #000000;  /* Black - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #555555;       /* Medium Gray - Default borders */
+$border-focus: #00ffff; /* Cyan - Focused element borders */
+$border-muted: #333333; /* Dark Gray - Subtle borders */
+
+/* ===== Legacy Variables (for backward compatibility) ===== */
+$bg-primary: $background;
+$fg-primary: $text;
+$border-color: $border;
+$focus-color: $border-focus;
+$highlight-bg: $surface-variant;
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/main/resources/themes/dracula.tcss
+++ b/tamboui-css/src/main/resources/themes/dracula.tcss
@@ -1,0 +1,39 @@
+/* ===================================================================
+ * Dracula Theme
+ * A dark theme with vibrant, high-contrast colors
+ * https://draculatheme.com/
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #bd93f9;      /* Purple - Primary brand color */
+$secondary: #8be9fd;    /* Cyan - Secondary accent */
+$accent: #ff79c6;       /* Pink - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #ff5555;        /* Red - Error states */
+$warning: #f1fa8c;      /* Yellow - Warning states */
+$success: #50fa7b;      /* Green - Success states */
+$info: #8be9fd;         /* Cyan - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #282a36;   /* Background - Main background */
+$surface: #44475a;      /* Current Line - Elevated surface */
+$surface-variant: #6272a4;  /* Comment - Alternative surface (lighter) */
+$surface-dim: #21222c;  /* Darker background - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #f8f8f2;         /* Foreground - Primary text color */
+$text-muted: #6272a4;   /* Comment - Muted text */
+$text-disabled: #44475a;  /* Current Line - Disabled text */
+$text-on-primary: #282a36;  /* Background - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #6272a4;       /* Comment - Default borders */
+$border-focus: #bd93f9; /* Purple - Focused element borders */
+$border-muted: #44475a; /* Current Line - Subtle borders */
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/main/resources/themes/gruvbox-dark.tcss
+++ b/tamboui-css/src/main/resources/themes/gruvbox-dark.tcss
@@ -1,0 +1,39 @@
+/* ===================================================================
+ * Gruvbox Dark Theme
+ * A retro groove color scheme with warm, earthy tones
+ * https://github.com/morhetz/gruvbox
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #d3869b;      /* Purple - Primary brand color */
+$secondary: #83a598;    /* Blue - Secondary accent */
+$accent: #fe8019;       /* Orange - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #fb4934;        /* Red - Error states */
+$warning: #fabd2f;      /* Yellow - Warning states */
+$success: #b8bb26;      /* Green - Success states */
+$info: #8ec07c;         /* Aqua - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #282828;   /* bg - Main background */
+$surface: #3c3836;      /* bg1 - Elevated surface */
+$surface-variant: #504945;  /* bg2 - Alternative surface */
+$surface-dim: #1d2021;  /* bg0_h - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #ebdbb2;         /* fg - Primary text color */
+$text-muted: #a89984;   /* fg4 - Muted text */
+$text-disabled: #665c54;  /* bg4 - Disabled text */
+$text-on-primary: #282828;  /* bg - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #665c54;       /* bg4 - Default borders */
+$border-focus: #fe8019; /* Orange - Focused element borders */
+$border-muted: #504945; /* bg2 - Subtle borders */
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/main/resources/themes/light.tcss
+++ b/tamboui-css/src/main/resources/themes/light.tcss
@@ -1,0 +1,45 @@
+/* ===================================================================
+ * Light Theme
+ * A classic light theme with clean aesthetics
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #0066cc;      /* Blue - Primary brand color */
+$secondary: #6c757d;    /* Gray - Secondary accent */
+$accent: #0099ff;       /* Light Blue - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #dc3545;        /* Red - Error states */
+$warning: #ffc107;      /* Amber - Warning states */
+$success: #28a745;      /* Green - Success states */
+$info: #17a2b8;         /* Teal - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #ffffff;   /* White - Main background */
+$surface: #f8f9fa;      /* Light Gray - Elevated surface */
+$surface-variant: #e9ecef;  /* Medium Gray - Alternative surface */
+$surface-dim: #dee2e6;  /* Darker Gray - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #212529;         /* Near Black - Primary text color */
+$text-muted: #6c757d;   /* Gray - Muted text */
+$text-disabled: #adb5bd;  /* Light Gray - Disabled text */
+$text-on-primary: #ffffff;  /* White - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #ced4da;       /* Light Gray - Default borders */
+$border-focus: #0066cc; /* Blue - Focused element borders */
+$border-muted: #e9ecef; /* Very Light Gray - Subtle borders */
+
+/* ===== Legacy Variables (for backward compatibility) ===== */
+$bg-primary: $background;
+$fg-primary: $text;
+$border-color: $border;
+$focus-color: $border-focus;
+$highlight-bg: $surface-variant;
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/main/resources/themes/nord.tcss
+++ b/tamboui-css/src/main/resources/themes/nord.tcss
@@ -1,0 +1,39 @@
+/* ===================================================================
+ * Nord Theme
+ * An arctic, north-bluish color palette
+ * https://www.nordtheme.com/
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #88c0d0;      /* Frost 2 - Primary brand color */
+$secondary: #81a1c1;    /* Frost 3 - Secondary accent */
+$accent: #b48ead;       /* Aurora Purple - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #bf616a;        /* Aurora Red - Error states */
+$warning: #ebcb8b;      /* Aurora Yellow - Warning states */
+$success: #a3be8c;      /* Aurora Green - Success states */
+$info: #8fbcbb;         /* Frost 1 - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #2e3440;   /* Polar Night 0 - Main background */
+$surface: #3b4252;      /* Polar Night 1 - Elevated surface */
+$surface-variant: #434c5e;  /* Polar Night 2 - Alternative surface */
+$surface-dim: #4c566a;  /* Polar Night 3 - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #eceff4;         /* Snow Storm 2 - Primary text color */
+$text-muted: #d8dee9;   /* Snow Storm 1 - Muted text */
+$text-disabled: #4c566a;  /* Polar Night 3 - Disabled text */
+$text-on-primary: #2e3440;  /* Polar Night 0 - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #4c566a;       /* Polar Night 3 - Default borders */
+$border-focus: #88c0d0; /* Frost 2 - Focused element borders */
+$border-muted: #434c5e; /* Polar Night 2 - Subtle borders */
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/main/resources/themes/tokyo-night.tcss
+++ b/tamboui-css/src/main/resources/themes/tokyo-night.tcss
@@ -1,0 +1,39 @@
+/* ===================================================================
+ * Tokyo Night Theme
+ * A clean, dark theme inspired by the lights of Tokyo at night
+ * https://github.com/tokyo-night/tokyo-night-vscode-theme
+ * =================================================================== */
+
+/* ===== Core Brand Colors ===== */
+$primary: #bb9af7;      /* Purple - Primary brand color */
+$secondary: #7aa2f7;    /* Blue - Secondary accent */
+$accent: #ff007c;       /* Magenta - Highlight color */
+
+/* ===== Feedback Colors ===== */
+$error: #f7768e;        /* Red - Error states */
+$warning: #e0af68;      /* Yellow - Warning states */
+$success: #9ece6a;      /* Green - Success states */
+$info: #7dcfff;         /* Cyan - Informational states */
+
+/* ===== Surface Colors ===== */
+$background: #1a1b26;   /* bg - Main background */
+$surface: #24283b;      /* bg_dark - Elevated surface */
+$surface-variant: #414868;  /* bg_highlight - Alternative surface */
+$surface-dim: #16161e;  /* bg_darker - Dimmed surface */
+
+/* ===== Text Colors ===== */
+$text: #c0caf5;         /* fg - Primary text color */
+$text-muted: #9aa5ce;   /* fg_dark - Muted text */
+$text-disabled: #565f89;  /* comment - Disabled text */
+$text-on-primary: #1a1b26;  /* bg - Text on primary color backgrounds */
+
+/* ===== Border Colors ===== */
+$border: #565f89;       /* comment - Default borders */
+$border-focus: #bb9af7; /* Purple - Focused element borders */
+$border-muted: #414868; /* bg_highlight - Subtle borders */
+
+/* ===== Default Widget Styles ===== */
+* {
+    color: $text;
+    background: $background;
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/markup/CssMarkupBridgeTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/markup/CssMarkupBridgeTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.markup;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.theme.ThemePropertyNames;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.text.MarkupParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CssMarkupBridgeTest {
+
+    private StyleEngine engine;
+    private CssMarkupBridge bridge;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        engine = StyleEngine.create();
+
+        // Load a test theme with semantic tokens
+        String css = "$primary: #ff0000;\n"
+                + "$secondary: #00ff00;\n"
+                + "$error: #ff00ff;\n"
+                + "$success: #00ffff;\n";
+
+        engine.addStylesheet("test-theme", css);
+        engine.setActiveStylesheet("test-theme");
+
+        bridge = new CssMarkupBridge(engine);
+    }
+
+    @Test
+    void createResolverReturnsNonNullResolver() {
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+        assertThat(resolver).isNotNull();
+    }
+
+    @Test
+    void resolverResolvesPrimaryColor() {
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+        Style style = resolver.resolve(ThemePropertyNames.PRIMARY);
+
+        assertThat(style).isNotNull();
+        assertThat(style.fg()).isPresent();
+
+        Color.Rgb rgb = style.fg().get().toRgb();
+        assertThat(rgb.r()).isEqualTo(255);
+        assertThat(rgb.g()).isEqualTo(0);
+        assertThat(rgb.b()).isEqualTo(0);
+    }
+
+    @Test
+    void resolverResolvesSecondaryColor() {
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+        Style style = resolver.resolve(ThemePropertyNames.SECONDARY);
+
+        assertThat(style).isNotNull();
+        assertThat(style.fg()).isPresent();
+
+        Color.Rgb rgb = style.fg().get().toRgb();
+        assertThat(rgb.r()).isEqualTo(0);
+        assertThat(rgb.g()).isEqualTo(255);
+        assertThat(rgb.b()).isEqualTo(0);
+    }
+
+    @Test
+    void resolverResolvesErrorColor() {
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+        Style style = resolver.resolve(ThemePropertyNames.ERROR);
+
+        assertThat(style).isNotNull();
+        assertThat(style.fg()).isPresent();
+
+        Color.Rgb rgb = style.fg().get().toRgb();
+        assertThat(rgb.r()).isEqualTo(255);
+        assertThat(rgb.g()).isEqualTo(0);
+        assertThat(rgb.b()).isEqualTo(255);
+    }
+
+    @Test
+    void resolverReturnsNullForUnknownVariable() {
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+        Style style = resolver.resolve("unknown-variable");
+
+        assertThat(style).isNull();
+    }
+
+    @Test
+    void resolverReturnsNullForInvalidColorValue() throws IOException {
+        // Create a theme with invalid color value
+        String css = "$invalid: not-a-color;";
+        engine.addStylesheet("invalid-theme", css);
+        engine.setActiveStylesheet("invalid-theme");
+
+        CssMarkupBridge invalidBridge = new CssMarkupBridge(engine);
+        MarkupParser.StyleResolver resolver = invalidBridge.createResolver();
+
+        Style style = resolver.resolve("invalid");
+        assertThat(style).isNull();
+    }
+
+    @Test
+    void themeSwitchChangesResolvedColors() throws IOException {
+        // Create second theme with different colors
+        String css2 = "$primary: #0000ff;";
+        engine.addStylesheet("theme2", css2);
+
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+
+        // Check color with first theme
+        engine.setActiveStylesheet("test-theme");
+        Style style1 = resolver.resolve(ThemePropertyNames.PRIMARY);
+        assertThat(style1.fg()).isPresent();
+        Color.Rgb rgb1 = style1.fg().get().toRgb();
+        assertThat(rgb1.r()).isEqualTo(255);
+        assertThat(rgb1.g()).isEqualTo(0);
+        assertThat(rgb1.b()).isEqualTo(0);
+
+        // Switch theme and check again
+        engine.setActiveStylesheet("theme2");
+        Style style2 = resolver.resolve(ThemePropertyNames.PRIMARY);
+        assertThat(style2.fg()).isPresent();
+        Color.Rgb rgb2 = style2.fg().get().toRgb();
+        assertThat(rgb2.r()).isEqualTo(0);
+        assertThat(rgb2.g()).isEqualTo(0);
+        assertThat(rgb2.b()).isEqualTo(255);
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/markup/ThemeRenderingTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/markup/ThemeRenderingTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.markup;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.theme.ThemePropertyNames;
+import dev.tamboui.style.Color;
+import dev.tamboui.text.MarkupParser;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that themed markup actually produces styled text.
+ */
+class ThemeRenderingTest {
+
+    private StyleEngine engine;
+    private CssMarkupBridge bridge;
+    private MarkupParser.StyleResolver resolver;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        engine = StyleEngine.create();
+
+        // Load catppuccin-mocha theme
+        engine.loadStylesheet("catppuccin-mocha", "/themes/catppuccin-mocha.tcss");
+        engine.setActiveStylesheet("catppuccin-mocha");
+
+        bridge = new CssMarkupBridge(engine);
+        resolver = bridge.createResolver();
+    }
+
+    @Test
+    void markedUpTextHasColor() {
+        Text text = MarkupParser.parse("[" + ThemePropertyNames.PRIMARY + "]Hello[/]", resolver);
+
+        assertThat(text.lines()).hasSize(1);
+        assertThat(text.lines().get(0).spans()).hasSize(1);
+        Span span = text.lines().get(0).spans().get(0);
+        assertThat(span.content()).isEqualTo("Hello");
+        assertThat(span.style().fg()).isPresent();
+
+        // Catppuccin Mocha primary is #cba6f7 (mauve)
+        Color.Rgb rgb = span.style().fg().get().toRgb();
+        assertThat(rgb.r()).isEqualTo(203);
+        assertThat(rgb.g()).isEqualTo(166);
+        assertThat(rgb.b()).isEqualTo(247);
+    }
+
+    @Test
+    void switchingThemesChangesColors() throws IOException {
+        // Parse with catppuccin-mocha active
+        Text text1 = MarkupParser.parse("[" + ThemePropertyNames.PRIMARY + "]Test[/]", resolver);
+        Color.Rgb rgb1 = text1.lines().get(0).spans().get(0).style().fg().get().toRgb();
+
+        // Switch to dracula
+        engine.loadStylesheet("dracula", "/themes/dracula.tcss");
+        engine.setActiveStylesheet("dracula");
+
+        // Parse again - should get dracula's primary color
+        Text text2 = MarkupParser.parse("[" + ThemePropertyNames.PRIMARY + "]Test[/]", resolver);
+        Color.Rgb rgb2 = text2.lines().get(0).spans().get(0).style().fg().get().toRgb();
+
+        // Colors should be different
+        assertThat(rgb1.r()).isNotEqualTo(rgb2.r());
+
+        // Dracula primary is #bd93f9
+        assertThat(rgb2.r()).isEqualTo(189);
+        assertThat(rgb2.g()).isEqualTo(147);
+        assertThat(rgb2.b()).isEqualTo(249);
+    }
+
+    @Test
+    void multipleSemanticColorsInOneString() {
+        String markup = "[" + ThemePropertyNames.SUCCESS + "]✓ Success[/] and ["
+                + ThemePropertyNames.ERROR + "]✗ Error[/]";
+        Text text = MarkupParser.parse(markup, resolver);
+
+        assertThat(text.lines()).hasSize(1);
+        List<Span> spans = text.lines().get(0).spans();
+        assertThat(spans).hasSizeGreaterThanOrEqualTo(2);
+
+        // Find success and error spans
+        Span successSpan = spans.stream()
+                .filter(s -> s.content().contains("Success"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Success span not found"));
+        Span errorSpan = spans.stream()
+                .filter(s -> s.content().contains("Error"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Error span not found"));
+
+        // Both should have colors
+        assertThat(successSpan.style().fg()).isPresent();
+        assertThat(errorSpan.style().fg()).isPresent();
+
+        // And they should be different colors
+        Color successColor = successSpan.style().fg().get();
+        Color errorColor = errorSpan.style().fg().get();
+        assertThat(successColor.toRgb()).isNotEqualTo(errorColor.toRgb());
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeGenerateExample.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeGenerateExample.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.theme;
+
+import java.util.Map;
+
+import dev.tamboui.style.Color;
+
+/**
+ * Example demonstrating Theme.generate() and fluent Color API.
+ *
+ * <p>This is not a test - it's a runnable example showing the new APIs.</p>
+ */
+public class ThemeGenerateExample {
+
+    public static void main(String[] args) {
+        // Example 1: Minimal theme - just primary color
+        System.out.println("=== Example 1: Minimal Theme ===");
+        Theme minimal = Theme.builder()
+            .name("ocean")
+            .dark(true)
+            .primary("#3498DB")  // Ocean blue
+            .luminositySpread(0.15f)
+            .build();
+
+        Map<String, String> palette = minimal.generate();
+        System.out.println("Generated " + palette.size() + " colors from just primary!");
+        System.out.println("Primary shades:");
+        palette.entrySet().stream()
+            .filter(e -> e.getKey().startsWith("primary"))
+            .forEach(e -> System.out.println("  " + e.getKey() + ": " + e.getValue()));
+
+        System.out.println("\nDerived colors:");
+        System.out.println("  secondary: " + palette.get("secondary") + " (same as primary)");
+        System.out.println("  error: " + palette.get("error") + " (complementary)");
+        System.out.println("  warning: " + palette.get("warning") + " (analogous)");
+        System.out.println("  success: " + palette.get("success") + " (analogous)");
+
+        // Example 2: Explicit colors (no derivation)
+        System.out.println("\n=== Example 2: Explicit Colors ===");
+        Theme explicit = Theme.builder()
+            .name("gruvbox")
+            .dark(true)
+            .primary("#D3869B")
+            .secondary("#83A598")
+            .accent("#FE8019")
+            .error("#FB4934")
+            .warning("#FABD2F")
+            .success("#B8BB26")
+            .build();
+
+        Map<String, String> explicitPalette = explicit.generate();
+        System.out.println("Uses explicit values when provided:");
+        System.out.println("  primary: " + explicitPalette.get("primary"));
+        System.out.println("  secondary: " + explicitPalette.get("secondary") + " (explicit)");
+        System.out.println("  error: " + explicitPalette.get("error") + " (explicit)");
+
+        // Example 3: Different luminosity spreads
+        System.out.println("\n=== Example 3: Luminosity Spread Control ===");
+        Theme subtle = Theme.builder()
+            .primary("#808080")
+            .luminositySpread(0.1f)  // Subtle shades
+            .build();
+
+        Theme dramatic = Theme.builder()
+            .primary("#808080")
+            .luminositySpread(0.3f)  // Dramatic shades
+            .build();
+
+        Map<String, String> subtlePalette = subtle.generate();
+        Map<String, String> dramaticPalette = dramatic.generate();
+
+        System.out.println("Subtle (0.1 spread):");
+        System.out.println("  primary-lighten-3: " + subtlePalette.get("primary-lighten-3"));
+        System.out.println("  primary-darken-3: " + subtlePalette.get("primary-darken-3"));
+
+        System.out.println("Dramatic (0.3 spread):");
+        System.out.println("  primary-lighten-3: " + dramaticPalette.get("primary-lighten-3"));
+        System.out.println("  primary-darken-3: " + dramaticPalette.get("primary-darken-3"));
+
+        // Example 4: Fluent Color API
+        System.out.println("\n=== Example 4: Fluent Color API ===");
+        Color baseColor = Color.hex("#3498DB");
+
+        System.out.println("Base color: " + baseColor.toHex());
+        System.out.println("Lightened: " + baseColor.lighten(0.2f).toHex());
+        System.out.println("Darkened: " + baseColor.darken(0.2f).toHex());
+        System.out.println("Complementary: " + baseColor.rotateHue(180).toHex());
+        System.out.println("Desaturated: " + baseColor.adjustSaturation(0.5f).toHex());
+
+        // Chain operations
+        Color customShade = baseColor
+            .lighten(0.1f)
+            .rotateHue(15)
+            .mix(Color.rgb(255, 255, 255), 0.2f);
+        System.out.println("\nChained (lighten→rotateHue→mix): " + customShade.toHex());
+
+        // Convert to HSL
+        float[] hsl = baseColor.toHsl();
+        System.out.println(String.format("\nHSL: [%.1f°, %.1f%%, %.1f%%]", hsl[0], hsl[1], hsl[2]));
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeIntegrationTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeIntegrationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.theme;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.markup.CssMarkupBridge;
+import dev.tamboui.text.MarkupParser;
+import dev.tamboui.text.Text;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests showing Theme working with StyleEngine and CssMarkupBridge.
+ */
+class ThemeIntegrationTest {
+
+    @Test
+    void programmaticallyCreatedThemeWorksWithStyleEngine() {
+        // Create theme programmatically
+        Theme theme = Theme.builder()
+                .name("test-theme")
+                .dark(true)
+                .primary("#3498DB")
+                .error("#E74C3C")
+                .success("#27AE60")
+                .background("#1E1E1E")
+                .text("#FFFFFF")
+                .build();
+
+        // Load into StyleEngine
+        StyleEngine engine = StyleEngine.create();
+        engine.addStylesheet("test-theme", theme.toCss());
+        engine.setActiveStylesheet("test-theme");
+
+        // Verify colors are accessible via parseColor
+        assertThat(engine.parseColor("$primary")).isPresent();
+        assertThat(engine.parseColor("$primary").get().toRgb().r()).isEqualTo(52);
+        assertThat(engine.parseColor("$primary").get().toRgb().g()).isEqualTo(152);
+        assertThat(engine.parseColor("$primary").get().toRgb().b()).isEqualTo(219);
+    }
+
+    @Test
+    void programmaticallyCreatedThemeWorksWithMarkup() {
+        // Create theme
+        Theme theme = Theme.builder()
+                .name("markup-theme")
+                .primary("#FF0000")
+                .error("#00FF00")
+                .success("#0000FF")
+                .build();
+
+        // Load into StyleEngine
+        StyleEngine engine = StyleEngine.create();
+        engine.addStylesheet("markup-theme", theme.toCss());
+        engine.setActiveStylesheet("markup-theme");
+
+        // Use with CssMarkupBridge
+        CssMarkupBridge bridge = new CssMarkupBridge(engine);
+        MarkupParser.StyleResolver resolver = bridge.createResolver();
+
+        // Parse markup with semantic colors
+        Text text = MarkupParser.parse("[primary]Hello[/]", resolver);
+
+        // Verify the text has the correct color
+        assertThat(text.lines()).hasSize(1);
+        assertThat(text.lines().get(0).spans()).hasSize(1);
+        assertThat(text.lines().get(0).spans().get(0).style().fg()).isPresent();
+
+        // Should be red (primary = #FF0000)
+        assertThat(text.lines().get(0).spans().get(0).style().fg().get().toRgb().r()).isEqualTo(255);
+        assertThat(text.lines().get(0).spans().get(0).style().fg().get().toRgb().g()).isEqualTo(0);
+        assertThat(text.lines().get(0).spans().get(0).style().fg().get().toRgb().b()).isEqualTo(0);
+    }
+
+    @Test
+    void canParseExistingThemeAndModify() {
+        // Parse existing theme CSS
+        String originalCss = "$primary: #3498DB;\n$error: #E74C3C;\n$background: #1E1E1E;";
+        Theme original = Theme.from(originalCss);
+
+        assertThat(original.getPrimary()).isPresent();
+        assertThat(original.getError()).isPresent();
+
+        // Create modified version with additional colors
+        Theme modified = Theme.builder()
+                .name("modified-theme")
+                .dark(original.isDark())
+                .variables(original.getVariables())
+                .success("#27AE60")  // Add success color
+                .warning("#F39C12")  // Add warning color
+                .build();
+
+        assertThat(modified.getPrimary()).isPresent();  // Original colors preserved
+        assertThat(modified.getError()).isPresent();
+        assertThat(modified.getSuccess()).isPresent();  // New colors added
+        assertThat(modified.getWarning()).isPresent();
+
+        // Generate CSS for modified theme
+        String modifiedCss = modified.toCss();
+        assertThat(modifiedCss).contains("$primary: #3498DB");
+        assertThat(modifiedCss).contains("$success: #27AE60");
+    }
+
+    @Test
+    void minimalisticThemeWorksInPractice() {
+        // Create minimal theme with only essential colors
+        Theme minimal = Theme.builder()
+                .name("minimal")
+                .primary("#007ACC")
+                .background("#FFFFFF")
+                .text("#000000")
+                .build();
+
+        StyleEngine engine = StyleEngine.create();
+        engine.addStylesheet("minimal", minimal.toCss());
+        engine.setActiveStylesheet("minimal");
+
+        // Missing colors return Optional.empty() but don't break anything
+        assertThat(minimal.getError()).isEmpty();
+        assertThat(minimal.getWarning()).isEmpty();
+
+        // Can still use the colors that ARE defined
+        assertThat(engine.parseColor("$primary")).isPresent();
+        assertThat(engine.parseColor("$background")).isPresent();
+
+        // Missing colors just aren't resolvable
+        assertThat(engine.parseColor("$error")).isEmpty();
+    }
+
+    @Test
+    void darkThemeMetadataIsPreserved() {
+        Theme dark = Theme.builder()
+                .name("dark-theme")
+                .dark(true)
+                .background("#1E1E1E")
+                .text("#FFFFFF")
+                .build();
+
+        String css = dark.toCss();
+
+        // Re-parse the CSS
+        Theme reparsed = Theme.from(css);
+
+        // Dark mode should be inferred from colors
+        assertThat(reparsed.isDark()).isTrue();
+    }
+
+    @Test
+    void lightThemeMetadataIsPreserved() {
+        Theme light = Theme.builder()
+                .name("light-theme")
+                .dark(false)
+                .background("#FFFFFF")
+                .text("#000000")
+                .build();
+
+        String css = light.toCss();
+
+        // Re-parse the CSS
+        Theme reparsed = Theme.from(css);
+
+        // Light mode should be inferred from colors
+        assertThat(reparsed.isDark()).isFalse();
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeTest.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.theme;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.css.model.Stylesheet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ThemeTest {
+
+    @Test
+    void builderCreatesThemeWithSemanticColors() {
+        Theme theme = Theme.builder()
+                .name("test-theme")
+                .dark(true)
+                .primary("#FF0000")
+                .error("#00FF00")
+                .build();
+
+        assertThat(theme.getName()).isEqualTo("test-theme");
+        assertThat(theme.isDark()).isTrue();
+        assertThat(theme.getPrimary()).isPresent();
+        assertThat(theme.getPrimary().get().toRgb().r()).isEqualTo(255);
+        assertThat(theme.getError()).isPresent();
+        assertThat(theme.getError().get().toRgb().r()).isEqualTo(0);
+    }
+
+    @Test
+    void minimalThemeOnlyStoresDefinedColors() {
+        // Theme with only primary - NO auto-expansion
+        Theme minimal = Theme.builder()
+                .name("minimal")
+                .primary("#3498DB")
+                .build();
+
+        assertThat(minimal.getPrimary()).isPresent();
+        assertThat(minimal.getError()).isEmpty();
+        assertThat(minimal.getWarning()).isEmpty();
+        assertThat(minimal.getSuccess()).isEmpty();
+        assertThat(minimal.getInfo()).isEmpty();
+        assertThat(minimal.getSecondary()).isEmpty();
+        assertThat(minimal.getAccent()).isEmpty();
+        assertThat(minimal.getBackground()).isEmpty();
+    }
+
+    @Test
+    void toCssGeneratesOnlyDefinedVariables() {
+        Theme theme = Theme.builder()
+                .name("partial")
+                .dark(false)
+                .primary("#3498DB")
+                .error("#E74C3C")
+                .build();
+
+        String css = theme.toCss();
+        assertThat(css).contains("/* Theme: partial (light) */");
+        assertThat(css).contains("$primary: #3498DB;");
+        assertThat(css).contains("$error: #E74C3C;");
+
+        // Should NOT contain warning, success, etc.
+        assertThat(css).doesNotContain("$warning");
+        assertThat(css).doesNotContain("$success");
+        assertThat(css).doesNotContain("$secondary");
+    }
+
+    @Test
+    void darkThemeIncludesDarkAnnotation() {
+        Theme dark = Theme.builder()
+                .name("dark-theme")
+                .dark(true)
+                .primary("#000000")
+                .build();
+
+        assertThat(dark.toCss()).contains("(dark)");
+    }
+
+    @Test
+    void lightThemeIncludesLightAnnotation() {
+        Theme light = Theme.builder()
+                .name("light-theme")
+                .dark(false)
+                .primary("#FFFFFF")
+                .build();
+
+        assertThat(light.toCss()).contains("(light)");
+    }
+
+    @Test
+    void fromCssParsesOnlyPresentVariables() {
+        String css = "$primary: #FF0000;\n$error: #00FF00;";
+        Theme theme = Theme.from(css);
+
+        assertThat(theme.getVariable("primary")).hasValue("#FF0000");
+        assertThat(theme.getPrimary()).isPresent();
+        assertThat(theme.getError()).isPresent();
+
+        // Warning not in CSS = empty
+        assertThat(theme.getWarning()).isEmpty();
+        assertThat(theme.getSuccess()).isEmpty();
+    }
+
+    @Test
+    void roundTripPreservesOnlyDefinedVariables() {
+        Theme original = Theme.builder()
+                .name("original")
+                .dark(true)
+                .primary("#3498DB")
+                .variable("custom", "value")
+                .build();
+
+        String css = original.toCss();
+        Theme parsed = Theme.from(css);
+
+        assertThat(parsed.getVariable("primary")).isEqualTo(original.getVariable("primary"));
+        assertThat(parsed.getVariable("custom")).isEqualTo(original.getVariable("custom"));
+        assertThat(parsed.getVariables()).hasSize(2);
+    }
+
+    @Test
+    void customVariablesArePreserved() {
+        Theme theme = Theme.builder()
+                .primary("#3498DB")
+                .variable("border-radius", "4")
+                .variable("font-size", "14px")
+                .variable("spacing", "8")
+                .build();
+
+        assertThat(theme.getVariable("border-radius")).hasValue("4");
+        assertThat(theme.getVariable("font-size")).hasValue("14px");
+        assertThat(theme.getVariable("spacing")).hasValue("8");
+
+        String css = theme.toCss();
+        assertThat(css).contains("$border-radius: 4;");
+        assertThat(css).contains("$font-size: 14px;");
+        assertThat(css).contains("$spacing: 8;");
+    }
+
+    @Test
+    void toStylesheetProducesValidStylesheet() {
+        Theme theme = Theme.builder()
+                .name("test")
+                .primary("#FF0000")
+                .error("#00FF00")
+                .build();
+
+        Stylesheet stylesheet = theme.toStylesheet();
+        assertThat(stylesheet.variables()).containsKey("primary");
+        assertThat(stylesheet.variables()).containsKey("error");
+        assertThat(stylesheet.variables()).hasSize(2);
+    }
+
+    @Test
+    void builderWithVariablesMapAddsAllVariables() {
+        java.util.Map<String, String> vars = new java.util.LinkedHashMap<>();
+        vars.put("custom1", "value1");
+        vars.put("custom2", "value2");
+
+        Theme theme = Theme.builder()
+                .primary("#FF0000")
+                .variables(vars)
+                .build();
+
+        assertThat(theme.getVariable("primary")).hasValue("#FF0000");
+        assertThat(theme.getVariable("custom1")).hasValue("value1");
+        assertThat(theme.getVariable("custom2")).hasValue("value2");
+        assertThat(theme.getVariables()).hasSize(3);
+    }
+
+    @Test
+    void builderIgnoresNullVariableValues() {
+        Theme theme = Theme.builder()
+                .primary("#FF0000")
+                .variable("null-var", null)
+                .build();
+
+        assertThat(theme.getVariable("null-var")).isEmpty();
+        assertThat(theme.getVariables()).hasSize(1);
+    }
+
+    @Test
+    void allSemanticTokenSettersWork() {
+        Theme theme = Theme.builder()
+                .name("complete")
+                .dark(true)
+                .primary("#111111")
+                .secondary("#222222")
+                .accent("#333333")
+                .error("#444444")
+                .warning("#555555")
+                .success("#666666")
+                .info("#777777")
+                .background("#888888")
+                .surface("#999999")
+                .surfaceVariant("#AAAAAA")
+                .surfaceDim("#BBBBBB")
+                .text("#CCCCCC")
+                .textMuted("#DDDDDD")
+                .textDisabled("#EEEEEE")
+                .textOnPrimary("#FFFFFF")
+                .border("#F1F1F1")
+                .borderFocus("#F2F2F2")
+                .borderMuted("#F3F3F3")
+                .build();
+
+        assertThat(theme.getPrimary()).isPresent();
+        assertThat(theme.getSecondary()).isPresent();
+        assertThat(theme.getAccent()).isPresent();
+        assertThat(theme.getError()).isPresent();
+        assertThat(theme.getWarning()).isPresent();
+        assertThat(theme.getSuccess()).isPresent();
+        assertThat(theme.getInfo()).isPresent();
+        assertThat(theme.getBackground()).isPresent();
+        assertThat(theme.getSurface()).isPresent();
+        assertThat(theme.getSurfaceVariant()).isPresent();
+        assertThat(theme.getText()).isPresent();
+        assertThat(theme.getTextMuted()).isPresent();
+        assertThat(theme.getTextDisabled()).isPresent();
+        assertThat(theme.getBorder()).isPresent();
+
+        assertThat(theme.getVariables()).hasSize(18);
+    }
+
+    @Test
+    void infersDarkModeFromBackgroundAndTextColors() {
+        // Dark theme: dark background, light text
+        String darkCss = "$background: #1E1E1E;\n$text: #FFFFFF;";
+        Theme dark = Theme.from(darkCss);
+        assertThat(dark.isDark()).isTrue();
+
+        // Light theme: light background, dark text
+        String lightCss = "$background: #FFFFFF;\n$text: #000000;";
+        Theme light = Theme.from(lightCss);
+        assertThat(light.isDark()).isFalse();
+    }
+
+    @Test
+    void defaultsToDarkFalseWhenCannotInfer() {
+        String css = "$primary: #FF0000;";  // No background/text to infer from
+        Theme theme = Theme.from(css);
+        assertThat(theme.isDark()).isFalse();
+    }
+
+    @Test
+    void getVariablesReturnsUnmodifiableMap() {
+        Theme theme = Theme.builder()
+                .primary("#FF0000")
+                .build();
+
+        java.util.Map<String, String> vars = theme.getVariables();
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> {
+            vars.put("new-var", "value");
+        }).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void builderPreservesVariableInsertionOrder() {
+        Theme theme = Theme.builder()
+                .variable("z-var", "1")
+                .variable("a-var", "2")
+                .variable("m-var", "3")
+                .build();
+
+        String css = theme.toCss();
+        int zIndex = css.indexOf("$z-var");
+        int aIndex = css.indexOf("$a-var");
+        int mIndex = css.indexOf("$m-var");
+
+        // Order should be preserved (z, a, m)
+        assertThat(zIndex).isLessThan(aIndex);
+        assertThat(aIndex).isLessThan(mIndex);
+    }
+
+    @Test
+    void fromStylesheetExtractsAllVariables() {
+        String css = "$primary: #FF0000;\n$custom: value;\n$error: #00FF00;";
+        Stylesheet stylesheet = dev.tamboui.css.parser.CssParser.parse(css);
+
+        Theme theme = Theme.fromStylesheet("test", stylesheet);
+
+        assertThat(theme.getName()).isEqualTo("test");
+        assertThat(theme.getVariable(ThemePropertyNames.PRIMARY)).hasValue("#FF0000");
+        assertThat(theme.getVariable(ThemePropertyNames.ERROR)).hasValue("#00FF00");
+        assertThat(theme.getVariable("custom")).hasValue("value");
+    }
+
+    @Test
+    void generateCreatesFullPalette() {
+        Theme theme = Theme.builder()
+            .name("minimal")
+            .dark(true)
+            .primary("#3498DB")
+            .luminositySpread(0.15f)
+            .build();
+
+        java.util.Map<String, String> palette = theme.generate();
+
+        // Should have primary and all its shades
+        assertThat(palette).containsKey("primary");
+        assertThat(palette).containsKey("primary-lighten-1");
+        assertThat(palette).containsKey("primary-lighten-2");
+        assertThat(palette).containsKey("primary-lighten-3");
+        assertThat(palette).containsKey("primary-darken-1");
+        assertThat(palette).containsKey("primary-darken-2");
+        assertThat(palette).containsKey("primary-darken-3");
+
+        // Should derive secondary, error, warning, success from primary
+        assertThat(palette).containsKey("secondary");
+        assertThat(palette).containsKey("error");
+        assertThat(palette).containsKey("warning");
+        assertThat(palette).containsKey("success");
+
+        // Should have muted variants
+        assertThat(palette).containsKey("primary-muted");
+    }
+
+    @Test
+    void generateRequiresPrimaryColor() {
+        Theme theme = Theme.builder()
+            .name("no-primary")
+            .error("#E74C3C")
+            .build();
+
+        // Should throw because primary is required for generation
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> theme.generate())
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("Primary color required");
+    }
+
+    @Test
+    void generateUsesExplicitColorsWhenProvided() {
+        Theme theme = Theme.builder()
+            .primary("#3498DB")
+            .secondary("#2C3E50")  // Explicit, not derived
+            .error("#E74C3C")      // Explicit, not derived
+            .build();
+
+        java.util.Map<String, String> palette = theme.generate();
+
+        // Should use explicit values, not derive from primary
+        assertThat(palette.get("secondary")).isEqualTo("#2c3e50");  // May be lowercase
+        assertThat(palette.get("error")).isEqualTo("#e74c3c");
+    }
+
+    @Test
+    void luminositySpreadControlsShadeGeneration() {
+        Theme small = Theme.builder()
+            .primary("#808080")  // Gray
+            .luminositySpread(0.1f)
+            .build();
+
+        Theme large = Theme.builder()
+            .primary("#808080")  // Gray
+            .luminositySpread(0.3f)
+            .build();
+
+        java.util.Map<String, String> smallPalette = small.generate();
+        java.util.Map<String, String> largePalette = large.generate();
+
+        // Larger spread should produce lighter lighten-3 and darker darken-3
+        // (We can't easily assert exact values, but they should be different)
+        assertThat(smallPalette.get("primary-lighten-3"))
+            .isNotEqualTo(largePalette.get("primary-lighten-3"));
+        assertThat(smallPalette.get("primary-darken-3"))
+            .isNotEqualTo(largePalette.get("primary-darken-3"));
+    }
+}


### PR DESCRIPTION
This is draft-in-progress to explore notion of semantic color variables (which is closely related to Themes) 

This introduce set of variables that gets derived from a base color/theme similar to textual.

All starts from a primaryColor - everything else is derivable from there but possible to be defined in a theme.

This mainly add the color conversions needed + a "theme system" which is nothing but a programmatic typesafe api 
to generate a css that can be used by css system.

Looking for input on it.

Things not yet solved:
- themes/variables not used consistently in widget library today; would need to at least use these names as fallback
- MarkupParser has a styleresolver but we create a new everytime needed; rather than using styles so things dont "listen" to the css applied in componenttree; for now CssMarkupBridge but does not feel rightl
- ansi color interaction; should/could we map ansi index in a terminal theme to semantic names and vice-versa? idea being apps that dont want their own theme will "fit" automatically into  users terminal theme.

details:
Enables theme-independent applications using semantic color names ($primary, $error, etc.) instead of hardcoded values. Applications work with any theme without code changes.

Key features:
- Fluent Color API: color.lighten(0.2f).rotateHue(30).mix(white, 0.3f)
- Theme.generate(): Creates complete palettes from minimal input (inspired by Textual's ColorSystem)
- ColorSpace utilities: HSL/HSV conversion and color manipulation
- CssMarkupBridge: Use CSS variables in markup text [primary]Title[/]
- 7 themes included: Catppuccin, Dracula, Gruvbox, Nord, Tokyo Night, Dark, Light

The fluent API on Color delegates to ColorSpace for implementation, keeping ColorConverter focused on string parsing and ColorSpace on value transformations.

Co-Authored-By: Claude Sonnet 4.5 
