### PR TITLE
WIP: themes/color systems

### DIFF
--- a/.github/actions/shared-build-setup/action.yml
+++ b/.github/actions/shared-build-setup/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: The Java version to use for building
     required: false
     default: '25'
+  github-token:
+    description: 'GitHub token for API rate limiting (e.g. GraalVM download)'
+    required: false
+    default: ${{ github.token }}
   debug_enabled:
     description: 'Run the build with upterm debugging enabled (https://github.com/owenthereal/action-upterm)'
     required: false
@@ -32,7 +36,7 @@ runs:
       with:
         distribution: 'graalvm-community'
         java-version: '${{ inputs.java-version }}'
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ inputs.github-token }}
     - uses: gradle/actions/wrapper-validation@v5
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ docs/video/output
 # AI
 CLAUDE.md
 
+docs/superpowers/plans/

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -95,6 +95,7 @@ These work at any API level:
 * link:layouts.html[Layouts Reference] - Columns, Grid, Dock, Stack, Flow
 * link:markup.html[Markup Text] - BBCode-style text formatting
 * link:styling.html[CSS Styling] - External stylesheets and theming
+* link:themes.html[Themes] - Semantic color palettes with auto-generated shades
 
 == Toolkit DSL
 

--- a/docs/src/docs/asciidoc/themes.adoc
+++ b/docs/src/docs/asciidoc/themes.adoc
@@ -1,0 +1,598 @@
+= Themes
+:doctype: book
+:icons: font
+:source-highlighter: highlight.js
+:toc: left
+:toclevels: 3
+
+include::_attributes.adoc[]
+
+{project-name} includes a theme system that generates a complete color palette from a small set of semantic colors.
+Define a handful of colors — primary, error, success — and the system auto-derives 25+ shades, text colors, and UI colors.
+Themes integrate with both the CSS engine and the Java API.
+
+== Quick Start
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=quick-start,indent=0]
+----
+
+The `ThemeEngine` generates a `ColorSystem` from the theme's semantic palette and injects every color as a TCSS `$variable`.
+Your stylesheet can then reference them:
+
+[source,css]
+----
+Panel {
+    background: $surface;
+    border-color: $border;
+}
+
+Panel:focus {
+    border-color: $border-focus;
+}
+
+.primary {
+    color: $primary;
+    text-style: bold;
+}
+
+.error {
+    color: $error;
+}
+----
+
+Switch themes at runtime and the same stylesheet produces a completely different look — no extra stylesheets required.
+
+== Architecture
+
+The theme system has three layers:
+
+[cols="1,2",options="header"]
+|===
+|Layer |Responsibility
+
+|*Core* (`{core-module}`)
+|`Theme` definition, `ColorSystem` generation, `ThemePropertyResolver`
+
+|*CSS* (`{css-module}`)
+|`ThemeEngine` bridges themes with `StyleEngine` via `$variable` injection
+
+|*Widgets / Toolkit*
+|TCSS files and Java code consume `$primary`, `$border`, etc.
+|===
+
+Data flow:
+
+----
+Theme (7–12 seed colors)
+  → ColorSystem.generate()  →  25+ derived colors
+      ├── CSS path:   ThemeEngine.injectVariables(styleEngine)
+      │                 → TCSS uses $primary, $surface, ...
+      └── Java path:  theme.toResolver()
+                        → resolver.get(ThemeProperties.PRIMARY)
+----
+
+== Semantic Colors
+
+A `Theme` is built from a small set of _semantic_ colors that describe intent rather than appearance:
+
+[cols="1,3,1",options="header"]
+|===
+|Color |Purpose |Required
+
+|`primary`
+|Main brand / accent color — used for focused borders, selection highlights, active elements
+|Yes
+
+|`secondary`
+|Supporting color — used for secondary actions, alternative highlights
+|Yes
+
+|`error`
+|Errors and destructive actions
+|Yes
+
+|`success`
+|Success messages, positive confirmations
+|Yes
+
+|`warning`
+|Caution messages, non-blocking alerts
+|Yes
+
+|`accent`
+|Decorative accent for emphasis (defaults to `primary` if not set)
+|No
+
+|`info`
+|Informational content (defaults to `secondary` if not set)
+|No
+|===
+
+Additionally, themes may specify surface colors for the background hierarchy:
+
+[cols="1,3",options="header"]
+|===
+|Color |Purpose
+
+|`background`
+|App background — the darkest (or lightest) layer
+
+|`surface`
+|Elevated surface — panels, cards, modals
+
+|`panel`
+|Higher-elevation surface — nested containers, toolbars
+
+|`foreground`
+|Default text / content color
+|===
+
+If surface colors are omitted, they are auto-derived from the `dark` flag and `primary` color.
+
+== Generated Color System
+
+Calling `theme.generate()` produces a `ColorSystem` containing all derived colors.
+These are the colors available as TCSS variables (`$name`) and through `ThemeProperties` constants.
+
+=== Base Semantic Colors
+
+[cols="1,3",options="header"]
+|===
+|Variable |Description
+
+|`$primary`
+|Primary brand color
+
+|`$secondary`
+|Secondary brand color
+
+|`$error`
+|Error / danger color
+
+|`$success`
+|Success / positive color
+
+|`$warning`
+|Warning / caution color
+
+|`$accent`
+|Accent color (if defined on theme)
+
+|`$info`
+|Informational color (if defined on theme)
+|===
+
+=== Surface Hierarchy
+
+[cols="1,3",options="header"]
+|===
+|Variable |Description
+
+|`$background`
+|App background (auto-derived: dark → `#121212`, light → `#efefef`)
+
+|`$surface`
+|Elevated surface (auto-derived: dark → `#1e1e1e`, light → `#f5f5f5`)
+
+|`$panel`
+|Panel / toolbar surface (auto-derived: `surface` blended 10% with `primary`)
+
+|`$foreground`
+|Content color (auto-derived: inverse of `background`)
+|===
+
+=== Shade Variants
+
+Each key color gets light, dark, and muted variants generated via HSL manipulation.
+
+[cols="1,3",options="header"]
+|===
+|Variable |Derivation
+
+|`$primary-light`
+|`primary` lightened by `luminositySpread` (default 15%)
+
+|`$primary-dark`
+|`primary` darkened by `luminositySpread`
+
+|`$primary-muted`
+|`primary` blended 70% towards `background`
+
+|`$secondary-light`
+|`secondary` lightened by `luminositySpread`
+
+|`$secondary-dark`
+|`secondary` darkened by `luminositySpread`
+
+|`$secondary-muted`
+|`secondary` blended 70% towards `background`
+
+|`$error-light`
+|`error` lightened by `luminositySpread`
+
+|`$error-dark`
+|`error` darkened by `luminositySpread`
+|===
+
+=== Text Colors
+
+Text colors ensure readable contrast against the background.
+
+[cols="1,3",options="header"]
+|===
+|Variable |Derivation
+
+|`$text`
+|WCAG contrast text for `background` (white on dark themes, black on light)
+
+|`$text-muted`
+|`text` blended 40% towards `background`
+
+|`$text-disabled`
+|`text` blended 62% towards `background`
+
+|`$text-on-primary`
+|WCAG contrast text for `primary` (for text on primary-colored backgrounds)
+|===
+
+=== UI Colors
+
+[cols="1,3",options="header"]
+|===
+|Variable |Derivation
+
+|`$border`
+|`surface` darkened slightly (2.5%)
+
+|`$border-focus`
+|Same as `primary`
+
+|`$border-muted`
+|`surface` darkened very slightly (1%)
+
+|`$selection-bg`
+|`primary` blended 70% towards `background`
+
+|`$hover-bg`
+|`text` blended 96% towards `background` (subtle highlight)
+|===
+
+== Built-in Themes
+
+{project-name} ships with 7 built-in themes registered in `ThemeRegistry`.
+
+=== auto-terminal
+
+Adapts to your terminal's ANSI color scheme.
+Uses named ANSI colors instead of fixed hex values, so the palette changes when you switch terminal themes.
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |ANSI Blue
+|secondary |ANSI Cyan
+|error |ANSI Red
+|success |ANSI Green
+|warning |ANSI Yellow
+|accent |ANSI Light Blue
+|info |ANSI Light Cyan
+|===
+
+=== tamboui-default
+
+Branded cyan/teal theme.
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |`#00ffff`
+|secondary |`#0080ff`
+|error |`#ff6b6b`
+|success |`#4caf50`
+|warning |`#ffeb3b`
+|accent |`#00ffff`
+|info |`#00bcd4`
+|background |`#000000`
+|surface |`#1a1a1a`
+|panel |`#333333`
+|===
+
+=== nord
+
+Arctic, north-bluish palette. Source: https://www.nordtheme.com/[nordtheme.com]
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |`#88c0d0`
+|secondary |`#81a1c1`
+|error |`#bf616a`
+|success |`#a3be8c`
+|warning |`#ebcb8b`
+|accent |`#b48ead`
+|info |`#8fbcbb`
+|background |`#2e3440`
+|surface |`#3b4252`
+|panel |`#434c5e`
+|foreground |`#eceff4`
+|===
+
+=== gruvbox-dark
+
+Retro groove color scheme. Source: https://github.com/morhetz/gruvbox[gruvbox]
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |`#83a598`
+|secondary |`#d3869b`
+|error |`#fb4934`
+|success |`#b8bb26`
+|warning |`#fabd2f`
+|accent |`#fe8019`
+|info |`#8ec07c`
+|background |`#282828`
+|surface |`#3c3836`
+|panel |`#504945`
+|foreground |`#ebdbb2`
+|===
+
+=== dracula
+
+Dark theme with vibrant colors. Source: https://draculatheme.com/[draculatheme.com]
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |`#bd93f9`
+|secondary |`#8be9fd`
+|error |`#ff5555`
+|success |`#50fa7b`
+|warning |`#f1fa8c`
+|accent |`#ff79c6`
+|info |`#8be9fd`
+|background |`#282a36`
+|surface |`#44475a`
+|panel |`#44475a`
+|foreground |`#f8f8f2`
+|===
+
+=== catppuccin-mocha
+
+Soothing pastel theme. Source: https://catppuccin.com/[catppuccin.com]
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |`#89b4fa`
+|secondary |`#cba6f7`
+|error |`#f38ba8`
+|success |`#a6e3a1`
+|warning |`#f9e2af`
+|accent |`#f5c2e7`
+|info |`#94e2d5`
+|background |`#1e1e2e`
+|surface |`#313244`
+|panel |`#45475a`
+|foreground |`#cdd6f4`
+|===
+
+=== tokyo-night
+
+Clean dark theme inspired by Tokyo's night skyline. Source: https://github.com/enkia/tokyo-night-vscode-theme[tokyo-night]
+
+[cols="1,1",options="header"]
+|===
+|Color |Value
+
+|primary |`#7aa2f7`
+|secondary |`#bb9af7`
+|error |`#f7768e`
+|success |`#9ece6a`
+|warning |`#e0af68`
+|accent |`#ff9e64`
+|info |`#7dcfff`
+|background |`#1a1b26`
+|surface |`#24283b`
+|panel |`#414868`
+|foreground |`#a9b1d6`
+|===
+
+== Creating Custom Themes
+
+Use `Theme.Builder` to create a theme and register it:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=custom-theme,indent=0]
+----
+
+=== Builder Options
+
+[cols="1,1,3",options="header"]
+|===
+|Method |Default |Description
+
+|`name(String)`
+|—
+|Theme name (required)
+
+|`dark(boolean)`
+|`true`
+|Controls auto-derivation of surfaces and text colors
+
+|`primary(String\|Color)`
+|—
+|Primary color (required)
+
+|`secondary(String\|Color)`
+|primary
+|Secondary color
+
+|`error(String\|Color)`
+|ANSI Red
+|Error color
+
+|`success(String\|Color)`
+|ANSI Green
+|Success color
+
+|`warning(String\|Color)`
+|ANSI Yellow
+|Warning color
+
+|`accent(String\|Color)`
+|null
+|Optional accent color
+
+|`info(String\|Color)`
+|null
+|Optional info color
+
+|`background(String\|Color)`
+|auto
+|Background color (auto: `#121212` dark / `#efefef` light)
+
+|`surface(String\|Color)`
+|auto
+|Surface color (auto: `#1e1e1e` dark / `#f5f5f5` light)
+
+|`panel(String\|Color)`
+|auto
+|Panel color (auto: surface blended 10% primary)
+
+|`foreground(String\|Color)`
+|auto
+|Foreground color (auto: inverse of background)
+
+|`luminositySpread(float)`
+|`0.15`
+|How much to lighten/darken for shade variants (0.0–1.0)
+
+|`textAlpha(float)`
+|`0.95`
+|Reserved for future text transparency support
+
+|`variable(String, String)`
+|—
+|Override any generated color by name (e.g., `variable("border", "#4c566a")`)
+|===
+
+=== Variable Overrides
+
+Use `variable()` to override any auto-generated color:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=variable-overrides,indent=0]
+----
+
+== Runtime Theme Switching
+
+Switch themes at runtime and re-inject variables:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=theme-switching,indent=0]
+----
+
+== Using Themes Without CSS
+
+Themes work without the CSS engine via `ThemeProperties` and `StylePropertyResolver`:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=without-css,indent=0]
+----
+
+== Color Manipulation
+
+The `Color` interface provides convenience methods for color manipulation, powered by `ColorManipulation`:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=color-manipulation,indent=0]
+----
+
+Low-level color space conversions are available via `ColorManipulation`:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ThemeSnippets.java[tag=color-conversions,indent=0]
+----
+
+== Integration with CSS Stylesheets
+
+=== Theme-Aware Stylesheets
+
+Write a single stylesheet that works with any theme:
+
+[source,css]
+----
+/* All $variables come from the active theme */
+
+* {
+    color: $text;
+}
+
+Row, Column {
+    background: $background;
+}
+
+Panel {
+    background: $surface;
+    border-color: $border;
+}
+
+Panel:focus {
+    border-color: $border-focus;
+    border-type: double;
+}
+
+.primary   { color: $primary; text-style: bold; }
+.secondary { color: $secondary; }
+.error     { color: $error; text-style: bold; }
+.success   { color: $success; }
+.warning   { color: $warning; text-style: bold; }
+.info      { color: $info; }
+.muted     { color: $text-muted; }
+.disabled  { color: $text-disabled; }
+
+ListElement-item:selected {
+    background: $selection-bg;
+    color: $primary;
+    text-style: bold;
+}
+----
+
+=== Mixing Theme Variables with Overrides
+
+User-defined TCSS variables take precedence over theme-injected ones:
+
+[source,css]
+----
+/* Override the theme's primary color for this stylesheet */
+$primary: #ff6600;
+
+.custom-branded {
+    color: $primary;  /* Uses #ff6600, not the theme's primary */
+}
+
+.themed-text {
+    color: $secondary;  /* Still uses theme's secondary */
+}
+----
+
+== Next Steps
+
+* link:styling.html[CSS Styling] — full TCSS reference, selectors, properties
+* link:widgets.html[Widgets Reference] — available components to theme
+* link:developer-guide.html[Developer Guide] — creating custom widgets with theme support

--- a/docs/src/snippets/java/dev/tamboui/docs/snippets/ThemeSnippets.java
+++ b/docs/src/snippets/java/dev/tamboui/docs/snippets/ThemeSnippets.java
@@ -1,0 +1,155 @@
+package dev.tamboui.docs.snippets;
+
+import dev.tamboui.color.ColorManipulation;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.theme.ThemeEngine;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.StylePropertyResolver;
+import dev.tamboui.theme.ColorSystem;
+import dev.tamboui.theme.Theme;
+import dev.tamboui.theme.ThemeProperties;
+import dev.tamboui.theme.ThemeRegistry;
+import dev.tamboui.toolkit.app.ToolkitRunner;
+import dev.tamboui.tui.TuiConfig;
+
+import java.io.IOException;
+
+/**
+ * Code snippets for the Themes documentation page.
+ */
+@SuppressWarnings("unused")
+public class ThemeSnippets {
+
+    // tag::quick-start[]
+    void quickStart() throws Exception {
+        // 1. Create engines
+        StyleEngine styleEngine = StyleEngine.create();
+        styleEngine.loadStylesheet("app", "/app.tcss");
+        styleEngine.setActiveStylesheet("app");
+
+        ThemeEngine themeEngine = new ThemeEngine();
+        themeEngine.setTheme("nord");
+
+        // 2. Inject theme colors as TCSS variables ($primary, $border, etc.)
+        themeEngine.injectVariables(styleEngine);
+
+        // 3. Run with theme-aware stylesheet
+        try (var runner = ToolkitRunner.create(TuiConfig.defaults())) {
+            runner.styleEngine(styleEngine);
+            runner.run(() -> null /* your root element */);
+        }
+    }
+    // end::quick-start[]
+
+    // tag::custom-theme[]
+    void customTheme() {
+        Theme myTheme = new Theme.Builder()
+            .name("my-brand")
+            .primary("#ff6600")
+            .secondary("#0066ff")
+            .error("#cc0000")
+            .success("#00cc44")
+            .warning("#ffaa00")
+            .accent("#ff00ff")
+            .background("#0a0a0a")
+            .surface("#1a1a1a")
+            .dark(true)
+            .build();
+
+        ThemeRegistry.register(myTheme);
+
+        // Now usable by name:
+        ThemeEngine engine = new ThemeEngine();
+        engine.setTheme("my-brand");
+    }
+    // end::custom-theme[]
+
+    // tag::variable-overrides[]
+    void variableOverrides() {
+        Theme nordCustom = new Theme.Builder()
+            .name("nord-custom")
+            .primary("#88c0d0")
+            .secondary("#81a1c1")
+            .error("#bf616a")
+            .success("#a3be8c")
+            .warning("#ebcb8b")
+            .background("#2e3440")
+            .dark(true)
+            // Override auto-generated colors:
+            .variable("border", "#4c566a")
+            .variable("text-muted", "#d8dee9")
+            .variable("text-on-primary", "#2e3440")
+            .build();
+    }
+    // end::variable-overrides[]
+
+    // tag::theme-switching[]
+    void themeSwitching(ThemeEngine themeEngine, StyleEngine styleEngine) {
+        String[] themes = {"nord", "dracula", "catppuccin-mocha", "tokyo-night"};
+        int current = 0;
+
+        // Switch to next theme
+        current = (current + 1) % themes.length;
+        themeEngine.setTheme(themes[current]);
+        themeEngine.injectVariables(styleEngine);
+        // UI re-renders with new theme colors automatically
+    }
+    // end::theme-switching[]
+
+    // tag::without-css[]
+    void withoutCss() {
+        ThemeEngine themeEngine = new ThemeEngine();
+        themeEngine.setTheme("dracula");
+
+        // Access colors via typed properties
+        StylePropertyResolver resolver = themeEngine.getResolver();
+        Color primary = resolver.get(ThemeProperties.PRIMARY).orElse(Color.BLUE);
+        Color border = resolver.get(ThemeProperties.BORDER_FOCUS).orElse(Color.WHITE);
+        Color textMuted = resolver.get(ThemeProperties.TEXT_MUTED).orElse(Color.GRAY);
+
+        // Or access via ColorSystem by name
+        ColorSystem colors = themeEngine.getColorSystem();
+        Color selectionBg = colors.get("selection-bg");
+        Color hoverBg = colors.get("hover-bg");
+    }
+    // end::without-css[]
+
+    // tag::color-manipulation[]
+    void colorManipulation() {
+        Color base = Color.hex("#3366cc");
+
+        // Lighten / darken (HSL space)
+        Color lighter = base.lighten(0.2f);
+        Color darker = base.darken(0.15f);
+
+        // Blend two colors (linear RGB interpolation)
+        Color blended = base.blend(Color.hex("#ff6600"), 0.3f);
+
+        // Get readable text color for a background
+        Color textColor = base.getContrastText();  // white or black
+
+        // Invert
+        Color inverted = base.inverse();
+    }
+    // end::color-manipulation[]
+
+    // tag::color-conversions[]
+    void colorConversions() {
+        // RGB ↔ HSL
+        float[] hsl = ColorManipulation.rgbToHsl(136, 192, 208);  // Nord primary
+        // hsl = [193.3, 43.4, 67.5]  (hue°, saturation%, lightness%)
+
+        int[] rgb = ColorManipulation.hslToRgb(193.3f, 43.4f, 67.5f);
+        // rgb = [136, 192, 208]
+
+        // RGB ↔ HSV
+        float[] hsv = ColorManipulation.rgbToHsv(136, 192, 208);
+        int[] rgb2 = ColorManipulation.hsvToRgb(hsv[0], hsv[1], hsv[2]);
+
+        // Linear interpolation between two colors
+        Color from = Color.hex("#88c0d0");
+        Color to = Color.hex("#bf616a");
+        Color mid = ColorManipulation.lerp(from, to, 0.5f);
+    }
+    // end::color-conversions[]
+}

--- a/docs/video/theme-demo.tape
+++ b/docs/video/theme-demo.tape
@@ -1,0 +1,28 @@
+Source shared_.tape
+
+# Setup
+Hide
+Type "jbang theme-demo"
+Enter
+Sleep 2
+Show
+
+# Recording - cycle through themes
+Sleep 2s
+Type "2"
+Sleep 2s
+Type "3"
+Sleep 2s
+Type "4"
+Sleep 2s
+Type "5"
+Sleep 2s
+Type "6"
+Sleep 2s
+Type "7"
+Sleep 2s
+Type "1"
+Sleep 2s
+
+# Exit
+Type "q"

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -58,6 +58,9 @@
     "stack-demo": {
       "script-ref": "tamboui-core/demos/stack-demo/src/main/java/dev/tamboui/demo/StackDemo.java"
     },
+    "theme-demo": {
+      "script-ref": "tamboui-core/demos/theme-demo/src/main/java/dev/tamboui/demo/ThemeDemo.java"
+    },
     "css-demo": {
       "script-ref": "tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java"
     },

--- a/tamboui-core/demos/theme-demo/build.gradle.kts
+++ b/tamboui-core/demos/theme-demo/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Demo showcasing the Theme system with live theme switching"
+
+demo {
+    displayName = "Theme Switcher"
+    tags = setOf("theme", "colors", "styling")
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.ThemeDemo")
+}

--- a/tamboui-core/demos/theme-demo/src/main/java/dev/tamboui/demo/ThemeDemo.java
+++ b/tamboui-core/demos/theme-demo/src/main/java/dev/tamboui/demo/ThemeDemo.java
@@ -1,0 +1,453 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS dev.tamboui:tamboui-core:LATEST
+//DEPS dev.tamboui:tamboui-widgets:LATEST
+//DEPS dev.tamboui:tamboui-jline3-backend:LATEST
+
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.style.StylePropertyResolver;
+import dev.tamboui.terminal.Backend;
+import dev.tamboui.terminal.BackendFactory;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.terminal.Terminal;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.theme.Theme;
+import dev.tamboui.theme.ThemeProperties;
+import dev.tamboui.theme.ThemeRegistry;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.block.Title;
+import dev.tamboui.widgets.gauge.Gauge;
+import dev.tamboui.widgets.paragraph.Paragraph;
+
+/**
+ * Demo TUI application showcasing the Theme system.
+ * <p>
+ * Demonstrates:
+ * <ul>
+ *   <li>All 7 built-in themes</li>
+ *   <li>Live theme switching with number keys</li>
+ *   <li>Semantic color usage (primary, error, success, etc.)</li>
+ *   <li>Auto-terminal theme adapting to user's terminal colors</li>
+ * </ul>
+ */
+public class ThemeDemo {
+
+    private static final String[] THEME_NAMES = {
+        "auto-terminal",
+        "tamboui-default",
+        "nord",
+        "gruvbox-dark",
+        "dracula",
+        "catppuccin-mocha",
+        "tokyo-night"
+    };
+
+    private boolean running = true;
+    private int currentThemeIndex = 0;
+    private Theme currentTheme;
+    private StylePropertyResolver themeResolver;
+
+    private ThemeDemo() {
+        loadTheme(0);
+    }
+
+    /**
+     * Demo entry point.
+     * @param args the CLI arguments
+     * @throws Exception on unexpected error
+     */
+    public static void main(String[] args) throws Exception {
+        new ThemeDemo().run();
+    }
+
+    /**
+     * Runs the demo application.
+     *
+     * @throws Exception if an error occurs
+     */
+    public void run() throws Exception {
+        try (Backend backend = BackendFactory.create()) {
+            backend.enableRawMode();
+            backend.enterAlternateScreen();
+            backend.hideCursor();
+
+            Terminal<Backend> terminal = new Terminal<>(backend);
+
+            backend.onResize(() -> {
+                terminal.draw(this::ui);
+            });
+
+            while (running) {
+                terminal.draw(this::ui);
+
+                int c = backend.read(100);
+                switch (c) {
+                    case 'q', 'Q', 3 -> running = false;
+                    case '1' -> loadTheme(0);
+                    case '2' -> loadTheme(1);
+                    case '3' -> loadTheme(2);
+                    case '4' -> loadTheme(3);
+                    case '5' -> loadTheme(4);
+                    case '6' -> loadTheme(5);
+                    case '7' -> loadTheme(6);
+                    case 'n', 'N' -> loadTheme((currentThemeIndex + 1) % THEME_NAMES.length);
+                    case 'p', 'P' -> loadTheme((currentThemeIndex - 1 + THEME_NAMES.length) % THEME_NAMES.length);
+                }
+            }
+        }
+    }
+
+    private void loadTheme(int index) {
+        currentThemeIndex = index;
+        currentTheme = ThemeRegistry.get(THEME_NAMES[index])
+            .orElseThrow(() -> new IllegalStateException("Theme not found: " + THEME_NAMES[index]));
+        themeResolver = currentTheme.toResolver();
+    }
+
+    private void ui(Frame frame) {
+        Rect area = frame.area();
+
+        var layout = Layout.vertical()
+            .constraints(
+                Constraint.length(3),
+                Constraint.fill(),
+                Constraint.length(6)
+            )
+            .split(area);
+
+        renderHeader(frame, layout.get(0));
+        renderWidgets(frame, layout.get(1));
+        renderFooter(frame, layout.get(2));
+    }
+
+    private void renderHeader(Frame frame, Rect area) {
+        Color primary = themeResolver.get(ThemeProperties.PRIMARY).orElse(Color.CYAN);
+
+        Block headerBlock = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(primary))
+            .title(Title.from(
+                Line.from(
+                    Span.raw(" TamboUI ").bold().fg(primary),
+                    Span.raw("Theme Demo ").fg(themeResolver.get(ThemeProperties.SECONDARY).orElse(Color.YELLOW)),
+                    Span.raw("[" + THEME_NAMES[currentThemeIndex] + "]").dim()
+                )
+            ).centered())
+            .build();
+
+        frame.renderWidget(headerBlock, area);
+    }
+
+    private void renderWidgets(Frame frame, Rect area) {
+        var layout = Layout.vertical()
+            .constraints(
+                Constraint.percentage(33),
+                Constraint.percentage(33),
+                Constraint.percentage(34)
+            )
+            .split(area);
+
+        var topLayout = Layout.horizontal()
+            .constraints(
+                Constraint.percentage(50),
+                Constraint.percentage(50)
+            )
+            .split(layout.get(0));
+
+        renderNotificationBlocks(frame, topLayout.get(0));
+        renderProgressGauges(frame, topLayout.get(1));
+        renderListWidget(frame, layout.get(1));
+        renderTextStyles(frame, layout.get(2));
+    }
+
+    private void renderNotificationBlocks(Frame frame, Rect area) {
+        Color borderColor = themeResolver.get(ThemeProperties.BORDER).orElse(Color.DARK_GRAY);
+
+        var vLayout = Layout.vertical()
+            .constraints(
+                Constraint.length(5),
+                Constraint.length(5),
+                Constraint.length(5),
+                Constraint.fill()
+            )
+            .split(area);
+
+        // Success notification
+        Color success = themeResolver.get(ThemeProperties.SUCCESS).orElse(Color.GREEN);
+        Block successBlock = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(success))
+            .title(Title.from(Line.from(Span.raw(" ✓ Success ").bold().fg(success))))
+            .build();
+        frame.renderWidget(successBlock, vLayout.get(0));
+        Paragraph successText = Paragraph.builder()
+            .text(Text.from(
+                Line.from(Span.raw(" Operation completed").fg(themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE))),
+                Line.from(Span.raw(" successfully!").fg(themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE)))
+            ))
+            .build();
+        frame.renderWidget(successText, successBlock.inner(vLayout.get(0)));
+
+        // Warning notification
+        Color warning = themeResolver.get(ThemeProperties.WARNING).orElse(Color.YELLOW);
+        Block warningBlock = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(warning))
+            .title(Title.from(Line.from(Span.raw(" ⚠ Warning ").bold().fg(warning))))
+            .build();
+        frame.renderWidget(warningBlock, vLayout.get(1));
+        Paragraph warningText = Paragraph.builder()
+            .text(Text.from(
+                Line.from(Span.raw(" Low disk space").fg(themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE))),
+                Line.from(Span.raw(" detected.").fg(themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE)))
+            ))
+            .build();
+        frame.renderWidget(warningText, warningBlock.inner(vLayout.get(1)));
+
+        // Error notification
+        Color error = themeResolver.get(ThemeProperties.ERROR).orElse(Color.RED);
+        Block errorBlock = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(error))
+            .title(Title.from(Line.from(Span.raw(" ✗ Error ").bold().fg(error))))
+            .build();
+        frame.renderWidget(errorBlock, vLayout.get(2));
+        Paragraph errorText = Paragraph.builder()
+            .text(Text.from(
+                Line.from(Span.raw(" Connection failed").fg(themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE))),
+                Line.from(Span.raw(" to server.").fg(themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE)))
+            ))
+            .build();
+        frame.renderWidget(errorText, errorBlock.inner(vLayout.get(2)));
+    }
+
+    private void renderProgressGauges(Frame frame, Rect area) {
+        Color borderColor = themeResolver.get(ThemeProperties.BORDER).orElse(Color.DARK_GRAY);
+
+        Block block = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(borderColor))
+            .title(Title.from(Line.from(Span.raw(" Progress ").bold())))
+            .build();
+
+        frame.renderWidget(block, area);
+        Rect inner = block.inner(area);
+
+        var vLayout = Layout.vertical()
+            .constraints(
+                Constraint.length(4),
+                Constraint.length(4),
+                Constraint.length(4),
+                Constraint.fill()
+            )
+            .split(inner);
+
+        Color primary = themeResolver.get(ThemeProperties.PRIMARY).orElse(Color.CYAN);
+        Color secondary = themeResolver.get(ThemeProperties.SECONDARY).orElse(Color.MAGENTA);
+        Color accent = themeResolver.get(ThemeProperties.ACCENT).orElse(Color.YELLOW);
+
+        // CPU gauge
+        Gauge cpuGauge = Gauge.builder()
+            .label("CPU")
+            .ratio(0.75)
+            .gaugeStyle(Style.EMPTY.fg(primary))
+            .build();
+        frame.renderWidget(cpuGauge, vLayout.get(0));
+
+        // Memory gauge
+        Gauge memGauge = Gauge.builder()
+            .label("Memory")
+            .ratio(0.45)
+            .gaugeStyle(Style.EMPTY.fg(secondary))
+            .build();
+        frame.renderWidget(memGauge, vLayout.get(1));
+
+        // Disk gauge
+        Gauge diskGauge = Gauge.builder()
+            .label("Disk")
+            .ratio(0.90)
+            .gaugeStyle(Style.EMPTY.fg(accent))
+            .build();
+        frame.renderWidget(diskGauge, vLayout.get(2));
+    }
+
+    private void renderListWidget(Frame frame, Rect area) {
+        Color borderColor = themeResolver.get(ThemeProperties.BORDER).orElse(Color.DARK_GRAY);
+        Color primary = themeResolver.get(ThemeProperties.PRIMARY).orElse(Color.CYAN);
+        Color text = themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE);
+        Color success = themeResolver.get(ThemeProperties.SUCCESS).orElse(Color.GREEN);
+        Color textMuted = themeResolver.get(ThemeProperties.TEXT_MUTED).orElse(Color.DARK_GRAY);
+
+        Block block = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(borderColor))
+            .title(Title.from(Line.from(Span.raw(" Task List ").bold())))
+            .build();
+
+        frame.renderWidget(block, area);
+        Rect inner = block.inner(area);
+
+        Paragraph taskList = Paragraph.builder()
+            .text(Text.from(
+                Line.from(
+                    Span.raw(" ✓ ").fg(success),
+                    Span.raw("Complete theme system core").fg(text)
+                ),
+                Line.from(
+                    Span.raw(" ✓ ").fg(success),
+                    Span.raw("Add CSS integration").fg(text)
+                ),
+                Line.from(
+                    Span.raw(" ▶ ").fg(primary),
+                    Span.raw("Build interactive demo").fg(text).bold()
+                ),
+                Line.from(
+                    Span.raw("   ").fg(text),
+                    Span.raw("Update documentation").fg(textMuted)
+                ),
+                Line.from(
+                    Span.raw("   ").fg(text),
+                    Span.raw("Add more themes").fg(textMuted)
+                )
+            ))
+            .build();
+
+        frame.renderWidget(taskList, inner);
+    }
+
+    private void renderTextStyles(Frame frame, Rect area) {
+        Color borderColor = themeResolver.get(ThemeProperties.BORDER).orElse(Color.DARK_GRAY);
+
+        Block block = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(borderColor))
+            .title(Title.from(Line.from(Span.raw(" Text Styles ").bold())))
+            .build();
+
+        frame.renderWidget(block, area);
+        Rect inner = block.inner(area);
+
+        Color primary = themeResolver.get(ThemeProperties.PRIMARY).orElse(Color.CYAN);
+        Color secondary = themeResolver.get(ThemeProperties.SECONDARY).orElse(Color.MAGENTA);
+        Color text = themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE);
+        Color textMuted = themeResolver.get(ThemeProperties.TEXT_MUTED).orElse(Color.DARK_GRAY);
+        Color accent = themeResolver.get(ThemeProperties.ACCENT).orElse(Color.YELLOW);
+
+        Paragraph textDemo = Paragraph.builder()
+            .text(Text.from(
+                Line.from(
+                    Span.raw("Primary: ").fg(textMuted),
+                    Span.raw("The quick brown fox ").fg(primary).bold()
+                ),
+                Line.from(
+                    Span.raw("Secondary: ").fg(textMuted),
+                    Span.raw("jumps over the lazy ").fg(secondary).italic()
+                ),
+                Line.from(
+                    Span.raw("Accent: ").fg(textMuted),
+                    Span.raw("dog every morning ").fg(accent).underlined()
+                ),
+                Line.from(
+                    Span.raw("Normal: ").fg(textMuted),
+                    Span.raw("Regular text example ").fg(text)
+                ),
+                Line.from(
+                    Span.raw("Muted: ").fg(textMuted),
+                    Span.raw("Subtle text for hints ").fg(textMuted)
+                )
+            ))
+            .build();
+
+        frame.renderWidget(textDemo, inner);
+    }
+
+    private void renderFooter(Frame frame, Rect area) {
+        Color textColor = themeResolver.get(ThemeProperties.TEXT).orElse(Color.WHITE);
+        Color mutedColor = themeResolver.get(ThemeProperties.TEXT_MUTED).orElse(Color.DARK_GRAY);
+        Color primaryColor = themeResolver.get(ThemeProperties.PRIMARY).orElse(Color.CYAN);
+
+        Block block = Block.builder()
+            .borders(Borders.ALL)
+            .borderType(BorderType.ROUNDED)
+            .borderStyle(Style.EMPTY.fg(themeResolver.get(ThemeProperties.BORDER).orElse(Color.DARK_GRAY)))
+            .build();
+
+        frame.renderWidget(block, area);
+        Rect inner = block.inner(area);
+
+        var vLayout = Layout.vertical()
+            .constraints(
+                Constraint.length(1),
+                Constraint.length(1),
+                Constraint.length(1),
+                Constraint.length(1)
+            )
+            .split(inner);
+
+        Line line1 = Line.from(
+            Span.raw(" Themes: ").fg(textColor),
+            Span.raw("1").bold().fg(primaryColor),
+            Span.raw(" Auto  ").fg(mutedColor),
+            Span.raw("2").bold().fg(primaryColor),
+            Span.raw(" Default  ").fg(mutedColor),
+            Span.raw("3").bold().fg(primaryColor),
+            Span.raw(" Nord  ").fg(mutedColor),
+            Span.raw("4").bold().fg(primaryColor),
+            Span.raw(" Gruvbox  ").fg(mutedColor),
+            Span.raw("5").bold().fg(primaryColor),
+            Span.raw(" Dracula").fg(mutedColor)
+        );
+
+        Line line2 = Line.from(
+            Span.raw("         ").fg(textColor),
+            Span.raw("6").bold().fg(primaryColor),
+            Span.raw(" Catppuccin  ").fg(mutedColor),
+            Span.raw("7").bold().fg(primaryColor),
+            Span.raw(" Tokyo Night").fg(mutedColor)
+        );
+
+        Line line3 = Line.from(
+            Span.raw(" Navigate: ").fg(textColor),
+            Span.raw("n").bold().fg(primaryColor),
+            Span.raw("/").fg(mutedColor),
+            Span.raw("p").bold().fg(primaryColor),
+            Span.raw(" Next/Prev  ").fg(mutedColor),
+            Span.raw("q").bold().fg(primaryColor),
+            Span.raw(" Quit").fg(mutedColor)
+        );
+
+        Line line4 = Line.from(
+            Span.raw(" Widgets showcase semantic colors, text styles, and theme-aware components").fg(mutedColor).dim()
+        );
+
+        Paragraph footer1 = Paragraph.builder().text(Text.from(line1)).build();
+        Paragraph footer2 = Paragraph.builder().text(Text.from(line2)).build();
+        Paragraph footer3 = Paragraph.builder().text(Text.from(line3)).build();
+        Paragraph footer4 = Paragraph.builder().text(Text.from(line4)).build();
+
+        frame.renderWidget(footer1, vLayout.get(0));
+        frame.renderWidget(footer2, vLayout.get(1));
+        frame.renderWidget(footer3, vLayout.get(2));
+        frame.renderWidget(footer4, vLayout.get(3));
+    }
+}

--- a/tamboui-core/src/main/java/dev/tamboui/color/ColorManipulation.java
+++ b/tamboui-core/src/main/java/dev/tamboui/color/ColorManipulation.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.color;
+
+import dev.tamboui.style.Color;
+
+/**
+ * Color manipulation operations and color space conversions.
+ * <p>
+ * Provides both low-level color space conversions (RGB/HSL/HSV) and
+ * high-level semantic operations (lighten, darken, blend, contrast).
+ */
+public final class ColorManipulation {
+
+    private ColorManipulation() {
+        // Utility class
+    }
+
+    // ===== Low-Level Color Space Conversions =====
+
+    /**
+     * Converts RGB to HSL color space.
+     *
+     * @param r red component (0-255)
+     * @param g green component (0-255)
+     * @param b blue component (0-255)
+     * @return array [hue (0-360), saturation (0-100), lightness (0-100)]
+     */
+    public static float[] rgbToHsl(int r, int g, int b) {
+        float rf = r / 255.0f;
+        float gf = g / 255.0f;
+        float bf = b / 255.0f;
+
+        float max = Math.max(rf, Math.max(gf, bf));
+        float min = Math.min(rf, Math.min(gf, bf));
+        float delta = max - min;
+
+        // Lightness
+        float l = (max + min) / 2.0f;
+
+        // Saturation
+        float s;
+        if (delta == 0.0f) {
+            s = 0.0f;
+        } else {
+            s = delta / (1.0f - Math.abs(2.0f * l - 1.0f));
+        }
+
+        // Hue
+        float h;
+        if (delta == 0.0f) {
+            h = 0.0f;
+        } else if (max == rf) {
+            h = 60.0f * (((gf - bf) / delta) % 6.0f);
+        } else if (max == gf) {
+            h = 60.0f * ((bf - rf) / delta + 2.0f);
+        } else {
+            h = 60.0f * ((rf - gf) / delta + 4.0f);
+        }
+
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+
+        return new float[]{h, s * 100.0f, l * 100.0f};
+    }
+
+    /**
+     * Converts HSL to RGB color space.
+     *
+     * @param h hue in degrees (0-360)
+     * @param s saturation percentage (0-100)
+     * @param l lightness percentage (0-100)
+     * @return array [red (0-255), green (0-255), blue (0-255)]
+     */
+    public static int[] hslToRgb(float h, float s, float l) {
+        h = h % 360.0f;
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+        s = s / 100.0f;
+        l = l / 100.0f;
+
+        float c = (1.0f - Math.abs(2.0f * l - 1.0f)) * s;
+        float x = c * (1.0f - Math.abs((h / 60.0f) % 2.0f - 1.0f));
+        float m = l - c / 2.0f;
+
+        float r, g, b;
+        if (h < 60.0f) {
+            r = c; g = x; b = 0.0f;
+        } else if (h < 120.0f) {
+            r = x; g = c; b = 0.0f;
+        } else if (h < 180.0f) {
+            r = 0.0f; g = c; b = x;
+        } else if (h < 240.0f) {
+            r = 0.0f; g = x; b = c;
+        } else if (h < 300.0f) {
+            r = x; g = 0.0f; b = c;
+        } else {
+            r = c; g = 0.0f; b = x;
+        }
+
+        return new int[]{
+            Math.round((r + m) * 255.0f),
+            Math.round((g + m) * 255.0f),
+            Math.round((b + m) * 255.0f)
+        };
+    }
+
+    /**
+     * Converts RGB to HSV color space.
+     *
+     * @param r red component (0-255)
+     * @param g green component (0-255)
+     * @param b blue component (0-255)
+     * @return array [hue (0-360), saturation (0-100), value (0-100)]
+     */
+    public static float[] rgbToHsv(int r, int g, int b) {
+        float rf = r / 255.0f;
+        float gf = g / 255.0f;
+        float bf = b / 255.0f;
+
+        float max = Math.max(rf, Math.max(gf, bf));
+        float min = Math.min(rf, Math.min(gf, bf));
+        float delta = max - min;
+
+        // Hue
+        float h;
+        if (delta == 0.0f) {
+            h = 0.0f;
+        } else if (max == rf) {
+            h = 60.0f * (((gf - bf) / delta) % 6.0f);
+        } else if (max == gf) {
+            h = 60.0f * ((bf - rf) / delta + 2.0f);
+        } else {
+            h = 60.0f * ((rf - gf) / delta + 4.0f);
+        }
+
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+
+        // Saturation
+        float s = max == 0.0f ? 0.0f : delta / max;
+
+        // Value
+        float v = max;
+
+        return new float[]{h, s * 100.0f, v * 100.0f};
+    }
+
+    /**
+     * Converts HSV to RGB color space.
+     *
+     * @param h hue in degrees (0-360)
+     * @param s saturation percentage (0-100)
+     * @param v value/brightness percentage (0-100)
+     * @return array [red (0-255), green (0-255), blue (0-255)]
+     */
+    public static int[] hsvToRgb(float h, float s, float v) {
+        h = h % 360.0f;
+        if (h < 0.0f) {
+            h += 360.0f;
+        }
+        s = s / 100.0f;
+        v = v / 100.0f;
+
+        float c = v * s;
+        float x = c * (1.0f - Math.abs((h / 60.0f) % 2.0f - 1.0f));
+        float m = v - c;
+
+        float r, g, b;
+        if (h < 60.0f) {
+            r = c; g = x; b = 0.0f;
+        } else if (h < 120.0f) {
+            r = x; g = c; b = 0.0f;
+        } else if (h < 180.0f) {
+            r = 0.0f; g = c; b = x;
+        } else if (h < 240.0f) {
+            r = 0.0f; g = x; b = c;
+        } else if (h < 300.0f) {
+            r = x; g = 0.0f; b = c;
+        } else {
+            r = c; g = 0.0f; b = x;
+        }
+
+        return new int[]{
+            Math.round((r + m) * 255.0f),
+            Math.round((g + m) * 255.0f),
+            Math.round((b + m) * 255.0f)
+        };
+    }
+
+    /**
+     * Linear interpolation between two colors in RGB space.
+     *
+     * @param from starting color
+     * @param to target color
+     * @param alpha interpolation factor (0.0 to 1.0)
+     * @return interpolated color
+     */
+    public static Color lerp(Color from, Color to, float alpha) {
+        alpha = Math.max(0.0f, Math.min(1.0f, alpha));
+
+        if (alpha == 0.0f) return from;
+        if (alpha == 1.0f) return to;
+
+        Color.Rgb fromRgb = from.toRgb();
+        Color.Rgb toRgb = to.toRgb();
+
+        int r = Math.round(fromRgb.r() + (toRgb.r() - fromRgb.r()) * alpha);
+        int g = Math.round(fromRgb.g() + (toRgb.g() - fromRgb.g()) * alpha);
+        int b = Math.round(fromRgb.b() + (toRgb.b() - fromRgb.b()) * alpha);
+
+        return Color.rgb(r, g, b);
+    }
+
+    // ===== High-Level Color Manipulation =====
+
+    /**
+     * Lightens a color by increasing its lightness in HSL space.
+     *
+     * @param color the color to lighten
+     * @param amount amount to increase lightness (0.0 to 1.0)
+     * @return lightened color
+     * @throws IllegalArgumentException if color is null or amount is out of range
+     */
+    public static Color lighten(Color color, float amount) {
+        if (color == null) {
+            throw new IllegalArgumentException("color cannot be null");
+        }
+        if (amount < 0.0f || amount > 1.0f) {
+            throw new IllegalArgumentException("amount must be between 0.0 and 1.0, got: " + amount);
+        }
+
+        Color.Rgb rgb = color.toRgb();
+        float[] hsl = rgbToHsl(rgb.r(), rgb.g(), rgb.b());
+
+        float newL = Math.min(100.0f, hsl[2] + amount * 100.0f);
+        int[] newRgb = hslToRgb(hsl[0], hsl[1], newL);
+
+        return Color.rgb(newRgb[0], newRgb[1], newRgb[2]);
+    }
+
+    /**
+     * Darkens a color by decreasing its lightness in HSL space.
+     *
+     * @param color the color to darken
+     * @param amount amount to decrease lightness (0.0 to 1.0)
+     * @return darkened color
+     * @throws IllegalArgumentException if color is null or amount is out of range
+     */
+    public static Color darken(Color color, float amount) {
+        if (color == null) {
+            throw new IllegalArgumentException("color cannot be null");
+        }
+        if (amount < 0.0f || amount > 1.0f) {
+            throw new IllegalArgumentException("amount must be between 0.0 and 1.0, got: " + amount);
+        }
+
+        Color.Rgb rgb = color.toRgb();
+        float[] hsl = rgbToHsl(rgb.r(), rgb.g(), rgb.b());
+
+        float newL = Math.max(0.0f, hsl[2] - amount * 100.0f);
+        int[] newRgb = hslToRgb(hsl[0], hsl[1], newL);
+
+        return Color.rgb(newRgb[0], newRgb[1], newRgb[2]);
+    }
+
+    /**
+     * Blends two colors using linear RGB interpolation.
+     *
+     * @param base the base color
+     * @param other the color to blend with
+     * @param ratio blend ratio (0.0 = all base, 1.0 = all other)
+     * @return blended color
+     * @throws IllegalArgumentException if base or other is null
+     */
+    public static Color blend(Color base, Color other, float ratio) {
+        if (base == null) {
+            throw new IllegalArgumentException("base cannot be null");
+        }
+        if (other == null) {
+            throw new IllegalArgumentException("other cannot be null");
+        }
+
+        ratio = Math.max(0.0f, Math.min(1.0f, ratio));
+
+        Color.Rgb baseRgb = base.toRgb();
+        Color.Rgb otherRgb = other.toRgb();
+
+        int r = Math.round(baseRgb.r() + (otherRgb.r() - baseRgb.r()) * ratio);
+        int g = Math.round(baseRgb.g() + (otherRgb.g() - baseRgb.g()) * ratio);
+        int b = Math.round(baseRgb.b() + (otherRgb.b() - baseRgb.b()) * ratio);
+
+        return Color.rgb(r, g, b);
+    }
+
+    /**
+     * Returns a contrasting text color (black or white) based on background luminance.
+     * Uses WCAG relative luminance calculation.
+     *
+     * @param background the background color
+     * @return white for dark backgrounds, black for light backgrounds
+     * @throws IllegalArgumentException if background is null
+     */
+    public static Color getContrastText(Color background) {
+        if (background == null) {
+            throw new IllegalArgumentException("background cannot be null");
+        }
+
+        Color.Rgb rgb = background.toRgb();
+
+        // Calculate relative luminance (WCAG formula)
+        double r = rgb.r() / 255.0;
+        double g = rgb.g() / 255.0;
+        double b = rgb.b() / 255.0;
+
+        // Apply gamma correction
+        r = r <= 0.03928 ? r / 12.92 : Math.pow((r + 0.055) / 1.055, 2.4);
+        g = g <= 0.03928 ? g / 12.92 : Math.pow((g + 0.055) / 1.055, 2.4);
+        b = b <= 0.03928 ? b / 12.92 : Math.pow((b + 0.055) / 1.055, 2.4);
+
+        double luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+
+        // Return white for dark backgrounds, black for light backgrounds
+        return luminance > 0.5 ? Color.rgb(0, 0, 0) : Color.rgb(255, 255, 255);
+    }
+
+    /**
+     * Inverts a color by flipping RGB components.
+     *
+     * @param color the color to invert
+     * @return inverted color
+     * @throws IllegalArgumentException if color is null
+     */
+    public static Color inverse(Color color) {
+        if (color == null) {
+            throw new IllegalArgumentException("color cannot be null");
+        }
+
+        Color.Rgb rgb = color.toRgb();
+        return Color.rgb(255 - rgb.r(), 255 - rgb.g(), 255 - rgb.b());
+    }
+
+    /**
+     * Applies alpha/transparency to a color.
+     * Note: Current Color interface doesn't support alpha, so this is a no-op.
+     * Reserved for future RGBA support.
+     *
+     * @param color the base color
+     * @param alpha alpha value (0.0 to 1.0)
+     * @return the color (unchanged until RGBA support added)
+     * @throws IllegalArgumentException if color is null
+     */
+    public static Color withAlpha(Color color, float alpha) {
+        if (color == null) {
+            throw new IllegalArgumentException("color cannot be null");
+        }
+
+        // TODO: Implement when Color supports RGBA
+        return color;
+    }
+}

--- a/tamboui-core/src/main/java/dev/tamboui/style/Color.java
+++ b/tamboui-core/src/main/java/dev/tamboui/style/Color.java
@@ -4,6 +4,8 @@
  */
 package dev.tamboui.style;
 
+import dev.tamboui.color.ColorManipulation;
+
 /**
  * Terminal colors supporting ANSI 16, 256-color indexed, and RGB true color modes.
  */
@@ -500,6 +502,66 @@ public interface Color {
      */
     default Rgb toRgb() {
         return new Rgb(255, 255, 255);
+    }
+
+    /**
+     * Lightens this color by increasing its lightness in HSL space.
+     *
+     * @param amount amount to increase lightness (0.0 to 1.0)
+     * @return lightened color
+     */
+    default Color lighten(float amount) {
+        return ColorManipulation.lighten(this, amount);
+    }
+
+    /**
+     * Darkens this color by decreasing its lightness in HSL space.
+     *
+     * @param amount amount to decrease lightness (0.0 to 1.0)
+     * @return darkened color
+     */
+    default Color darken(float amount) {
+        return ColorManipulation.darken(this, amount);
+    }
+
+    /**
+     * Blends this color with another using linear RGB interpolation.
+     *
+     * @param other the color to blend with
+     * @param ratio blend ratio (0.0 = all this, 1.0 = all other)
+     * @return blended color
+     */
+    default Color blend(Color other, float ratio) {
+        return ColorManipulation.blend(this, other, ratio);
+    }
+
+    /**
+     * Returns a contrasting text color (black or white) for this background.
+     *
+     * @return white for dark backgrounds, black for light backgrounds
+     */
+    default Color getContrastText() {
+        return ColorManipulation.getContrastText(this);
+    }
+
+    /**
+     * Inverts this color by flipping RGB components.
+     *
+     * @return inverted color
+     */
+    default Color inverse() {
+        return ColorManipulation.inverse(this);
+    }
+
+    /**
+     * Applies alpha/transparency to this color.
+     * Note: Reserved for future RGBA support, currently returns unchanged.
+     *
+     * @param alpha alpha value (0.0 to 1.0)
+     * @return the color (unchanged until RGBA support added)
+     */
+    default Color withAlpha(float alpha) {
+        return ColorManipulation.withAlpha(this, alpha);
     }
 
     /**

--- a/tamboui-core/src/main/java/dev/tamboui/theme/ColorSystem.java
+++ b/tamboui-core/src/main/java/dev/tamboui/theme/ColorSystem.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.theme;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import dev.tamboui.style.Color;
+
+/**
+ * Generated color palette from a theme.
+ * <p>
+ * Contains ~20-30 derived colors organized into categories:
+ * <ul>
+ *   <li>Base semantic: primary, secondary, error, success, warning, accent, info</li>
+ *   <li>Surface hierarchy: background, surface, panel, foreground</li>
+ *   <li>Shades: primary-light, primary-dark, primary-muted (similar for others)</li>
+ *   <li>Text: text, text-muted, text-disabled, text-on-primary</li>
+ *   <li>UI: border, border-focus, border-muted, selection-bg, hover-bg</li>
+ * </ul>
+ * <p>
+ * Access colors by name via {@link #get(String)}.
+ */
+public final class ColorSystem {
+
+    private final Map<String, Color> colors;
+
+    ColorSystem(Map<String, Color> colors) {
+        this.colors = Collections.unmodifiableMap(new HashMap<>(colors));
+    }
+
+    /**
+     * Gets a color by name.
+     *
+     * @param name the color name (e.g., "primary", "border-focus")
+     * @return the color, or null if not found
+     */
+    public Color get(String name) {
+        return colors.get(name);
+    }
+
+    /**
+     * Returns all color names in this system.
+     *
+     * @return set of color names
+     */
+    public Set<String> colorNames() {
+        return colors.keySet();
+    }
+
+    /**
+     * Checks if a color exists in this system.
+     *
+     * @param name the color name
+     * @return true if the color exists
+     */
+    public boolean has(String name) {
+        return colors.containsKey(name);
+    }
+}

--- a/tamboui-core/src/main/java/dev/tamboui/theme/Theme.java
+++ b/tamboui-core/src/main/java/dev/tamboui/theme/Theme.java
@@ -224,12 +224,14 @@ public final class Theme {
         // TODO: Add success/warning shades when widgets need them
 
         // 5. Generate text colors
-        Color contrastText = effectiveBg.getContrastText();
-        colors.put("text", getOrVariable("text", contrastText));
+        // Use the theme's foreground color as the base text color rather than
+        // a pure black/white contrast.  Themes like Nord (#eceff4) and
+        // Catppuccin (#cdd6f4) intentionally use softer foreground tones.
+        colors.put("text", getOrVariable("text", effectiveFg));
         colors.put("text-muted", getOrVariable("text-muted",
-            contrastText.blend(effectiveBg, 0.4f)));
+            effectiveFg.blend(effectiveBg, 0.4f)));
         colors.put("text-disabled", getOrVariable("text-disabled",
-            contrastText.blend(effectiveBg, 0.62f)));
+            effectiveFg.blend(effectiveBg, 0.62f)));
         colors.put("text-on-primary", getOrVariable("text-on-primary",
             primary.getContrastText()));
 
@@ -243,7 +245,7 @@ public final class Theme {
         colors.put("selection-bg", getOrVariable("selection-bg",
             primary.blend(effectiveBg, 0.7f)));
         colors.put("hover-bg", getOrVariable("hover-bg",
-            contrastText.blend(effectiveBg, 0.96f)));
+            effectiveFg.blend(effectiveBg, 0.96f)));
 
         // TODO: scrollbar colors when ScrollBar widget implemented
         // TODO: link colors when Link widget implemented

--- a/tamboui-core/src/main/java/dev/tamboui/theme/Theme.java
+++ b/tamboui-core/src/main/java/dev/tamboui/theme/Theme.java
@@ -1,0 +1,591 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.theme;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.StylePropertyResolver;
+
+/**
+ * Defines a theme with semantic colors and generation parameters.
+ * <p>
+ * A theme consists of:
+ * <ul>
+ *   <li>Semantic colors (primary, secondary, error, success, warning, etc.)</li>
+ *   <li>Generation parameters (luminositySpread, textAlpha)</li>
+ *   <li>Optional override variables for specific colors/properties</li>
+ * </ul>
+ * <p>
+ * Themes are immutable. Use {@link Builder} to construct instances.
+ *
+ * @see ColorSystem
+ * @see ThemeRegistry
+ */
+public final class Theme {
+
+    private final String name;
+    private final boolean dark;
+
+    // Semantic colors
+    private final Color primary;
+    private final Color secondary;
+    private final Color error;
+    private final Color success;
+    private final Color warning;
+    private final Color accent;
+    private final Color info;
+
+    // Surface colors
+    private final Color background;
+    private final Color surface;
+    private final Color panel;
+    private final Color foreground;
+
+    // Generation parameters
+    private final float luminositySpread;
+    private final float textAlpha;
+
+    // Override variables
+    private final Map<String, String> variables;
+
+    private Theme(Builder builder) {
+        this.name = builder.name;
+        this.dark = builder.dark;
+        this.primary = builder.primary;
+        this.secondary = builder.secondary;
+        this.error = builder.error;
+        this.success = builder.success;
+        this.warning = builder.warning;
+        this.accent = builder.accent;
+        this.info = builder.info;
+        this.background = builder.background;
+        this.surface = builder.surface;
+        this.panel = builder.panel;
+        this.foreground = builder.foreground;
+        this.luminositySpread = builder.luminositySpread;
+        this.textAlpha = builder.textAlpha;
+        this.variables = Collections.unmodifiableMap(new HashMap<>(builder.variables));
+    }
+
+    /**
+     * Gets the theme name.
+     * @return the theme name
+     */
+    public String name() { return name; }
+
+    /**
+     * Checks whether this is a dark theme.
+     * @return whether this is a dark theme
+     */
+    public boolean dark() { return dark; }
+
+    /**
+     * Gets the primary semantic color.
+     * @return primary semantic color
+     */
+    public Color primary() { return primary; }
+
+    /**
+     * Gets the secondary semantic color.
+     * @return secondary semantic color
+     */
+    public Color secondary() { return secondary; }
+
+    /**
+     * Gets the error semantic color.
+     * @return error semantic color
+     */
+    public Color error() { return error; }
+
+    /**
+     * Gets the success semantic color.
+     * @return success semantic color
+     */
+    public Color success() { return success; }
+
+    /**
+     * Gets the warning semantic color.
+     * @return warning semantic color
+     */
+    public Color warning() { return warning; }
+
+    /**
+     * Gets the accent semantic color.
+     * @return accent semantic color
+     */
+    public Color accent() { return accent; }
+
+    /**
+     * Gets the info semantic color.
+     * @return info semantic color
+     */
+    public Color info() { return info; }
+
+    /**
+     * Gets the background surface color.
+     * @return background surface color
+     */
+    public Color background() { return background; }
+
+    /**
+     * Gets the surface color.
+     * @return surface color
+     */
+    public Color surface() { return surface; }
+
+    /**
+     * Gets the panel color.
+     * @return panel color
+     */
+    public Color panel() { return panel; }
+
+    /**
+     * Gets the foreground color.
+     * @return foreground color
+     */
+    public Color foreground() { return foreground; }
+
+    /**
+     * Gets the luminosity spread for color derivation.
+     * @return luminosity spread for color derivation (0.0-1.0)
+     */
+    public float luminositySpread() { return luminositySpread; }
+
+    /**
+     * Gets the text alpha for muted text.
+     * @return text alpha for muted text (0.0-1.0)
+     */
+    public float textAlpha() { return textAlpha; }
+
+    /**
+     * Gets the custom CSS variable overrides.
+     * @return custom CSS variable overrides
+     */
+    public Map<String, String> variables() { return variables; }
+
+    /**
+     * Generates a ColorSystem from this theme.
+     *
+     * @return generated color system with ~20-30 derived colors
+     */
+    public ColorSystem generate() {
+        Map<String, Color> colors = new HashMap<>();
+
+        // 1. Apply defaults for nullable colors
+        Color effectiveBg = background != null ? background :
+            (dark ? Color.hex("#121212") : Color.hex("#efefef"));
+        Color effectiveSurface = surface != null ? surface :
+            (dark ? Color.hex("#1e1e1e") : Color.hex("#f5f5f5"));
+        Color effectiveFg = foreground != null ? foreground :
+            effectiveBg.inverse();
+        Color effectivePanel = panel != null ? panel :
+            effectiveSurface.blend(primary, 0.1f);
+
+        // 2. Store base semantic colors
+        colors.put("primary", primary);
+        colors.put("secondary", secondary);
+        colors.put("error", error);
+        colors.put("success", success);
+        colors.put("warning", warning);
+        if (accent != null) colors.put("accent", accent);
+        if (info != null) colors.put("info", info);
+
+        // 3. Store surface hierarchy
+        colors.put("background", effectiveBg);
+        colors.put("surface", effectiveSurface);
+        colors.put("panel", effectivePanel);
+        colors.put("foreground", effectiveFg);
+
+        // 4. Generate shades (light/dark/muted variants)
+        colors.put("primary-light", getOrVariable("primary-light",
+            primary.lighten(luminositySpread)));
+        colors.put("primary-dark", getOrVariable("primary-dark",
+            primary.darken(luminositySpread)));
+        colors.put("primary-muted", getOrVariable("primary-muted",
+            primary.blend(effectiveBg, 0.7f)));
+
+        colors.put("secondary-light", getOrVariable("secondary-light",
+            secondary.lighten(luminositySpread)));
+        colors.put("secondary-dark", getOrVariable("secondary-dark",
+            secondary.darken(luminositySpread)));
+        colors.put("secondary-muted", getOrVariable("secondary-muted",
+            secondary.blend(effectiveBg, 0.7f)));
+
+        colors.put("error-light", getOrVariable("error-light",
+            error.lighten(luminositySpread)));
+        colors.put("error-dark", getOrVariable("error-dark",
+            error.darken(luminositySpread)));
+
+        // TODO: Add success/warning shades when widgets need them
+
+        // 5. Generate text colors
+        Color contrastText = effectiveBg.getContrastText();
+        colors.put("text", getOrVariable("text", contrastText));
+        colors.put("text-muted", getOrVariable("text-muted",
+            contrastText.blend(effectiveBg, 0.4f)));
+        colors.put("text-disabled", getOrVariable("text-disabled",
+            contrastText.blend(effectiveBg, 0.62f)));
+        colors.put("text-on-primary", getOrVariable("text-on-primary",
+            primary.getContrastText()));
+
+        // 6. Generate UI colors
+        colors.put("border", getOrVariable("border",
+            effectiveSurface.darken(0.025f)));
+        colors.put("border-focus", getOrVariable("border-focus", primary));
+        colors.put("border-muted", getOrVariable("border-muted",
+            effectiveSurface.darken(0.01f)));
+
+        colors.put("selection-bg", getOrVariable("selection-bg",
+            primary.blend(effectiveBg, 0.7f)));
+        colors.put("hover-bg", getOrVariable("hover-bg",
+            contrastText.blend(effectiveBg, 0.96f)));
+
+        // TODO: scrollbar colors when ScrollBar widget implemented
+        // TODO: link colors when Link widget implemented
+
+        return new ColorSystem(colors);
+    }
+
+    private Color getOrVariable(String name, Color generated) {
+        if (variables.containsKey(name)) {
+            return Color.hex(variables.get(name));
+        }
+        return generated;
+    }
+
+    /**
+     * Creates a StylePropertyResolver from this theme.
+     *
+     * @return property resolver for querying theme colors
+     */
+    public StylePropertyResolver toResolver() {
+        ColorSystem system = generate();
+        return new ThemePropertyResolver(system, this.variables);
+    }
+
+    /**
+     * Builder for constructing Theme instances.
+     */
+    public static final class Builder {
+        private String name;
+        private boolean dark = true;
+        private Color primary;
+        private Color secondary;
+        private Color error;
+        private Color success;
+        private Color warning;
+        private Color accent;
+        private Color info;
+        private Color background;
+        private Color surface;
+        private Color panel;
+        private Color foreground;
+        private float luminositySpread = 0.15f;
+        private float textAlpha = 0.95f;
+        private Map<String, String> variables = new HashMap<>();
+
+        /**
+         * Creates a new builder.
+         */
+        public Builder() {
+        }
+
+        /**
+         * Sets the theme name.
+         * @param name theme name
+         * @return this builder
+         */
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        /**
+         * Sets whether this is a dark theme.
+         * @param dark whether this is a dark theme
+         * @return this builder
+         */
+        public Builder dark(boolean dark) {
+            this.dark = dark;
+            return this;
+        }
+
+        /**
+         * Sets the primary color from hex string.
+         * @param hex primary color as hex string
+         * @return this builder
+         */
+        public Builder primary(String hex) {
+            this.primary = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the primary color.
+         * @param color primary color
+         * @return this builder
+         */
+        public Builder primary(Color color) {
+            this.primary = color;
+            return this;
+        }
+
+        /**
+         * Sets the secondary color from hex string.
+         * @param hex secondary color as hex string
+         * @return this builder
+         */
+        public Builder secondary(String hex) {
+            this.secondary = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the secondary color.
+         * @param color secondary color
+         * @return this builder
+         */
+        public Builder secondary(Color color) {
+            this.secondary = color;
+            return this;
+        }
+
+        /**
+         * Sets the error color from hex string.
+         * @param hex error color as hex string
+         * @return this builder
+         */
+        public Builder error(String hex) {
+            this.error = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the error color.
+         * @param color error color
+         * @return this builder
+         */
+        public Builder error(Color color) {
+            this.error = color;
+            return this;
+        }
+
+        /**
+         * Sets the success color from hex string.
+         * @param hex success color as hex string
+         * @return this builder
+         */
+        public Builder success(String hex) {
+            this.success = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the success color.
+         * @param color success color
+         * @return this builder
+         */
+        public Builder success(Color color) {
+            this.success = color;
+            return this;
+        }
+
+        /**
+         * Sets the warning color from hex string.
+         * @param hex warning color as hex string
+         * @return this builder
+         */
+        public Builder warning(String hex) {
+            this.warning = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the warning color.
+         * @param color warning color
+         * @return this builder
+         */
+        public Builder warning(Color color) {
+            this.warning = color;
+            return this;
+        }
+
+        /**
+         * Sets the accent color from hex string.
+         * @param hex accent color as hex string
+         * @return this builder
+         */
+        public Builder accent(String hex) {
+            this.accent = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the accent color.
+         * @param color accent color
+         * @return this builder
+         */
+        public Builder accent(Color color) {
+            this.accent = color;
+            return this;
+        }
+
+        /**
+         * Sets the info color from hex string.
+         * @param hex info color as hex string
+         * @return this builder
+         */
+        public Builder info(String hex) {
+            this.info = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the info color.
+         * @param color info color
+         * @return this builder
+         */
+        public Builder info(Color color) {
+            this.info = color;
+            return this;
+        }
+
+        /**
+         * Sets the background color from hex string.
+         * @param hex background color as hex string
+         * @return this builder
+         */
+        public Builder background(String hex) {
+            this.background = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the background color.
+         * @param color background color
+         * @return this builder
+         */
+        public Builder background(Color color) {
+            this.background = color;
+            return this;
+        }
+
+        /**
+         * Sets the surface color from hex string.
+         * @param hex surface color as hex string
+         * @return this builder
+         */
+        public Builder surface(String hex) {
+            this.surface = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the surface color.
+         * @param color surface color
+         * @return this builder
+         */
+        public Builder surface(Color color) {
+            this.surface = color;
+            return this;
+        }
+
+        /**
+         * Sets the panel color from hex string.
+         * @param hex panel color as hex string
+         * @return this builder
+         */
+        public Builder panel(String hex) {
+            this.panel = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the panel color.
+         * @param color panel color
+         * @return this builder
+         */
+        public Builder panel(Color color) {
+            this.panel = color;
+            return this;
+        }
+
+        /**
+         * Sets the foreground color from hex string.
+         * @param hex foreground color as hex string
+         * @return this builder
+         */
+        public Builder foreground(String hex) {
+            this.foreground = Color.hex(hex);
+            return this;
+        }
+
+        /**
+         * Sets the foreground color.
+         * @param color foreground color
+         * @return this builder
+         */
+        public Builder foreground(Color color) {
+            this.foreground = color;
+            return this;
+        }
+
+        /**
+         * Sets the luminosity spread for color derivation.
+         * @param spread luminosity spread for color derivation (0.0-1.0)
+         * @return this builder
+         */
+        public Builder luminositySpread(float spread) {
+            this.luminositySpread = spread;
+            return this;
+        }
+
+        /**
+         * Sets the text alpha for muted text.
+         * @param alpha text alpha for muted text (0.0-1.0)
+         * @return this builder
+         */
+        public Builder textAlpha(float alpha) {
+            this.textAlpha = alpha;
+            return this;
+        }
+
+        /**
+         * Adds a custom CSS variable override.
+         * @param key variable name
+         * @param value variable value
+         * @return this builder
+         */
+        public Builder variable(String key, String value) {
+            this.variables.put(key, value);
+            return this;
+        }
+
+        /**
+         * Builds the theme.
+         * @return the constructed theme
+         * @throws IllegalStateException if required fields are missing
+         */
+        public Theme build() {
+            if (name == null || name.isEmpty()) {
+                throw new IllegalStateException("Theme name is required");
+            }
+            if (primary == null) {
+                throw new IllegalStateException("Primary color is required");
+            }
+
+            // Set defaults for required semantic colors if not provided
+            if (secondary == null) secondary = primary;
+            if (error == null) error = Color.RED;
+            if (success == null) success = Color.GREEN;
+            if (warning == null) warning = Color.YELLOW;
+
+            return new Theme(this);
+        }
+    }
+}

--- a/tamboui-core/src/main/java/dev/tamboui/theme/ThemeProperties.java
+++ b/tamboui-core/src/main/java/dev/tamboui/theme/ThemeProperties.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.theme;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.ColorConverter;
+import dev.tamboui.style.PropertyDefinition;
+
+/**
+ * Standard property definitions for theme colors.
+ * <p>
+ * These properties can be queried from StylePropertyResolver to get
+ * theme-generated colors in widgets that don't use CSS.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * StylePropertyResolver resolver = theme.toResolver();
+ * Color primary = resolver.get(ThemeProperties.PRIMARY).orElse(Color.BLUE);
+ * }</pre>
+ */
+public final class ThemeProperties {
+
+    private ThemeProperties() {
+        // Utility class
+    }
+
+    // ===== Base Semantic Colors =====
+
+    /** Primary semantic color property. */
+    public static final PropertyDefinition<Color> PRIMARY =
+        PropertyDefinition.of("primary", ColorConverter.INSTANCE);
+
+    /** Secondary semantic color property. */
+    public static final PropertyDefinition<Color> SECONDARY =
+        PropertyDefinition.of("secondary", ColorConverter.INSTANCE);
+
+    /** Error semantic color property. */
+    public static final PropertyDefinition<Color> ERROR =
+        PropertyDefinition.of("error", ColorConverter.INSTANCE);
+
+    /** Success semantic color property. */
+    public static final PropertyDefinition<Color> SUCCESS =
+        PropertyDefinition.of("success", ColorConverter.INSTANCE);
+
+    /** Warning semantic color property. */
+    public static final PropertyDefinition<Color> WARNING =
+        PropertyDefinition.of("warning", ColorConverter.INSTANCE);
+
+    /** Accent semantic color property. */
+    public static final PropertyDefinition<Color> ACCENT =
+        PropertyDefinition.of("accent", ColorConverter.INSTANCE);
+
+    /** Info semantic color property. */
+    public static final PropertyDefinition<Color> INFO =
+        PropertyDefinition.of("info", ColorConverter.INSTANCE);
+
+    // ===== Surface Hierarchy =====
+
+    /** Background surface color property. */
+    public static final PropertyDefinition<Color> BACKGROUND =
+        PropertyDefinition.of("background", ColorConverter.INSTANCE);
+
+    /** Surface color property. */
+    public static final PropertyDefinition<Color> SURFACE =
+        PropertyDefinition.of("surface", ColorConverter.INSTANCE);
+
+    /** Panel color property. */
+    public static final PropertyDefinition<Color> PANEL =
+        PropertyDefinition.of("panel", ColorConverter.INSTANCE);
+
+    /** Foreground color property. */
+    public static final PropertyDefinition<Color> FOREGROUND =
+        PropertyDefinition.of("foreground", ColorConverter.INSTANCE);
+
+    // ===== Derived Colors - Primary =====
+
+    /** Lightened variant of primary color. */
+    public static final PropertyDefinition<Color> PRIMARY_LIGHT =
+        PropertyDefinition.of("primary-light", ColorConverter.INSTANCE);
+
+    /** Darkened variant of primary color. */
+    public static final PropertyDefinition<Color> PRIMARY_DARK =
+        PropertyDefinition.of("primary-dark", ColorConverter.INSTANCE);
+
+    /** Muted/desaturated variant of primary color. */
+    public static final PropertyDefinition<Color> PRIMARY_MUTED =
+        PropertyDefinition.of("primary-muted", ColorConverter.INSTANCE);
+
+    // ===== Derived Colors - Secondary =====
+
+    /** Lightened variant of secondary color. */
+    public static final PropertyDefinition<Color> SECONDARY_LIGHT =
+        PropertyDefinition.of("secondary-light", ColorConverter.INSTANCE);
+
+    /** Darkened variant of secondary color. */
+    public static final PropertyDefinition<Color> SECONDARY_DARK =
+        PropertyDefinition.of("secondary-dark", ColorConverter.INSTANCE);
+
+    /** Muted/desaturated variant of secondary color. */
+    public static final PropertyDefinition<Color> SECONDARY_MUTED =
+        PropertyDefinition.of("secondary-muted", ColorConverter.INSTANCE);
+
+    // ===== Derived Colors - Error =====
+
+    /** Lightened variant of error color. */
+    public static final PropertyDefinition<Color> ERROR_LIGHT =
+        PropertyDefinition.of("error-light", ColorConverter.INSTANCE);
+
+    /** Darkened variant of error color. */
+    public static final PropertyDefinition<Color> ERROR_DARK =
+        PropertyDefinition.of("error-dark", ColorConverter.INSTANCE);
+
+    // TODO: Add success/warning shades when widgets need them
+
+    // ===== Text Colors =====
+
+    /** Default text color property. */
+    public static final PropertyDefinition<Color> TEXT =
+        PropertyDefinition.of("text", ColorConverter.INSTANCE);
+
+    /** Muted/subtle text color property. */
+    public static final PropertyDefinition<Color> TEXT_MUTED =
+        PropertyDefinition.of("text-muted", ColorConverter.INSTANCE);
+
+    /** Disabled text color property. */
+    public static final PropertyDefinition<Color> TEXT_DISABLED =
+        PropertyDefinition.of("text-disabled", ColorConverter.INSTANCE);
+
+    /** Text color for content on primary colored backgrounds. */
+    public static final PropertyDefinition<Color> TEXT_ON_PRIMARY =
+        PropertyDefinition.of("text-on-primary", ColorConverter.INSTANCE);
+
+    // ===== UI Colors =====
+
+    /** Default border color property. */
+    public static final PropertyDefinition<Color> BORDER =
+        PropertyDefinition.of("border", ColorConverter.INSTANCE);
+
+    /** Focused border color property. */
+    public static final PropertyDefinition<Color> BORDER_FOCUS =
+        PropertyDefinition.of("border-focus", ColorConverter.INSTANCE);
+
+    /** Muted border color property. */
+    public static final PropertyDefinition<Color> BORDER_MUTED =
+        PropertyDefinition.of("border-muted", ColorConverter.INSTANCE);
+
+    /** Selection background color property. */
+    public static final PropertyDefinition<Color> SELECTION_BG =
+        PropertyDefinition.of("selection-bg", ColorConverter.INSTANCE);
+
+    /** Hover background color property. */
+    public static final PropertyDefinition<Color> HOVER_BG =
+        PropertyDefinition.of("hover-bg", ColorConverter.INSTANCE);
+
+    // TODO: SCROLLBAR, SCROLLBAR_HOVER when ScrollBar widget implemented
+    // TODO: LINK, LINK_HOVER when Link widget exists
+}

--- a/tamboui-core/src/main/java/dev/tamboui/theme/ThemePropertyResolver.java
+++ b/tamboui-core/src/main/java/dev/tamboui/theme/ThemePropertyResolver.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.theme;
+
+import java.util.Map;
+import java.util.Optional;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.PropertyDefinition;
+import dev.tamboui.style.StylePropertyResolver;
+
+/**
+ * StylePropertyResolver implementation backed by a ColorSystem.
+ * <p>
+ * Provides property-based access to theme colors. Used as fallback
+ * when CSS doesn't define a property.
+ */
+final class ThemePropertyResolver implements StylePropertyResolver {
+
+    private final ColorSystem colorSystem;
+    private final Map<String, String> rawVariables;
+
+    ThemePropertyResolver(ColorSystem colorSystem, Map<String, String> rawVariables) {
+        this.colorSystem = colorSystem;
+        this.rawVariables = rawVariables;
+    }
+
+    @Override
+    public <T> Optional<T> get(PropertyDefinition<T> property) {
+        String name = property.name();
+
+        // 1. Check raw variables for overrides (non-color properties)
+        if (rawVariables.containsKey(name)) {
+            String rawValue = rawVariables.get(name);
+            return property.convert(rawValue);
+        }
+
+        // 2. Check ColorSystem for color properties
+        Color color = colorSystem.get(name);
+        if (color != null) {
+            // Try to cast - if this is a Color property, it will work
+            try {
+                @SuppressWarnings("unchecked")
+                T value = (T) color;
+                return Optional.of(value);
+            } catch (ClassCastException e) {
+                // Not a color property, continue
+            }
+        }
+
+        // 3. Not found
+        return Optional.empty();
+    }
+}

--- a/tamboui-core/src/main/java/dev/tamboui/theme/ThemeRegistry.java
+++ b/tamboui-core/src/main/java/dev/tamboui/theme/ThemeRegistry.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.theme;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import dev.tamboui.style.Color;
+
+/**
+ * Registry of built-in and user-registered themes.
+ */
+public final class ThemeRegistry {
+
+    private static final Map<String, Theme> THEMES = new HashMap<>();
+
+    static {
+        // Auto-terminal theme - adapts to terminal's ANSI colors
+        THEMES.put("auto-terminal", new Theme.Builder()
+            .name("auto-terminal")
+            .primary(Color.BLUE)
+            .secondary(Color.CYAN)
+            .error(Color.RED)
+            .success(Color.GREEN)
+            .warning(Color.YELLOW)
+            .accent(Color.LIGHT_BLUE)
+            .info(Color.LIGHT_CYAN)
+            .dark(true)
+            .build());
+
+        // TamboUI branded theme (cyan/teal)
+        THEMES.put("tamboui-default", new Theme.Builder()
+            .name("tamboui-default")
+            .primary("#00ffff")
+            .secondary("#0080ff")
+            .error("#ff6b6b")
+            .success("#4caf50")
+            .warning("#ffeb3b")
+            .accent("#00ffff")
+            .info("#00bcd4")
+            .background("#000000")
+            .surface("#1a1a1a")
+            .panel("#333333")
+            .dark(true)
+            .build());
+
+        // Nord - Arctic, north-bluish color palette
+        // Source: https://www.nordtheme.com/
+        // Palette: https://www.nordtheme.com/docs/colors-and-palettes
+        THEMES.put("nord", new Theme.Builder()
+            .name("nord")
+            .primary("#88c0d0")
+            .secondary("#81a1c1")
+            .error("#bf616a")
+            .success("#a3be8c")
+            .warning("#ebcb8b")
+            .accent("#b48ead")
+            .info("#8fbcbb")
+            .background("#2e3440")
+            .surface("#3b4252")
+            .panel("#434c5e")
+            .foreground("#eceff4")
+            .dark(true)
+            .variable("text-muted", "#d8dee9")
+            .variable("text-disabled", "#4c566a")
+            .variable("border", "#4c566a")
+            .variable("border-muted", "#434c5e")
+            .variable("text-on-primary", "#2e3440")
+            .build());
+
+        // Gruvbox Dark - Retro groove color scheme
+        // Source: https://github.com/morhetz/gruvbox
+        // Palette: https://github.com/morhetz/gruvbox#dark-mode
+        THEMES.put("gruvbox-dark", new Theme.Builder()
+            .name("gruvbox-dark")
+            .primary("#83a598")
+            .secondary("#d3869b")
+            .error("#fb4934")
+            .success("#b8bb26")
+            .warning("#fabd2f")
+            .accent("#fe8019")
+            .info("#8ec07c")
+            .background("#282828")
+            .surface("#3c3836")
+            .panel("#504945")
+            .foreground("#ebdbb2")
+            .dark(true)
+            .variable("text-on-primary", "#282828")
+            .build());
+
+        // Dracula - Dark theme with vibrant colors
+        // Source: https://draculatheme.com/
+        // Specification: https://spec.draculatheme.com/
+        THEMES.put("dracula", new Theme.Builder()
+            .name("dracula")
+            .primary("#bd93f9")
+            .secondary("#8be9fd")
+            .error("#ff5555")
+            .success("#50fa7b")
+            .warning("#f1fa8c")
+            .accent("#ff79c6")
+            .info("#8be9fd")
+            .background("#282a36")
+            .surface("#44475a")
+            .panel("#44475a")
+            .foreground("#f8f8f2")
+            .dark(true)
+            .variable("text-on-primary", "#282a36")
+            .build());
+
+        // Catppuccin Mocha - Soothing pastel theme for cozy coding
+        // Source: https://github.com/catppuccin/catppuccin
+        // Palette: https://catppuccin.com/palette
+        THEMES.put("catppuccin-mocha", new Theme.Builder()
+            .name("catppuccin-mocha")
+            .primary("#89b4fa")
+            .secondary("#cba6f7")
+            .error("#f38ba8")
+            .success("#a6e3a1")
+            .warning("#f9e2af")
+            .accent("#f5c2e7")
+            .info("#94e2d5")
+            .background("#1e1e2e")
+            .surface("#313244")
+            .panel("#45475a")
+            .foreground("#cdd6f4")
+            .dark(true)
+            .variable("text-on-primary", "#1e1e2e")
+            .build());
+
+        // Tokyo Night - Clean dark theme inspired by Tokyo's night skyline
+        // Source: https://github.com/enkia/tokyo-night-vscode-theme
+        // Also: https://github.com/folke/tokyonight.nvim
+        THEMES.put("tokyo-night", new Theme.Builder()
+            .name("tokyo-night")
+            .primary("#7aa2f7")
+            .secondary("#bb9af7")
+            .error("#f7768e")
+            .success("#9ece6a")
+            .warning("#e0af68")
+            .accent("#ff9e64")
+            .info("#7dcfff")
+            .background("#1a1b26")
+            .surface("#24283b")
+            .panel("#414868")
+            .foreground("#a9b1d6")
+            .dark(true)
+            .variable("text-on-primary", "#24283b")
+            .build());
+
+        // TODO: Light themes when requested
+        // - gruvbox-light: https://github.com/morhetz/gruvbox#light-mode
+        // - catppuccin-latte: https://catppuccin.com/palette
+        // - solarized-light: https://ethanschoonover.com/solarized/
+    }
+
+    /**
+     * Gets a theme by name.
+     *
+     * @param name the theme name
+     * @return the theme, or empty if not found
+     */
+    public static Optional<Theme> get(String name) {
+        return Optional.ofNullable(THEMES.get(name));
+    }
+
+    /**
+     * Registers a custom theme.
+     *
+     * @param theme the theme to register
+     */
+    public static void register(Theme theme) {
+        THEMES.put(theme.name(), theme);
+    }
+
+    /**
+     * Gets all registered themes.
+     *
+     * @return a map of theme name to theme
+     */
+    public static Map<String, Theme> all() {
+        return new HashMap<>(THEMES);
+    }
+
+    private ThemeRegistry() {
+        // Utility class
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/color/ColorManipulationTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/color/ColorManipulationTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.color;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.style.Color;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ColorManipulationTest {
+
+    @Test
+    void testLighten() {
+        Color base = Color.rgb(100, 100, 100);
+        Color lighter = ColorManipulation.lighten(base, 0.2f);
+
+        Color.Rgb rgb = lighter.toRgb();
+        assertTrue(rgb.r() > 100);
+        assertTrue(rgb.g() > 100);
+        assertTrue(rgb.b() > 100);
+    }
+
+    @Test
+    void testDarken() {
+        Color base = Color.rgb(200, 200, 200);
+        Color darker = ColorManipulation.darken(base, 0.2f);
+
+        Color.Rgb rgb = darker.toRgb();
+        assertTrue(rgb.r() < 200);
+        assertTrue(rgb.g() < 200);
+        assertTrue(rgb.b() < 200);
+    }
+
+    @Test
+    void testBlend() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+        Color blended = ColorManipulation.blend(red, blue, 0.5f);
+
+        Color.Rgb rgb = blended.toRgb();
+        assertEquals(127, rgb.r(), 2);
+        assertEquals(0, rgb.g(), 2);
+        assertEquals(127, rgb.b(), 2);
+    }
+
+    @Test
+    void testGetContrastText_Dark() {
+        Color dark = Color.rgb(0, 0, 0);
+        Color contrast = ColorManipulation.getContrastText(dark);
+
+        // Should return white or very light color
+        Color.Rgb rgb = contrast.toRgb();
+        assertTrue(rgb.r() > 200);
+    }
+
+    @Test
+    void testGetContrastText_Light() {
+        Color light = Color.rgb(255, 255, 255);
+        Color contrast = ColorManipulation.getContrastText(light);
+
+        // Should return black or very dark color
+        Color.Rgb rgb = contrast.toRgb();
+        assertTrue(rgb.r() < 50);
+    }
+
+    @Test
+    void testInverse() {
+        Color color = Color.rgb(100, 150, 200);
+        Color inverted = ColorManipulation.inverse(color);
+        Color.Rgb rgb = inverted.toRgb();
+        assertEquals(155, rgb.r());
+        assertEquals(105, rgb.g());
+        assertEquals(55, rgb.b());
+    }
+
+    @Test
+    void testWithAlpha() {
+        Color color = Color.rgb(100, 100, 100);
+        Color result = ColorManipulation.withAlpha(color, 0.5f);
+        // Currently a no-op, should return same color
+        assertEquals(color, result);
+    }
+
+    // Low-level color space conversion tests
+
+    @Test
+    void testRgbToHsl_Red() {
+        float[] hsl = ColorManipulation.rgbToHsl(255, 0, 0);
+        assertEquals(0.0f, hsl[0], 0.1f);      // Hue
+        assertEquals(100.0f, hsl[1], 0.1f);    // Saturation
+        assertEquals(50.0f, hsl[2], 0.1f);     // Lightness
+    }
+
+    @Test
+    void testRgbToHsl_Gray() {
+        float[] hsl = ColorManipulation.rgbToHsl(128, 128, 128);
+        assertEquals(0.0f, hsl[1], 0.1f);      // No saturation
+        assertEquals(50.2f, hsl[2], 0.5f);     // Mid lightness
+    }
+
+    @Test
+    void testHslToRgb_Red() {
+        int[] rgb = ColorManipulation.hslToRgb(0.0f, 100.0f, 50.0f);
+        assertEquals(255, rgb[0]);
+        assertEquals(0, rgb[1]);
+        assertEquals(0, rgb[2]);
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/style/ColorConvenienceTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/style/ColorConvenienceTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.style;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ColorConvenienceTest {
+
+    @Test
+    void testLightenConvenience() {
+        Color base = Color.rgb(100, 100, 100);
+        Color lighter = base.lighten(0.2f);
+
+        Color.Rgb rgb = lighter.toRgb();
+        assertTrue(rgb.r() > 100);
+    }
+
+    @Test
+    void testDarkenConvenience() {
+        Color base = Color.rgb(200, 200, 200);
+        Color darker = base.darken(0.2f);
+
+        Color.Rgb rgb = darker.toRgb();
+        assertTrue(rgb.r() < 200);
+    }
+
+    @Test
+    void testBlendConvenience() {
+        Color red = Color.rgb(255, 0, 0);
+        Color blue = Color.rgb(0, 0, 255);
+        Color blended = red.blend(blue, 0.5f);
+
+        assertNotNull(blended);
+    }
+
+    @Test
+    void testGetContrastTextConvenience() {
+        Color dark = Color.rgb(0, 0, 0);
+        Color contrast = dark.getContrastText();
+
+        Color.Rgb rgb = contrast.toRgb();
+        assertTrue(rgb.r() > 200);
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/theme/ColorSystemTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/theme/ColorSystemTest.java
@@ -1,0 +1,102 @@
+package dev.tamboui.theme;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.style.Color;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ColorSystemTest {
+
+    @Test
+    void testGenerateBaseColors() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#0000ff")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        ColorSystem system = theme.generate();
+
+        assertNotNull(system.get("primary"));
+        assertNotNull(system.get("secondary"));
+        assertNotNull(system.get("error"));
+        assertNotNull(system.get("success"));
+        assertNotNull(system.get("warning"));
+    }
+
+    @Test
+    void testGenerateDerivedColors() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#808080")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .luminositySpread(0.15f)
+            .build();
+
+        ColorSystem system = theme.generate();
+
+        // Shades
+        assertNotNull(system.get("primary-light"));
+        assertNotNull(system.get("primary-dark"));
+        assertNotNull(system.get("primary-muted"));
+
+        // Text colors
+        assertNotNull(system.get("text"));
+        assertNotNull(system.get("text-muted"));
+        assertNotNull(system.get("text-disabled"));
+
+        // UI colors
+        assertNotNull(system.get("border"));
+        assertNotNull(system.get("border-focus"));
+        assertNotNull(system.get("selection-bg"));
+    }
+
+    @Test
+    void testGenerateAutoDerivesBackground() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#0000ff")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .dark(true)
+            .build();
+
+        ColorSystem system = theme.generate();
+
+        Color bg = system.get("background");
+        assertNotNull(bg);
+        // Should be dark (low luminance)
+        Color.Rgb rgb = bg.toRgb();
+        assertTrue(rgb.r() < 50);
+    }
+
+    @Test
+    void testVariableOverride() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#0000ff")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .variable("border-focus", "#ff00ff")
+            .build();
+
+        ColorSystem system = theme.generate();
+
+        Color borderFocus = system.get("border-focus");
+        Color.Rgb rgb = borderFocus.toRgb();
+        assertEquals(255, rgb.r());
+        assertEquals(0, rgb.g());
+        assertEquals(255, rgb.b());
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/theme/ThemePropertiesTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/theme/ThemePropertiesTest.java
@@ -1,0 +1,50 @@
+package dev.tamboui.theme;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.StylePropertyResolver;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThemePropertiesTest {
+
+    @Test
+    void testPrimaryProperty() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#ff0000")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        StylePropertyResolver resolver = theme.toResolver();
+
+        Color primary = resolver.get(ThemeProperties.PRIMARY).orElse(null);
+        assertNotNull(primary);
+
+        Color.Rgb rgb = primary.toRgb();
+        assertEquals(255, rgb.r());
+        assertEquals(0, rgb.g());
+        assertEquals(0, rgb.b());
+    }
+
+    @Test
+    void testDerivedProperty() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#808080")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        StylePropertyResolver resolver = theme.toResolver();
+
+        Color primaryLight = resolver.get(ThemeProperties.PRIMARY_LIGHT).orElse(null);
+        assertNotNull(primaryLight);
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/theme/ThemePropertyResolverTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/theme/ThemePropertyResolverTest.java
@@ -1,0 +1,57 @@
+package dev.tamboui.theme;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.style.ColorConverter;
+import dev.tamboui.style.PropertyDefinition;
+import dev.tamboui.style.StylePropertyResolver;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThemePropertyResolverTest {
+
+    @Test
+    void testResolveColorProperty() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#0000ff")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        StylePropertyResolver resolver = theme.toResolver();
+
+        PropertyDefinition<Color> primaryProp =
+            PropertyDefinition.of("primary", ColorConverter.INSTANCE);
+
+        Color primary = resolver.get(primaryProp).orElse(null);
+        assertNotNull(primary);
+
+        Color.Rgb rgb = primary.toRgb();
+        assertEquals(0, rgb.r());
+        assertEquals(0, rgb.g());
+        assertEquals(255, rgb.b());
+    }
+
+    @Test
+    void testResolveMissingProperty() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#0000ff")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        StylePropertyResolver resolver = theme.toResolver();
+
+        PropertyDefinition<Color> missing =
+            PropertyDefinition.of("nonexistent", ColorConverter.INSTANCE);
+
+        assertFalse(resolver.get(missing).isPresent());
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/theme/ThemeRegistryTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/theme/ThemeRegistryTest.java
@@ -1,0 +1,57 @@
+package dev.tamboui.theme;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThemeRegistryTest {
+
+    @Test
+    void testGetAutoTerminalTheme() {
+        Theme theme = ThemeRegistry.get("auto-terminal").orElse(null);
+        assertNotNull(theme);
+        assertEquals("auto-terminal", theme.name());
+        assertTrue(theme.dark());
+    }
+
+    @Test
+    void testGetNordTheme() {
+        Theme theme = ThemeRegistry.get("nord").orElse(null);
+        assertNotNull(theme);
+        assertEquals("nord", theme.name());
+    }
+
+    @Test
+    void testGetMissingTheme() {
+        assertFalse(ThemeRegistry.get("nonexistent").isPresent());
+    }
+
+    @Test
+    void testRegisterCustomTheme() {
+        Theme custom = new Theme.Builder()
+            .name("custom-test")
+            .primary("#abcdef")
+            .secondary("#fedcba")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        ThemeRegistry.register(custom);
+
+        Theme retrieved = ThemeRegistry.get("custom-test").orElse(null);
+        assertNotNull(retrieved);
+        assertEquals("custom-test", retrieved.name());
+    }
+
+    @Test
+    void testAllThemes() {
+        Map<String, Theme> themes = ThemeRegistry.all();
+        assertTrue(themes.size() >= 7);  // At least 7 built-in themes
+        assertTrue(themes.containsKey("auto-terminal"));
+        assertTrue(themes.containsKey("nord"));
+        assertTrue(themes.containsKey("gruvbox-dark"));
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/theme/ThemeTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/theme/ThemeTest.java
@@ -1,0 +1,69 @@
+package dev.tamboui.theme;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThemeTest {
+
+    @Test
+    void testBuilderMinimal() {
+        Theme theme = new Theme.Builder()
+            .name("test")
+            .primary("#ff0000")
+            .secondary("#00ff00")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .build();
+
+        assertEquals("test", theme.name());
+        assertTrue(theme.dark());  // default
+        assertNotNull(theme.primary());
+    }
+
+    @Test
+    void testBuilderComplete() {
+        Theme theme = new Theme.Builder()
+            .name("complete")
+            .primary("#0000ff")
+            .secondary("#00ffff")
+            .error("#ff0000")
+            .success("#00ff00")
+            .warning("#ffff00")
+            .accent("#ff00ff")
+            .info("#00ffff")
+            .background("#000000")
+            .surface("#1a1a1a")
+            .panel("#333333")
+            .foreground("#ffffff")
+            .dark(false)
+            .luminositySpread(0.2f)
+            .textAlpha(0.9f)
+            .variable("custom", "#abcdef")
+            .build();
+
+        assertEquals("complete", theme.name());
+        assertFalse(theme.dark());
+        assertEquals(0.2f, theme.luminositySpread(), 0.01f);
+        assertEquals(0.9f, theme.textAlpha(), 0.01f);
+    }
+
+    @Test
+    void testBuilderRequiresName() {
+        assertThrows(IllegalStateException.class, () -> {
+            new Theme.Builder()
+                .primary("#ff0000")
+                .build();
+        });
+    }
+
+    @Test
+    void testBuilderRequiresPrimary() {
+        assertThrows(IllegalStateException.class, () -> {
+            new Theme.Builder()
+                .name("test")
+                .build();
+        });
+    }
+}

--- a/tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java
+++ b/tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java
@@ -1,6 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS dev.tamboui:tamboui-toolkit:LATEST
 //DEPS dev.tamboui:tamboui-jline3-backend:LATEST
+//FILES themes-css/themed.tcss=../../../../resources/themes-css/themed.tcss
 /*
  * Copyright TamboUI Contributors
  * SPDX-License-Identifier: MIT
@@ -13,9 +14,13 @@ import java.time.Duration;
 import java.util.List;
 
 import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.theme.ThemeEngine;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.theme.ColorSystem;
+import dev.tamboui.theme.ThemeRegistry;
 import dev.tamboui.toolkit.app.ToolkitRunner;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
@@ -28,22 +33,33 @@ import dev.tamboui.tui.event.KeyEvent;
 import static dev.tamboui.toolkit.Toolkit.*;
 
 /**
- * CSS Demo showcasing live theme switching.
+ * CSS Demo showcasing theme-aware styling with semantic colors.
+ * <p>
+ * A single TCSS stylesheet references theme variables ({@code $primary},
+ * {@code $border}, etc.) that are injected by {@link ThemeEngine}.
+ * Switching themes re-injects the variables so the same stylesheet
+ * produces a completely different look.
  * <p>
  * Features demonstrated:
  * <ul>
- *   <li>Loading CSS stylesheets from resources</li>
- *   <li>Live theme switching with 't' key</li>
- *   <li>CSS classes on elements</li>
- *   <li>Pseudo-class states (:focus) - Tab to navigate, see border change</li>
- *   <li>List elements with selection highlighting</li>
- *   <li>Combining CSS with programmatic styles</li>
+ *   <li>Theme-aware CSS using injected {@code $variables}</li>
+ *   <li>Live theme switching across 7 built-in themes with number keys</li>
+ *   <li>Semantic color classes (primary, error, success, …)</li>
+ *   <li>Auto-generated palette: shades, text colors, UI colors</li>
+ *   <li>Pseudo-class states (:focus) – Tab to navigate</li>
+ *   <li>List selection highlighting from theme colors</li>
  * </ul>
  */
 public class CssDemo implements Element {
 
-    private String currentTheme = "dark";
+    private static final String[] THEME_NAMES = ThemeRegistry.all().keySet().stream()
+        .sorted()
+        .toArray(String[]::new);
+
+    private int currentThemeIndex;
     private final StyleEngine styleEngine;
+    private final ThemeEngine themeEngine;
+
     private final List<String> listItems = List.of(
         "Dashboard",
         "Settings",
@@ -56,14 +72,18 @@ public class CssDemo implements Element {
     private CssDemo() {
         styleEngine = StyleEngine.create();
         try {
-            // Load both themes
-            styleEngine.loadStylesheet("dark", "/themes-css/dark.tcss");
-            styleEngine.loadStylesheet("light", "/themes-css/light.tcss");
-            styleEngine.setActiveStylesheet(currentTheme);
+            styleEngine.loadStylesheet("themed", "/themes-css/themed.tcss");
+            styleEngine.setActiveStylesheet("themed");
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to load CSS themes", e);
+            throw new UncheckedIOException("Failed to load CSS stylesheet", e);
         }
-        // Create navigation list
+
+        themeEngine = new ThemeEngine();
+
+        // Default to tamboui-default (or first available)
+        currentThemeIndex = indexOf("tamboui-default");
+        applyTheme();
+
         navList = list(listItems)
             .id("nav-list")
             .title("Navigation")
@@ -73,12 +93,12 @@ public class CssDemo implements Element {
 
     /**
      * Demo entry point.
+     *
      * @param args the CLI arguments
      * @throws Exception on unexpected error
      */
     public static void main(String[] args) throws Exception {
-        var demo = new CssDemo();
-        demo.run();
+        new CssDemo().run();
     }
 
     /**
@@ -86,7 +106,7 @@ public class CssDemo implements Element {
      *
      * @throws Exception if an error occurs
      */
-     public void run() throws Exception {
+    public void run() throws Exception {
         var config = TuiConfig.builder()
             .mouseCapture(true)
             .tickRate(Duration.ofMillis(100))
@@ -100,53 +120,108 @@ public class CssDemo implements Element {
 
     @Override
     public void render(Frame frame, Rect area, RenderContext context) {
+        String themeName = THEME_NAMES[currentThemeIndex];
+
         dock()
             // Header
             .top(panel(() -> row(
-                text(" CSS Demo ").addClass("header"),
+                text(" CSS + Themes ").addClass("header"),
                 spacer(),
                 text(" Theme: ").addClass("dim"),
-                text(currentTheme.toUpperCase()).id("theme-indicator"),
-                text(" [t] Toggle ").addClass("dim"),
+                text(themeName).id("theme-indicator"),
+                text(" [t/T] Switch ").addClass("dim"),
                 text(" [Tab] Focus ").addClass("dim"),
                 text(" [q] Quit ").addClass("dim")
             )).rounded().addClass("status"))
 
-            // Left sidebar with navigation list
+            // Left sidebar – navigation list
             .left(navList, Constraint.length(20))
 
-            // Center panel - Style Classes (focusable)
-            .center(panel(() -> column(
-                text("Primary Action").addClass("primary"),
-                text("Secondary Info").addClass("secondary"),
-                text("Warning Message").addClass("warning"),
-                text("Error Message").addClass("error"),
-                text("Success Message").addClass("success"),
-                text("Info Message").addClass("info")
-            )).id("styles-panel").focusable().title("Style Classes").rounded())
+            // Center – semantic colors + generated palette
+            .center(column(
+                // Semantic colors
+                panel(() -> column(
+                    text("Primary").addClass("primary"),
+                    text("Secondary").addClass("secondary"),
+                    text("Warning").addClass("warning"),
+                    text("Error").addClass("error"),
+                    text("Success").addClass("success"),
+                    text("Info").addClass("info"),
+                    text("Accent").addClass("accent")
+                )).id("styles-panel").focusable().title("Semantic Colors").rounded(),
 
-            // Right panel - About (focusable)
+                // Generated palette
+                panel(() -> buildPaletteView())
+                    .id("palette-panel").focusable().title("Generated Palette").rounded()
+            ))
+
+            // Right panel – about / help
             .right(panel(() -> column(
-                text("This demo shows live CSS styling."),
+                text("Theme-Aware CSS").addClass("primary"),
                 spacer(1),
-                text("Try these features:"),
-                text("  [t] Toggle dark/light theme"),
-                text("  [Tab] Cycle focus between panels"),
-                text("  [Up/Down] Navigate the list"),
+                text("One TCSS stylesheet uses"),
+                text("$variables injected from the"),
+                text("active theme's ColorSystem."),
                 spacer(1),
-                text("Notice how:").addClass("info"),
-                text("  - Focused panels have colored borders"),
-                text("  - List selection is highlighted"),
-                text("  - Styles come from CSS files")
-            )).id("about-panel").focusable().title("About").rounded())
+                text("Keys:").addClass("info"),
+                text("  [t]      Next theme"),
+                text("  [T]      Previous theme"),
+                text("  [Tab]    Cycle focus"),
+                text("  [Up/Dn]  Navigate list"),
+                text("  [q]      Quit"),
+                spacer(1),
+                text("Themes:").addClass("info"),
+                buildThemeList()
+            )).id("about-panel").focusable().title("About").rounded(), Constraint.length(30))
 
             // Footer
             .bottom(panel(() -> row(
-                text("Programmatic ").bold().cyan(),
-                text("+ CSS ").addClass("primary"),
-                text("= Powerful Styling").addClass("success")
+                text("CSS $variables ").addClass("primary"),
+                text("+ ThemeEngine ").addClass("secondary"),
+                text("= Semantic Styling").addClass("success")
             )).rounded())
+
         .render(frame, area, context);
+    }
+
+    private Element buildThemeList() {
+        var elements = new Element[THEME_NAMES.length];
+        for (int i = 0; i < THEME_NAMES.length; i++) {
+            String marker = (i == currentThemeIndex) ? " ▸ " : "   ";
+            var item = text(marker + THEME_NAMES[i]);
+            elements[i] = (i == currentThemeIndex) ? item.addClass("primary") : item.addClass("muted");
+        }
+        return column(elements);
+    }
+
+    private Element buildPaletteView() {
+        ColorSystem cs = themeEngine.getColorSystem();
+        return column(
+            swatchRow("Surfaces", cs, "background", "surface", "panel"),
+            swatchRow("Primary",  cs, "primary-light", "primary-dark", "primary-muted"),
+            swatchRow("Second.",  cs, "secondary-light", "secondary-dark", "secondary-muted"),
+            swatchRow("Error",    cs, "error-light", "error-dark"),
+            swatchRow("Text",     cs, "text", "text-muted", "text-disabled"),
+            swatchRow("UI",       cs, "border", "border-focus", "selection-bg", "hover-bg")
+        );
+    }
+
+    private Element swatchRow(String label, ColorSystem cs, String... names) {
+        // label ██ name ██ name ...
+        var elements = new Element[1 + names.length * 2];
+        elements[0] = text(String.format("%-9s", label)).addClass("dim");
+        for (int i = 0; i < names.length; i++) {
+            Color color = cs.get(names[i]);
+            if (color != null) {
+                Color.Rgb rgb = color.toRgb();
+                elements[1 + i * 2] = text("██").fg(Color.rgb(rgb.r(), rgb.g(), rgb.b()));
+                elements[2 + i * 2] = text(names[i] + " ").addClass("muted");
+            } else {
+                elements[1 + i * 2] = text("  ");
+                elements[2 + i * 2] = text(names[i] + "? ").addClass("disabled");
+            }
+        }
+        return row(elements);
     }
 
     @Override
@@ -161,8 +236,15 @@ public class CssDemo implements Element {
 
     @Override
     public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
-        if (event.isCharIgnoreCase('t')) {
-            toggleTheme();
+        // Theme switching
+        if (event.isChar('t')) {
+            currentThemeIndex = (currentThemeIndex + 1) % THEME_NAMES.length;
+            applyTheme();
+            return EventResult.HANDLED;
+        }
+        if (event.isChar('T')) {
+            currentThemeIndex = (currentThemeIndex - 1 + THEME_NAMES.length) % THEME_NAMES.length;
+            applyTheme();
             return EventResult.HANDLED;
         }
         // List navigation
@@ -177,8 +259,17 @@ public class CssDemo implements Element {
         return EventResult.UNHANDLED;
     }
 
-    private void toggleTheme() {
-        currentTheme = currentTheme.equals("dark") ? "light" : "dark";
-        styleEngine.setActiveStylesheet(currentTheme);
+    private void applyTheme() {
+        themeEngine.setTheme(THEME_NAMES[currentThemeIndex]);
+        themeEngine.injectVariables(styleEngine);
+    }
+
+    private static int indexOf(String name) {
+        for (int i = 0; i < THEME_NAMES.length; i++) {
+            if (THEME_NAMES[i].equals(name)) {
+                return i;
+            }
+        }
+        return 0;
     }
 }

--- a/tamboui-css/demos/css-demo/src/main/resources/themes-css/themed.tcss
+++ b/tamboui-css/demos/css-demo/src/main/resources/themes-css/themed.tcss
@@ -1,0 +1,90 @@
+/* Theme-aware stylesheet.
+ *
+ * All $variables are injected by ThemeEngine from the active theme's
+ * ColorSystem.  Switching themes re-injects the variables — one
+ * stylesheet, many looks.
+ */
+
+/* ===== Base ===== */
+* {
+    color: $text;
+}
+
+Row, Column {
+    background: $background;
+}
+
+/* ===== Panels ===== */
+Panel {
+    background: $surface;
+    border-color: $border;
+    border-type: rounded;
+}
+
+Panel:focus {
+    border-color: $border-focus;
+    border-type: double;
+    text-style: bold;
+}
+
+/* ===== List ===== */
+ListElement {
+    background: $surface;
+    border-color: $border;
+}
+
+ListElement:focus {
+    border-color: $border-focus;
+}
+
+ListElement-item {
+    color: $text;
+}
+
+ListElement-item:selected {
+    background: $selection-bg;
+    color: $primary;
+    text-style: bold;
+}
+
+/* ===== Header / Status ===== */
+.header {
+    color: $primary;
+    text-style: bold;
+    text-align: center;
+}
+
+.status {
+    background: $background;
+    color: $text;
+    border-color: $border-muted;
+}
+
+/* ===== Semantic text classes ===== */
+.primary       { color: $primary;   text-style: bold; }
+.secondary     { color: $secondary; }
+.warning       { color: $warning;   text-style: bold; }
+.error         { color: $error;     text-style: bold; }
+.success       { color: $success; }
+.info          { color: $info; }
+.accent        { color: $accent; }
+
+/* ===== Derived color classes ===== */
+.muted         { color: $text-muted; }
+.disabled      { color: $text-disabled; }
+.primary-light { color: $primary-light; }
+.primary-dark  { color: $primary-dark; }
+.primary-muted { color: $primary-muted; }
+.error-light   { color: $error-light; }
+.error-dark    { color: $error-dark; }
+
+/* ===== Dim helper ===== */
+.dim {
+    color: $text-muted;
+}
+
+/* ===== Theme indicator ===== */
+#theme-indicator {
+    color: $primary;
+    text-style: bold;
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/engine/StyleEngine.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/engine/StyleEngine.java
@@ -78,12 +78,16 @@ public final class StyleEngine {
 
     private String activeStylesheetName;
 
+    // Theme variable storage (global scope)
+    private Map<String, String> themeVariables;
+
     private StyleEngine() {
         this.namedStylesheets = new LinkedHashMap<>();
         this.inlineStylesheets = new ArrayList<>();
         this.cascadeResolver = new CascadeResolver();
         this.listeners = new CopyOnWriteArrayList<>();
         this.activeStylesheetName = null;
+        this.themeVariables = new HashMap<>();
     }
 
     /**
@@ -370,12 +374,15 @@ public final class StyleEngine {
     private Map<String, String> collectVariables() {
         Map<String, String> variables = new LinkedHashMap<>();
 
-        // Collect from inline stylesheets
+        // 1. Theme variables (lowest priority)
+        variables.putAll(themeVariables);
+
+        // 2. Collect from inline stylesheets (overrides theme)
         for (Stylesheet stylesheet : inlineStylesheets) {
             variables.putAll(stylesheet.variables());
         }
 
-        // Collect from active named stylesheet (overrides inline)
+        // 3. Collect from active named stylesheet (overrides inline)
         if (activeStylesheetName != null) {
             StylesheetEntry entry = namedStylesheets.get(activeStylesheetName);
             if (entry != null) {
@@ -384,6 +391,36 @@ public final class StyleEngine {
         }
 
         return variables;
+    }
+
+    /**
+     * Sets theme variables for TCSS $variable resolution.
+     * Called by ThemeEngine.injectVariables().
+     * <p>
+     * These variables are available globally in all TCSS files without declaration.
+     */
+    public void setThemeVariables(Map<String, String> variables) {
+        this.themeVariables = new HashMap<>(variables);
+        // Trigger re-resolution if stylesheets are already loaded
+        notifyListeners();
+    }
+
+    /**
+     * Resolves a TCSS variable reference ($varname).
+     * <p>
+     * Resolution order:
+     * <ol>
+     *   <li>User-defined variables in current TCSS file ($varname: value;)</li>
+     *   <li>Theme-injected variables ($primary, $error, etc.)</li>
+     *   <li>Return null if not found (parser will error)</li>
+     * </ol>
+     *
+     * @param varName variable name (without $ prefix)
+     * @return resolved value, or null if not found
+     */
+    public String resolveVariable(String varName) {
+        Map<String, String> allVariables = collectVariables();
+        return allVariables.get(varName);
     }
 
     private String readClasspathResource(String resource) throws IOException {

--- a/tamboui-css/src/main/java/dev/tamboui/css/engine/StyleEngine.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/engine/StyleEngine.java
@@ -398,6 +398,8 @@ public final class StyleEngine {
      * Called by ThemeEngine.injectVariables().
      * <p>
      * These variables are available globally in all TCSS files without declaration.
+     *
+     * @param variables map of variable names to values
      */
     public void setThemeVariables(Map<String, String> variables) {
         this.themeVariables = new HashMap<>(variables);

--- a/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemeEngine.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemeEngine.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import dev.tamboui.css.cascade.CssStyleResolver;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.PropertyDefinition;
 import dev.tamboui.style.StylePropertyResolver;
 import dev.tamboui.theme.ColorSystem;
 import dev.tamboui.theme.Theme;
@@ -159,9 +160,17 @@ public final class ThemeEngine {
      * @return a composed resolver that checks CSS rules first, then falls back to the theme
      */
     public StylePropertyResolver composeWithCss(CssStyleResolver cssResolver) {
-        // TODO: Implement proper composition in Task 11
-        // For now, just return the theme resolver
-        return themeResolver;
+        StylePropertyResolver fallback = themeResolver;
+        return new StylePropertyResolver() {
+            @Override
+            public <T> java.util.Optional<T> get(PropertyDefinition<T> property) {
+                java.util.Optional<T> cssValue = cssResolver.get(property);
+                if (cssValue.isPresent()) {
+                    return cssValue;
+                }
+                return fallback.get(property);
+            }
+        };
     }
 
     private String toCssValue(Color color) {

--- a/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemeEngine.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemeEngine.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.css.theme;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import dev.tamboui.css.cascade.CssStyleResolver;
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.StylePropertyResolver;
+import dev.tamboui.theme.ColorSystem;
+import dev.tamboui.theme.Theme;
+import dev.tamboui.theme.ThemeRegistry;
+
+/**
+ * Integrates themes with the CSS engine.
+ * <p>
+ * Responsibilities:
+ * <ul>
+ *   <li>Generate ColorSystem from Theme</li>
+ *   <li>Inject theme colors as CSS variables ($primary, $error, etc.)</li>
+ *   <li>Provide fallback resolver for non-CSS contexts</li>
+ * </ul>
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * ThemeEngine themeEngine = new ThemeEngine();
+ * themeEngine.setTheme("nord");
+ * themeEngine.injectVariables(styleEngine);  // One-time setup
+ *
+ * // Per-element during rendering:
+ * CssStyleResolver css = styleEngine.resolve(element);
+ * StylePropertyResolver composed = themeEngine.composeWithCss(css);
+ * }</pre>
+ */
+public final class ThemeEngine {
+
+    private Theme currentTheme;
+    private ColorSystem colorSystem;
+    private StylePropertyResolver themeResolver;
+
+    /**
+     * Creates a ThemeEngine with the auto-terminal theme.
+     */
+    public ThemeEngine() {
+        this(ThemeRegistry.get("auto-terminal")
+            .orElseThrow(() -> new IllegalStateException("auto-terminal theme not found")));
+    }
+
+    /**
+     * Creates a ThemeEngine with the specified theme.
+     */
+    public ThemeEngine(Theme theme) {
+        setTheme(theme);
+    }
+
+    /**
+     * Sets the active theme and regenerates colors.
+     */
+    public void setTheme(Theme theme) {
+        this.currentTheme = theme;
+        this.colorSystem = theme.generate();
+        this.themeResolver = theme.toResolver();
+    }
+
+    /**
+     * Sets the active theme by name.
+     */
+    public void setTheme(String themeName) {
+        Theme theme = ThemeRegistry.get(themeName)
+            .orElseThrow(() -> new IllegalArgumentException("Unknown theme: " + themeName));
+        setTheme(theme);
+    }
+
+    /**
+     * Gets the current theme.
+     */
+    public Theme getTheme() {
+        return currentTheme;
+    }
+
+    /**
+     * Gets the generated color system.
+     */
+    public ColorSystem getColorSystem() {
+        return colorSystem;
+    }
+
+    /**
+     * Gets the theme property resolver.
+     * Use this as fallback when no CSS is available.
+     */
+    public StylePropertyResolver getResolver() {
+        return themeResolver;
+    }
+
+    /**
+     * Injects theme colors as TCSS variables into the given style engine.
+     * <p>
+     * Generated variables (automatically available in all TCSS files):
+     * <ul>
+     *   <li>$primary, $secondary, $error, $success, $warning, $accent, $info</li>
+     *   <li>$primary-light, $primary-dark, $primary-muted (similar for secondary, error)</li>
+     *   <li>$background, $surface, $panel, $foreground</li>
+     *   <li>$text, $text-muted, $text-disabled, $text-on-primary</li>
+     *   <li>$border, $border-focus, $border-muted</li>
+     *   <li>$selection-bg, $hover-bg</li>
+     * </ul>
+     * <p>
+     * Call this once at application startup.
+     */
+    public void injectVariables(StyleEngine styleEngine) {
+        Map<String, String> cssVariables = new HashMap<>();
+
+        // Convert all ColorSystem colors to TCSS variables
+        for (String colorName : colorSystem.colorNames()) {
+            Color color = colorSystem.get(colorName);
+            String cssValue = toCssValue(color);
+            cssVariables.put(colorName, cssValue);
+        }
+
+        // Inject into style engine's global variable context
+        styleEngine.setThemeVariables(cssVariables);
+    }
+
+    /**
+     * Creates a composed resolver: CSS with theme fallback.
+     * <p>
+     * Resolution order:
+     * <ol>
+     *   <li>CSS rules (highest specificity)</li>
+     *   <li>Theme-generated colors</li>
+     *   <li>Property defaults</li>
+     * </ol>
+     * <p>
+     * Call this per-element during rendering.
+     */
+    public StylePropertyResolver composeWithCss(CssStyleResolver cssResolver) {
+        // TODO: Implement proper composition in Task 11
+        // For now, just return the theme resolver
+        return themeResolver;
+    }
+
+    private String toCssValue(Color color) {
+        // Convert Color to CSS-compatible string
+        if (color instanceof Color.Rgb) {
+            Color.Rgb rgb = (Color.Rgb) color;
+            return String.format("#%02x%02x%02x", rgb.r(), rgb.g(), rgb.b());
+        } else if (color instanceof Color.Named) {
+            Color.Named named = (Color.Named) color;
+            // For ANSI colors, use the name (e.g., "blue" for terminal adaptation)
+            return named.name();
+        } else if (color instanceof Color.Ansi) {
+            Color.Ansi ansi = (Color.Ansi) color;
+            return ansi.color().name().toLowerCase().replace('_', '-');
+        }
+        // Fallback: convert to RGB
+        Color.Rgb rgb = color.toRgb();
+        return String.format("#%02x%02x%02x", rgb.r(), rgb.g(), rgb.b());
+    }
+}

--- a/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemeEngine.java
+++ b/tamboui-css/src/main/java/dev/tamboui/css/theme/ThemeEngine.java
@@ -44,6 +44,8 @@ public final class ThemeEngine {
 
     /**
      * Creates a ThemeEngine with the auto-terminal theme.
+     *
+     * @throws IllegalStateException if the auto-terminal theme is not found
      */
     public ThemeEngine() {
         this(ThemeRegistry.get("auto-terminal")
@@ -52,6 +54,8 @@ public final class ThemeEngine {
 
     /**
      * Creates a ThemeEngine with the specified theme.
+     *
+     * @param theme the initial theme to use
      */
     public ThemeEngine(Theme theme) {
         setTheme(theme);
@@ -59,6 +63,8 @@ public final class ThemeEngine {
 
     /**
      * Sets the active theme and regenerates colors.
+     *
+     * @param theme the theme to set as active
      */
     public void setTheme(Theme theme) {
         this.currentTheme = theme;
@@ -68,6 +74,9 @@ public final class ThemeEngine {
 
     /**
      * Sets the active theme by name.
+     *
+     * @param themeName the name of the theme to look up and set
+     * @throws IllegalArgumentException if no theme with the given name is registered
      */
     public void setTheme(String themeName) {
         Theme theme = ThemeRegistry.get(themeName)
@@ -77,6 +86,8 @@ public final class ThemeEngine {
 
     /**
      * Gets the current theme.
+     *
+     * @return the current theme
      */
     public Theme getTheme() {
         return currentTheme;
@@ -84,6 +95,8 @@ public final class ThemeEngine {
 
     /**
      * Gets the generated color system.
+     *
+     * @return the color system generated from the current theme
      */
     public ColorSystem getColorSystem() {
         return colorSystem;
@@ -92,6 +105,8 @@ public final class ThemeEngine {
     /**
      * Gets the theme property resolver.
      * Use this as fallback when no CSS is available.
+     *
+     * @return the theme-based property resolver
      */
     public StylePropertyResolver getResolver() {
         return themeResolver;
@@ -111,6 +126,8 @@ public final class ThemeEngine {
      * </ul>
      * <p>
      * Call this once at application startup.
+     *
+     * @param styleEngine the style engine to inject theme variables into
      */
     public void injectVariables(StyleEngine styleEngine) {
         Map<String, String> cssVariables = new HashMap<>();
@@ -137,6 +154,9 @@ public final class ThemeEngine {
      * </ol>
      * <p>
      * Call this per-element during rendering.
+     *
+     * @param cssResolver the CSS style resolver to compose with the theme resolver
+     * @return a composed resolver that checks CSS rules first, then falls back to the theme
      */
     public StylePropertyResolver composeWithCss(CssStyleResolver cssResolver) {
         // TODO: Implement proper composition in Task 11

--- a/tamboui-css/src/test/java/dev/tamboui/css/engine/StyleEngineThemeTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/engine/StyleEngineThemeTest.java
@@ -1,0 +1,54 @@
+package dev.tamboui.css.engine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StyleEngineThemeTest {
+
+    @Test
+    void testSetThemeVariables() {
+        StyleEngine engine = StyleEngine.create();
+
+        Map<String, String> variables = new HashMap<>();
+        variables.put("primary", "#0000ff");
+        variables.put("secondary", "#00ff00");
+
+        engine.setThemeVariables(variables);
+
+        // Verify variables were stored
+        String primary = engine.resolveVariable("primary");
+        assertEquals("#0000ff", primary);
+    }
+
+    @Test
+    void testResolveThemeVariable() {
+        StyleEngine engine = StyleEngine.create();
+
+        Map<String, String> variables = new HashMap<>();
+        variables.put("primary", "#0000ff");
+
+        engine.setThemeVariables(variables);
+
+        // Verify variable can be resolved
+        String value = engine.resolveVariable("primary");
+        assertEquals("#0000ff", value);
+    }
+
+    @Test
+    void testResolveMissingVariable() {
+        StyleEngine engine = StyleEngine.create();
+
+        Map<String, String> variables = new HashMap<>();
+        variables.put("primary", "#0000ff");
+
+        engine.setThemeVariables(variables);
+
+        // Non-existent variable should return null
+        String value = engine.resolveVariable("nonexistent");
+        assertNull(value);
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/integration/ThemeIntegrationTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/integration/ThemeIntegrationTest.java
@@ -1,0 +1,99 @@
+package dev.tamboui.css.integration;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.css.theme.ThemeEngine;
+import dev.tamboui.theme.Theme;
+import dev.tamboui.theme.ThemeRegistry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test for theme system end-to-end flow.
+ */
+class ThemeIntegrationTest {
+
+    @Test
+    void testThemeToCSS_NordTheme() {
+        // 1. Get theme
+        Theme nord = ThemeRegistry.get("nord")
+            .orElseThrow(() -> new IllegalStateException("nord not found"));
+
+        // 2. Create theme engine
+        ThemeEngine themeEngine = new ThemeEngine(nord);
+
+        // 3. Create style engine
+        StyleEngine styleEngine = StyleEngine.create();
+
+        // 4. Inject theme variables
+        themeEngine.injectVariables(styleEngine);
+
+        // 5. Verify variables are resolvable
+        String primary = styleEngine.resolveVariable("primary");
+        assertNotNull(primary);
+        assertEquals("#88c0d0", primary);
+
+        String primaryLight = styleEngine.resolveVariable("primary-light");
+        assertNotNull(primaryLight);
+    }
+
+    @Test
+    void testThemeSwitching() {
+        ThemeEngine themeEngine = new ThemeEngine();
+        StyleEngine styleEngine = StyleEngine.create();
+
+        // Start with nord
+        themeEngine.setTheme("nord");
+        themeEngine.injectVariables(styleEngine);
+
+        String nordPrimary = styleEngine.resolveVariable("primary");
+        assertEquals("#88c0d0", nordPrimary);
+
+        // Switch to gruvbox
+        themeEngine.setTheme("gruvbox-dark");
+        themeEngine.injectVariables(styleEngine);
+
+        String gruvboxPrimary = styleEngine.resolveVariable("primary");
+        assertEquals("#83a598", gruvboxPrimary);
+    }
+
+    @Test
+    void testAutoTerminalThemeUsesANSI() {
+        Theme autoTerminal = ThemeRegistry.get("auto-terminal")
+            .orElseThrow(() -> new IllegalStateException("auto-terminal not found"));
+        ThemeEngine themeEngine = new ThemeEngine(autoTerminal);
+        StyleEngine styleEngine = StyleEngine.create();
+
+        themeEngine.injectVariables(styleEngine);
+
+        String primary = styleEngine.resolveVariable("primary");
+        assertNotNull(primary);
+        // Should be ANSI color name, not hex
+        assertTrue(primary.equals("blue") || primary.startsWith("ansi") || primary.startsWith("bright"),
+            "Expected ANSI color name but got: " + primary);
+    }
+
+    @Test
+    void testAllBuiltInThemesWork() {
+        StyleEngine styleEngine = StyleEngine.create();
+        ThemeEngine themeEngine = new ThemeEngine();
+
+        // Test all 7 built-in themes can be loaded and injected
+        String[] themes = {"auto-terminal", "tamboui-default", "nord",
+            "gruvbox-dark", "dracula", "catppuccin-mocha", "tokyo-night"};
+
+        for (String themeName : themes) {
+            themeEngine.setTheme(themeName);
+            themeEngine.injectVariables(styleEngine);
+
+            // Verify basic colors are available
+            assertNotNull(styleEngine.resolveVariable("primary"),
+                "Theme " + themeName + " missing primary color");
+            assertNotNull(styleEngine.resolveVariable("background"),
+                "Theme " + themeName + " missing background color");
+            assertNotNull(styleEngine.resolveVariable("text"),
+                "Theme " + themeName + " missing text color");
+        }
+    }
+}

--- a/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeEngineTest.java
+++ b/tamboui-css/src/test/java/dev/tamboui/css/theme/ThemeEngineTest.java
@@ -1,0 +1,124 @@
+package dev.tamboui.css.theme;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.css.cascade.CssStyleResolver;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.ColorConverter;
+import dev.tamboui.style.PropertyDefinition;
+import dev.tamboui.style.StandardProperties;
+import dev.tamboui.style.StylePropertyResolver;
+import dev.tamboui.theme.Theme;
+import dev.tamboui.theme.ThemeProperties;
+import dev.tamboui.theme.ThemeRegistry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ThemeEngineTest {
+
+    @Test
+    void testDefaultTheme() {
+        ThemeEngine engine = new ThemeEngine();
+        assertNotNull(engine.getTheme());
+        assertEquals("auto-terminal", engine.getTheme().name());
+    }
+
+    @Test
+    void testSetThemeByInstance() {
+        Theme nord = ThemeRegistry.get("nord")
+            .orElseThrow(() -> new IllegalStateException("nord theme not found"));
+        ThemeEngine engine = new ThemeEngine(nord);
+
+        assertEquals("nord", engine.getTheme().name());
+        assertNotNull(engine.getColorSystem());
+    }
+
+    @Test
+    void testSetThemeByName() {
+        ThemeEngine engine = new ThemeEngine();
+        engine.setTheme("gruvbox-dark");
+
+        assertEquals("gruvbox-dark", engine.getTheme().name());
+    }
+
+    @Test
+    void testGetResolver() {
+        ThemeEngine engine = new ThemeEngine();
+        assertNotNull(engine.getResolver());
+    }
+
+    @Test
+    void composeWithCss_cssValueTakesPrecedenceOverTheme() {
+        ThemeEngine engine = new ThemeEngine();
+        engine.setTheme("nord");
+
+        // CSS explicitly sets a color property
+        Color cssColor = Color.hex("#ff0000");
+        CssStyleResolver cssResolver = CssStyleResolver.builder()
+            .set(StandardProperties.COLOR, cssColor)
+            .build();
+
+        StylePropertyResolver composed = engine.composeWithCss(cssResolver);
+
+        // CSS value wins
+        Optional<Color> resolved = composed.get(StandardProperties.COLOR);
+        assertTrue(resolved.isPresent());
+        assertEquals(cssColor, resolved.get());
+    }
+
+    @Test
+    void composeWithCss_fallsBackToThemeWhenCssIsEmpty() {
+        ThemeEngine engine = new ThemeEngine();
+        engine.setTheme("nord");
+
+        // CSS defines nothing
+        CssStyleResolver cssResolver = CssStyleResolver.empty();
+
+        StylePropertyResolver composed = engine.composeWithCss(cssResolver);
+
+        // Theme provides primary via fallback
+        Optional<Color> primary = composed.get(ThemeProperties.PRIMARY);
+        assertTrue(primary.isPresent(), "Theme primary should be available as fallback");
+
+        // Theme provides border-focus via fallback
+        Optional<Color> borderFocus = composed.get(ThemeProperties.BORDER_FOCUS);
+        assertTrue(borderFocus.isPresent(), "Theme border-focus should be available as fallback");
+    }
+
+    @Test
+    void composeWithCss_cssPropertyDoesNotAffectUnrelatedThemeProperty() {
+        ThemeEngine engine = new ThemeEngine();
+        engine.setTheme("dracula");
+
+        // CSS sets only color
+        CssStyleResolver cssResolver = CssStyleResolver.builder()
+            .set(StandardProperties.COLOR, Color.hex("#aabbcc"))
+            .build();
+
+        StylePropertyResolver composed = engine.composeWithCss(cssResolver);
+
+        // CSS value for color
+        assertEquals(Color.hex("#aabbcc"), composed.get(StandardProperties.COLOR).orElse(null));
+
+        // Theme value for selection-bg (not in CSS)
+        Optional<Color> selectionBg = composed.get(ThemeProperties.SELECTION_BG);
+        assertTrue(selectionBg.isPresent(), "Theme selection-bg should be available when CSS doesn't define it");
+    }
+
+    @Test
+    void composeWithCss_returnsEmptyWhenNeitherHasProperty() {
+        ThemeEngine engine = new ThemeEngine();
+        engine.setTheme("nord");
+
+        CssStyleResolver cssResolver = CssStyleResolver.empty();
+        StylePropertyResolver composed = engine.composeWithCss(cssResolver);
+
+        // A property that neither CSS nor theme defines
+        PropertyDefinition<Color> unknownProp =
+            PropertyDefinition.of("nonexistent-color", ColorConverter.INSTANCE);
+        Optional<Color> result = composed.get(unknownProp);
+        assertFalse(result.isPresent());
+    }
+}

--- a/tamboui-tfx/src/main/java/dev/tamboui/tfx/TFxColorSpace.java
+++ b/tamboui-tfx/src/main/java/dev/tamboui/tfx/TFxColorSpace.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.tfx;
 
+import dev.tamboui.color.ColorManipulation;
 import dev.tamboui.style.Color;
 
 /**
@@ -216,170 +217,21 @@ public enum TFxColorSpace {
     }
     
     // Color conversion utilities
-    
+
     float[] rgbToHsl(int r, int g, int b) {
-        float rf = r / 255.0f;
-        float gf = g / 255.0f;
-        float bf = b / 255.0f;
-        
-        float max = java.lang.Math.max(rf, java.lang.Math.max(gf, bf));
-        float min = java.lang.Math.min(rf, java.lang.Math.min(gf, bf));
-        float delta = max - min;
-        
-        // Lightness
-        float l = (max + min) / 2.0f;
-        
-        // Saturation
-        float s;
-        if (delta == 0.0f) {
-            s = 0.0f;
-        } else {
-            s = delta / (1.0f - java.lang.Math.abs(2.0f * l - 1.0f));
-        }
-        
-        // Hue
-        float h;
-        if (delta == 0.0f) {
-            h = 0.0f;
-        } else if (max == rf) {
-            h = 60.0f * (((gf - bf) / delta) % 6.0f);
-        } else if (max == gf) {
-            h = 60.0f * ((bf - rf) / delta + 2.0f);
-        } else {
-            h = 60.0f * ((rf - gf) / delta + 4.0f);
-        }
-        
-        if (h < 0.0f) {
-            h += 360.0f;
-        }
-        
-        return new float[]{h, s * 100.0f, l * 100.0f};
+        return ColorManipulation.rgbToHsl(r, g, b);
     }
-    
+
     int[] hslToRgb(float h, float s, float l) {
-        h = h % 360.0f;
-        if (h < 0.0f) {
-            h += 360.0f;
-        }
-        s = s / 100.0f;
-        l = l / 100.0f;
-        
-        float c = (1.0f - java.lang.Math.abs(2.0f * l - 1.0f)) * s;
-        float x = c * (1.0f - java.lang.Math.abs((h / 60.0f) % 2.0f - 1.0f));
-        float m = l - c / 2.0f;
-        
-        float r, g, b;
-        if (h < 60.0f) {
-            r = c;
-            g = x;
-            b = 0.0f;
-        } else if (h < 120.0f) {
-            r = x;
-            g = c;
-            b = 0.0f;
-        } else if (h < 180.0f) {
-            r = 0.0f;
-            g = c;
-            b = x;
-        } else if (h < 240.0f) {
-            r = 0.0f;
-            g = x;
-            b = c;
-        } else if (h < 300.0f) {
-            r = x;
-            g = 0.0f;
-            b = c;
-        } else {
-            r = c;
-            g = 0.0f;
-            b = x;
-        }
-        
-        return new int[]{
-            java.lang.Math.round((r + m) * 255.0f),
-            java.lang.Math.round((g + m) * 255.0f),
-            java.lang.Math.round((b + m) * 255.0f)
-        };
+        return ColorManipulation.hslToRgb(h, s, l);
     }
-    
+
     float[] rgbToHsv(int r, int g, int b) {
-        float rf = r / 255.0f;
-        float gf = g / 255.0f;
-        float bf = b / 255.0f;
-        
-        float max = java.lang.Math.max(rf, java.lang.Math.max(gf, bf));
-        float min = java.lang.Math.min(rf, java.lang.Math.min(gf, bf));
-        float delta = max - min;
-        
-        // Hue
-        float h;
-        if (delta == 0.0f) {
-            h = 0.0f;
-        } else if (max == rf) {
-            h = 60.0f * (((gf - bf) / delta) % 6.0f);
-        } else if (max == gf) {
-            h = 60.0f * ((bf - rf) / delta + 2.0f);
-        } else {
-            h = 60.0f * ((rf - gf) / delta + 4.0f);
-        }
-        
-        if (h < 0.0f) {
-            h += 360.0f;
-        }
-        
-        // Saturation
-        float s = max == 0.0f ? 0.0f : delta / max;
-        
-        // Value
-        float v = max;
-        
-        return new float[]{h, s * 100.0f, v * 100.0f};
+        return ColorManipulation.rgbToHsv(r, g, b);
     }
-    
+
     int[] hsvToRgb(float h, float s, float v) {
-        h = h % 360.0f;
-        if (h < 0.0f) {
-            h += 360.0f;
-        }
-        s = s / 100.0f;
-        v = v / 100.0f;
-        
-        float c = v * s;
-        float x = c * (1.0f - java.lang.Math.abs((h / 60.0f) % 2.0f - 1.0f));
-        float m = v - c;
-        
-        float r, g, b;
-        if (h < 60.0f) {
-            r = c;
-            g = x;
-            b = 0.0f;
-        } else if (h < 120.0f) {
-            r = x;
-            g = c;
-            b = 0.0f;
-        } else if (h < 180.0f) {
-            r = 0.0f;
-            g = c;
-            b = x;
-        } else if (h < 240.0f) {
-            r = 0.0f;
-            g = x;
-            b = c;
-        } else if (h < 300.0f) {
-            r = x;
-            g = 0.0f;
-            b = c;
-        } else {
-            r = c;
-            g = 0.0f;
-            b = x;
-        }
-        
-        return new int[]{
-            java.lang.Math.round((r + m) * 255.0f),
-            java.lang.Math.round((g + m) * 255.0f),
-            java.lang.Math.round((b + m) * 255.0f)
-        };
+        return ColorManipulation.hsvToRgb(h, s, v);
     }
     
     /**
@@ -454,57 +306,55 @@ public enum TFxColorSpace {
     
     /**
      * Creates a color from HSL (Hue, Saturation, Lightness) values.
-     * 
+     *
      * @param h Hue in degrees (0-360)
      * @param s Saturation percentage (0-100)
      * @param l Lightness percentage (0-100)
      * @return An RGB color
      */
     public static Color fromHsl(float h, float s, float l) {
-        TFxColorSpace instance = HSL; // Use any instance to access private methods
-        int[] rgb = instance.hslToRgb(h, s, l);
+        int[] rgb = ColorManipulation.hslToRgb(h, s, l);
         return Color.rgb(rgb[0], rgb[1], rgb[2]);
     }
-    
+
     /**
      * Creates a color from HSV (Hue, Saturation, Value) values.
-     * 
+     *
      * @param h Hue in degrees (0-360)
      * @param s Saturation percentage (0-100)
      * @param v Value/brightness percentage (0-100)
      * @return An RGB color
      */
     public static Color fromHsv(float h, float s, float v) {
-        TFxColorSpace instance = HSV; // Use any instance to access private methods
-        int[] rgb = instance.hsvToRgb(h, s, v);
+        int[] rgb = ColorManipulation.hsvToRgb(h, s, v);
         return Color.rgb(rgb[0], rgb[1], rgb[2]);
     }
     
     /**
      * Converts a color to HSL components.
-     * 
+     *
      * @param color The color to convert
      * @return An array [hue, saturation, lightness] where:
      *         - hue is in degrees (0-360)
      *         - saturation and lightness are percentages (0-100)
      */
     public static float[] toHsl(Color color) {
-        TFxColorSpace instance = HSL; // Use any instance to access private methods
+        TFxColorSpace instance = HSL;
         int[] rgb = instance.toRgbComponents(color);
-        return instance.rgbToHsl(rgb[0], rgb[1], rgb[2]);
+        return ColorManipulation.rgbToHsl(rgb[0], rgb[1], rgb[2]);
     }
-    
+
     /**
      * Converts a color to HSV components.
-     * 
+     *
      * @param color The color to convert
      * @return An array [hue, saturation, value] where:
      *         - hue is in degrees (0-360)
      *         - saturation and value are percentages (0-100)
      */
     public static float[] toHsv(Color color) {
-        TFxColorSpace instance = HSL; // Use any instance to access private methods
+        TFxColorSpace instance = HSL;
         int[] rgb = instance.toRgbComponents(color);
-        return instance.rgbToHsv(rgb[0], rgb[1], rgb[2]);
+        return ColorManipulation.rgbToHsv(rgb[0], rgb[1], rgb[2]);
     }
 }


### PR DESCRIPTION
This is still WIP - iterating on it and mainly for now looking on feedback on names and if the integration if the theme/color system into CSS is right.

also - the widgets dont use these colors/names yet so the effect is not visible outside css-demo and theme-demo.


 Adds a Textual-inspired theme system that generates a complete color palette from a small set of semantic colors.

 ### What it does

 Define a theme with ~10 semantic colors (primary, secondary, error, success, warning, etc.) and the system auto-generates
 25+ derived colors: light/dark/muted shades, text colors with proper contrast, surface hierarchy, border colors, selection
 and hover backgrounds.

 7 built-in themes: auto-terminal (adapts to terminal ANSI colors), tamboui-default, nord, gruvbox-dark, dracula,
 catppuccin-mocha, tokyo-night.

 CSS integration: ThemeEngine injects all generated colors as TCSS $variables ($primary, $surface, $border, $text-muted,
 etc.). One stylesheet works with all themes — switch themes at runtime and the UI updates automatically.

 Java API: ThemeProperties constants + StylePropertyResolver for widgets that don't use CSS.

 Color manipulation: Color interface gains .lighten(), .darken(), .blend(), .getContrastText(), .inverse() convenience
 methods. RGB↔HSL/HSV conversions extracted from TFxColorSpace into shared ColorManipulation.

 ### What works

 - Theme definition, registration, and runtime switching
 - ColorSystem generation from seed colors
 - CSS variable injection via ThemeEngine.injectVariables()
 - composeWithCss() fallback chain (CSS → theme → default) with tests
 - CSS demo updated to use ThemeEngine with all 7 themes, showing semantic colors and generated palette swatches
 - Standalone theme demo (low-level TuiRunner)
 - Full documentation page (themes.adoc) with color tables for every built-in theme and generated variable

 ### What's questionable

 - dark flag is underused — it only picks default background/surface when not explicitly set. All built-in themes set these
 explicitly, so the flag is effectively inert. It doesn't influence shade generation direction (e.g. "muted" always blends
 toward background regardless of light/dark).
 - No light themes yet — all 7 built-in themes are dark. The generation logic should work for light themes but it's untested.
 Some derivations (e.g. border always darkens surface) may need light-mode awareness.
 - text-on-primary still uses getContrastText() (pure black/white) rather than something more nuanced — acceptable for now
 since it's for text on primary-colored backgrounds where max contrast matters.

 ### What's missing for full effect

 - Widgets don't query theme properties — toolkit elements like ListElement, FormFieldElement, TabsElement still have
 hardcoded default colors (Color.RED, Color.CYAN, etc.). CSS child selectors can override these, but out-of-the-box widgets
 won't adapt to themes without a stylesheet. For full theme integration, widgets would need to resolve their defaults from
 ThemeProperties or CSS.
 - Light theme variants — gruvbox-light, catppuccin-latte, solarized-light.
 - Missing shade variants — success/warning don't get light/dark/muted shades yet (only primary, secondary, error do). Easy
 to add when widgets need them.
 - No scrollbar/link colors — deferred until those widgets exist.
 - Terminal color querying — the auto-terminal theme uses named ANSI colors but doesn't query the terminal's actual palette via OSC sequences.
