### PR TITLE
feat: make TextInput and TextArea elements binding-aware

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -49,6 +49,7 @@ import dev.tamboui.toolkit.elements.TextElement;
 import dev.tamboui.toolkit.elements.TextInputElement;
 import dev.tamboui.toolkit.elements.TreeElement;
 import dev.tamboui.toolkit.elements.WaveTextElement;
+import dev.tamboui.tui.bindings.Actions;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widget.Widget;
 import dev.tamboui.widgets.form.BooleanFieldState;
@@ -1290,9 +1291,9 @@ public final class Toolkit {
                 state.moveCursorToEnd();
                 return true;
             case CHAR:
-                // Don't consume characters with Ctrl or Alt modifiers - those are control sequences
+                // Check for modifier keys in the active binding set
                 if (event.modifiers().ctrl() || event.modifiers().alt()) {
-                    return false;
+                    return handleTextInputAction(state, event);
                 }
                 char c = event.character();
                 if (c >= 32 && c < 127) {
@@ -1303,6 +1304,40 @@ public final class Toolkit {
             default:
                 return false;
         }
+    }
+
+    private static boolean handleTextInputAction(TextInputState state, KeyEvent event) {
+        if (event.matches(Actions.MOVE_LEFT)) {
+            state.moveCursorLeft();
+            return true;
+        }
+
+        if (event.matches(Actions.MOVE_RIGHT)) {
+            state.moveCursorRight();
+            return true;
+        }
+
+        if (event.matches(Actions.HOME)) {
+            state.moveCursorToStart();
+            return true;
+        }
+
+        if (event.matches(Actions.END)) {
+            state.moveCursorToEnd();
+            return true;
+        }
+
+        if (event.matches(Actions.DELETE_BACKWARD)) {
+            state.deleteBackward();
+            return true;
+        }
+
+        if (event.matches(Actions.DELETE_FORWARD)) {
+            state.deleteForward();
+            return true;
+        }
+
+        return false;
     }
 
 }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -16,6 +16,7 @@ import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.element.Size;
 import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.bindings.Actions;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
@@ -347,9 +348,9 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
                 state.insert("    "); // 4 spaces for tab
                 return true;
             case CHAR:
-                // Don't consume characters with Ctrl or Alt modifiers - those are control sequences
+                // Check for modifier keys in the active binding set
                 if (event.modifiers().ctrl() || event.modifiers().alt()) {
-                    return false;
+                    return handleTextAreaAction(state, event);
                 }
                 char c = event.character();
                 if (c >= 32 && c < 127) {
@@ -360,6 +361,50 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             default:
                 return false;
         }
+    }
+
+    private static boolean handleTextAreaAction(TextAreaState state, KeyEvent event) {
+        if (event.matches(Actions.MOVE_UP)) {
+            state.moveCursorUp();
+            return true;
+        }
+
+        if (event.matches(Actions.MOVE_DOWN)) {
+            state.moveCursorDown();
+            return true;
+        }
+
+        if (event.matches(Actions.MOVE_LEFT)) {
+            state.moveCursorLeft();
+            return true;
+        }
+
+        if (event.matches(Actions.MOVE_RIGHT)) {
+            state.moveCursorRight();
+            return true;
+        }
+
+        if (event.matches(Actions.HOME)) {
+            state.moveCursorToLineStart();
+            return true;
+        }
+
+        if (event.matches(Actions.END)) {
+            state.moveCursorToLineEnd();
+            return true;
+        }
+
+        if (event.matches(Actions.DELETE_BACKWARD)) {
+            state.deleteBackward();
+            return true;
+        }
+
+        if (event.matches(Actions.DELETE_FORWARD)) {
+            state.deleteForward();
+            return true;
+        }
+
+        return false;
     }
 
     @Override

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -20,6 +20,7 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
@@ -349,6 +350,118 @@ class TextAreaElementTest {
 
             assertThat(result).isEqualTo(EventResult.HANDLED);
             assertThat(element.getState().text()).isEqualTo("    ");
+        }
+
+        @Test
+        @DisplayName("Ctrl+P moves cursor up with emacs bindings")
+        void emacsCtrlP() {
+            TextAreaElement element = textArea().text("Line1\nLine2");
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'p', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().cursorRow()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Ctrl+N moves cursor down with emacs bindings")
+        void emacsCtrlN() {
+            TextAreaElement element = textArea().text("Line1\nLine2");
+            element.getState().moveCursorToStart();
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'n', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().cursorRow()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Ctrl+B moves cursor left with emacs bindings")
+        void emacsCtrlB() {
+            TextAreaElement element = textArea().text("Hello");
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'b', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().cursorCol()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("Ctrl+F moves cursor right with emacs bindings")
+        void emacsCtrlF() {
+            TextAreaElement element = textArea().text("Hello");
+            element.getState().moveCursorToStart();
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'f', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().cursorCol()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("Ctrl+A moves cursor to line start with emacs bindings")
+        void emacsCtrlA() {
+            TextAreaElement element = textArea().text("Hello");
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'a', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().cursorCol()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Ctrl+E moves cursor to line end with emacs bindings")
+        void emacsCtrlE() {
+            TextAreaElement element = textArea().text("Hello");
+            element.getState().moveCursorToStart();
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'e', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().cursorCol()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("Ctrl+H deletes backward with emacs bindings")
+        void emacsCtrlH() {
+            TextAreaElement element = textArea().text("Hello");
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'h', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().text()).isEqualTo("Hell");
+        }
+
+        @Test
+        @DisplayName("Ctrl+D deletes forward with emacs bindings")
+        void emacsCtrlD() {
+            TextAreaElement element = textArea().text("Hello");
+            element.getState().moveCursorToStart();
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'd', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.HANDLED);
+            assertThat(element.getState().text()).isEqualTo("ello");
+        }
+
+        @Test
+        @DisplayName("Unbound Ctrl combo returns UNHANDLED")
+        void unboundCtrlCombo() {
+            TextAreaElement element = textArea().text("Hello");
+            KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'z', BindingSets.emacs());
+
+            EventResult result = element.handleKeyEvent(event, true);
+
+            assertThat(result).isEqualTo(EventResult.UNHANDLED);
+            assertThat(element.getState().text()).isEqualTo("Hello");
         }
     }
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextInputElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextInputElementTest.java
@@ -13,6 +13,11 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import dev.tamboui.tui.bindings.BindingSets;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+import dev.tamboui.widgets.input.TextInputState;
 
 import static dev.tamboui.toolkit.Toolkit.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -77,5 +82,92 @@ class TextInputElementTest {
         textInput().placeholder("Enter...").rounded().render(frame, area, context);
 
         assertThat(buffer.get(0, 0).style().fg()).contains(Color.YELLOW);
+    }
+
+    @Test
+    @DisplayName("Ctrl+B moves cursor left with emacs bindings")
+    void ctrlB_emacs_movesCursorLeft() {
+        TextInputState state = new TextInputState("Hello");
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'b', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isTrue();
+        assertThat(state.cursorPosition()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("Ctrl+F moves cursor right with emacs bindings")
+    void ctrlF_emacs_movesCursorRight() {
+        TextInputState state = new TextInputState("Hello");
+        state.moveCursorToStart();
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'f', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isTrue();
+        assertThat(state.cursorPosition()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Ctrl+A moves cursor to start with emacs bindings")
+    void ctrlA_emacs_movesToStart() {
+        TextInputState state = new TextInputState("Hello");
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'a', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isTrue();
+        assertThat(state.cursorPosition()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("Ctrl+E moves cursor to end with emacs bindings")
+    void ctrlE_emacs_movesToEnd() {
+        TextInputState state = new TextInputState("Hello");
+        state.moveCursorToStart();
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'e', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isTrue();
+        assertThat(state.cursorPosition()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("Ctrl+H deletes backward with emacs bindings")
+    void ctrlH_emacs_deletesBackward() {
+        TextInputState state = new TextInputState("Hello");
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'h', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isTrue();
+        assertThat(state.text()).isEqualTo("Hell");
+    }
+
+    @Test
+    @DisplayName("Ctrl+D deletes forward with emacs bindings")
+    void ctrlD_emacs_deletesForward() {
+        TextInputState state = new TextInputState("Hello");
+        state.moveCursorToStart();
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'd', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isTrue();
+        assertThat(state.text()).isEqualTo("ello");
+    }
+
+    @Test
+    @DisplayName("Unbound Ctrl combo is not handled")
+    void unboundCtrl_notHandled() {
+        TextInputState state = new TextInputState("Hello");
+        KeyEvent event = new KeyEvent(KeyCode.CHAR, KeyModifiers.CTRL, 'z', BindingSets.emacs());
+
+        boolean handled = handleTextInputKey(state, event);
+
+        assertThat(handled).isFalse();
+        assertThat(state.text()).isEqualTo("Hello");
     }
 }


### PR DESCRIPTION
TextInputElement and TextAreaElement unconditionally reject all key events with Ctrl/Alt modifiers so configured binding sets are not respected in text editing fields.

This commit checks for modifier keys in the active binding set before rejecting them.