### PR TITLE
fix: map Windows Backspace (char 8) to KeyCode.BACKSPACE

### DIFF
--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
@@ -21,7 +21,8 @@ public final class EventParser {
     private static final int ESC = 27;
     private static final int PEEK_TIMEOUT = 50;
 
-    private EventParser() {}
+    private EventParser() {
+    }
 
     /**
      * Reads and parses the next event from the backend using the default bindings.
@@ -87,14 +88,16 @@ public final class EventParser {
     private static Event parseControlChar(int c, Bindings bindings) {
         switch (c) {
             case 3:
-                return KeyEvent.ofChar('c', KeyModifiers.CTRL, bindings);  // Ctrl+C
+                return KeyEvent.ofChar('c', KeyModifiers.CTRL, bindings); // Ctrl+C
+            case 8:
+                return KeyEvent.ofKey(KeyCode.BACKSPACE, bindings); // Backspace (BS on Windows)
             case 9:
-                return KeyEvent.ofKey(KeyCode.TAB, bindings);               // Tab
+                return KeyEvent.ofKey(KeyCode.TAB, bindings); // Tab
             case 10:
             case 13:
-                return KeyEvent.ofKey(KeyCode.ENTER, bindings);        // Enter (LF or CR)
+                return KeyEvent.ofKey(KeyCode.ENTER, bindings); // Enter (LF or CR)
             case 27:
-                return KeyEvent.ofKey(KeyCode.ESCAPE, bindings);           // Escape (standalone)
+                return KeyEvent.ofKey(KeyCode.ESCAPE, bindings); // Escape (standalone)
             default:
                 if (c >= 1 && c <= 26) {
                     char letter = (char) ('a' + c - 1);

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui.event;
+
+import java.io.IOException;
+
+import dev.tamboui.terminal.TestBackend;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+class EventParserTest {
+
+    @Test
+    @DisplayName("readEvent maps BS (char 8) to BACKSPACE")
+    void readEventMapsBsToBackspace() throws IOException {
+        QueueBackend backend = new QueueBackend(8);
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.BACKSPACE);
+        assertThat(keyEvent.modifiers()).isEqualTo(KeyModifiers.NONE);
+    }
+
+    private static final class QueueBackend extends TestBackend {
+
+        private final int[] input;
+
+        private int index;
+
+        private QueueBackend(int... input) {
+            super(80, 24);
+            this.input = input;
+            this.index = 0;
+        }
+
+        @Override
+        public int read(int timeoutMs) {
+            if (index >= input.length) {
+                return -2;
+            }
+            return input[index++];
+        }
+
+        @Override
+        public int peek(int timeoutMs) {
+            if (index >= input.length) {
+                return -2;
+            }
+            return input[index];
+        }
+    }
+}

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
@@ -6,9 +6,10 @@ package dev.tamboui.tui.event;
 
 import java.io.IOException;
 
-import dev.tamboui.terminal.TestBackend;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import dev.tamboui.terminal.TestBackend;
 
 import static org.assertj.core.api.Assertions.*;
 


### PR DESCRIPTION
## Summary
- map ASCII BS (char 8) to `KeyCode.BACKSPACE` in `EventParser.parseControlChar()`
- add regression test for Windows Backspace handling

## Why
On Windows terminals, Backspace is emitted as char 8 (BS). Without this mapping it becomes Ctrl+H and text deletion does not work.

Fixes #302.
