### PR TITLE
fix: let the app have multiple render threads

### DIFF
--- a/demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java
+++ b/demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java
@@ -11,14 +11,6 @@
  */
 package dev.tamboui.demo.aesh;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import org.aesh.terminal.Connection;
-import org.aesh.terminal.http.netty.NettyWebsocketTtyBootstrap;
-import org.aesh.terminal.ssh.netty.NettySshTtyBootstrap;
-
 import dev.tamboui.backend.aesh.AeshBackend;
 import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.app.ToolkitApp;
@@ -29,6 +21,11 @@ import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.widgets.input.TextAreaState;
+import org.aesh.terminal.Connection;
+import org.aesh.terminal.http.netty.NettyWebsocketTtyBootstrap;
+import org.aesh.terminal.ssh.netty.NettySshTtyBootstrap;
+
+import java.util.concurrent.TimeUnit;
 
 import static dev.tamboui.toolkit.Toolkit.*;
 
@@ -60,10 +57,6 @@ public class AeshSshHttpDemo implements java.util.function.Consumer<Connection> 
     private static final int SSH_PORT = 2222;
     private static final int HTTP_PORT = 8080;
 
-    // ==================== Shared State ====================
-
-    private final ExecutorService executor = Executors.newCachedThreadPool();
-
     // ==================== Main Entry Point ====================
 
     /**
@@ -85,8 +78,6 @@ public class AeshSshHttpDemo implements java.util.function.Consumer<Connection> 
             Thread.currentThread().join();
         } catch (InterruptedException e) {
             System.out.println("\nShutting down...");
-        } finally {
-            demo.stop();
         }
     }
 
@@ -147,7 +138,7 @@ public class AeshSshHttpDemo implements java.util.function.Consumer<Connection> 
             // Connection closed
         });
 
-        executor.submit(() -> {
+        Thread.startVirtualThread(() -> {
             try {
                 runTuiApp(connection);
             } catch (Exception e) {
@@ -179,20 +170,6 @@ public class AeshSshHttpDemo implements java.util.function.Consumer<Connection> 
         try (ToolkitRunner runner = ToolkitRunner.create(config)) {
             var app = new DemoApp();
             runner.run(() -> app.render());
-        }
-    }
-
-    // ==================== Shared Cleanup ====================
-
-    private void stop() {
-        // Shutdown executor - servers will be stopped when JVM exits
-        executor.shutdown();
-        try {
-            if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-                executor.shutdownNow();
-            }
-        } catch (InterruptedException e) {
-            executor.shutdownNow();
         }
     }
 

--- a/demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java
+++ b/demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java
@@ -11,6 +11,12 @@
  */
 package dev.tamboui.demo.aesh;
 
+import java.util.concurrent.TimeUnit;
+
+import org.aesh.terminal.Connection;
+import org.aesh.terminal.http.netty.NettyWebsocketTtyBootstrap;
+import org.aesh.terminal.ssh.netty.NettySshTtyBootstrap;
+
 import dev.tamboui.backend.aesh.AeshBackend;
 import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.app.ToolkitApp;
@@ -21,11 +27,6 @@ import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
 import dev.tamboui.widgets.input.TextAreaState;
-import org.aesh.terminal.Connection;
-import org.aesh.terminal.http.netty.NettyWebsocketTtyBootstrap;
-import org.aesh.terminal.ssh.netty.NettySshTtyBootstrap;
-
-import java.util.concurrent.TimeUnit;
 
 import static dev.tamboui.toolkit.Toolkit.*;
 

--- a/tamboui-tfx-toolkit/build.gradle.kts
+++ b/tamboui-tfx-toolkit/build.gradle.kts
@@ -7,4 +7,5 @@ description = "TFX effects integration with TamboUI Toolkit DSL"
 dependencies {
     api(projects.tambouiTfxTui)
     api(projects.tambouiToolkit)
+    testImplementation(testFixtures(projects.tambouiToolkit))
 }

--- a/tamboui-tfx-toolkit/src/test/java/dev/tamboui/tfx/toolkit/ElementEffectRegistryTest.java
+++ b/tamboui-tfx-toolkit/src/test/java/dev/tamboui/tfx/toolkit/ElementEffectRegistryTest.java
@@ -4,6 +4,13 @@
  */
 package dev.tamboui.tfx.toolkit;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
@@ -12,15 +19,9 @@ import dev.tamboui.style.Tags;
 import dev.tamboui.tfx.Effect;
 import dev.tamboui.tfx.Shader;
 import dev.tamboui.tfx.TFxDuration;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.ElementRegistry;
 import dev.tamboui.toolkit.focus.FocusManager;
-import dev.tamboui.toolkit.AbstractElementTest;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tamboui-tfx-toolkit/src/test/java/dev/tamboui/tfx/toolkit/ElementEffectRegistryTest.java
+++ b/tamboui-tfx-toolkit/src/test/java/dev/tamboui/tfx/toolkit/ElementEffectRegistryTest.java
@@ -4,13 +4,6 @@
  */
 package dev.tamboui.tfx.toolkit;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Style;
@@ -21,10 +14,17 @@ import dev.tamboui.tfx.Shader;
 import dev.tamboui.tfx.TFxDuration;
 import dev.tamboui.toolkit.element.ElementRegistry;
 import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ElementEffectRegistryTest {
+class ElementEffectRegistryTest extends AbstractElementTest {
 
     private ElementEffectRegistry effectRegistry;
     private ElementRegistry elementRegistry;

--- a/tamboui-toolkit/build.gradle.kts
+++ b/tamboui-toolkit/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     testFixturesImplementation(testFixtures(projects.tambouiTui))
     testFixturesImplementation(projects.tambouiCore)
     testFixturesImplementation(testFixtures(projects.tambouiCore))
+    testFixturesImplementation(platform(libs.junit.bom))
+    testFixturesImplementation(libs.junit.jupiter)
     testFixturesImplementation(libs.assertj.core)
 
     compileOnly(libs.jfr.polyfill)

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/CssRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/CssRenderingTest.java
@@ -17,7 +17,6 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
-import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.elements.Column;
 import dev.tamboui.toolkit.elements.Panel;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/CssRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/CssRenderingTest.java
@@ -17,6 +17,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.elements.Column;
 import dev.tamboui.toolkit.elements.Panel;
@@ -28,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test that verifies CSS styles are actually applied during rendering.
  */
-class CssRenderingTest {
+class CssRenderingTest extends AbstractElementTest {
 
     // Path to the demo's theme resources (single source of truth)
     private static final Path THEMES_DIR = Paths.get("../tamboui-css/demos/css-demo/src/main/resources/themes-css");

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/DetailedCssRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/DetailedCssRenderingTest.java
@@ -4,6 +4,12 @@
  */
 package dev.tamboui.toolkit;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.css.engine.StyleEngine;
@@ -15,12 +21,6 @@ import dev.tamboui.toolkit.elements.Column;
 import dev.tamboui.toolkit.elements.Panel;
 import dev.tamboui.toolkit.elements.Row;
 import dev.tamboui.toolkit.elements.TextElement;
-import dev.tamboui.toolkit.AbstractElementTest;
-import org.junit.jupiter.api.*;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/DetailedCssRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/DetailedCssRenderingTest.java
@@ -4,15 +4,6 @@
  */
 package dev.tamboui.toolkit;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.css.engine.StyleEngine;
@@ -24,10 +15,16 @@ import dev.tamboui.toolkit.elements.Column;
 import dev.tamboui.toolkit.elements.Panel;
 import dev.tamboui.toolkit.elements.Row;
 import dev.tamboui.toolkit.elements.TextElement;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class DetailedCssRenderingTest {
+class DetailedCssRenderingTest extends AbstractElementTest {
 
     // Path to the demo's theme resources (single source of truth)
     private static final Path THEMES_DIR = Paths.get("../tamboui-css/demos/css-demo/src/main/resources/themes-css");

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/InlineScopeIntegrationTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/InlineScopeIntegrationTest.java
@@ -15,7 +15,6 @@ import dev.tamboui.inline.InlineDisplay;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.TestBackend;
 import dev.tamboui.terminal.TestBackend.OpType;
-import dev.tamboui.toolkit.AbstractElementTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/InlineScopeIntegrationTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/InlineScopeIntegrationTest.java
@@ -15,6 +15,7 @@ import dev.tamboui.inline.InlineDisplay;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.TestBackend;
 import dev.tamboui.terminal.TestBackend.OpType;
+import dev.tamboui.toolkit.AbstractElementTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Integration test for InlineDisplay dynamic resizing behavior
  * when scopes collapse/expand.
  */
-class InlineScopeIntegrationTest {
+class InlineScopeIntegrationTest extends AbstractElementTest {
 
     private TestBackend backend;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/NamedColorCssOverrideTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/NamedColorCssOverrideTest.java
@@ -12,7 +12,6 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
-import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.elements.TextElement;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/NamedColorCssOverrideTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/NamedColorCssOverrideTest.java
@@ -12,6 +12,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.elements.TextElement;
 
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * When code uses {@code .red()} or {@code .fg(Color.RED)}, a CSS class "red" is added.
  * Theme stylesheets should be able to override the color via {@code .red { color: #FF5555; }}.
  */
-class NamedColorCssOverrideTest {
+class NamedColorCssOverrideTest extends AbstractElementTest {
 
     private static final Rect AREA = new Rect(0, 0, 10, 1);
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/ToolkitTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/ToolkitTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import dev.tamboui.layout.Constraint;
-import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.elements.BarChartElement;
 import dev.tamboui.toolkit.elements.CalendarElement;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/ToolkitTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/ToolkitTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import dev.tamboui.layout.Constraint;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.elements.BarChartElement;
 import dev.tamboui.toolkit.elements.CalendarElement;
@@ -39,7 +40,7 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * Tests for the Dsl factory methods.
  */
-class ToolkitTest {
+class ToolkitTest extends AbstractElementTest {
 
     @Nested
     @DisplayName("Text factory methods")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/ElementRegistryTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/ElementRegistryTest.java
@@ -4,12 +4,13 @@
  */
 package dev.tamboui.toolkit.element;
 
+import java.util.*;
+
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.css.cascade.PseudoClassState;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.toolkit.AbstractElementTest;
-import org.junit.jupiter.api.*;
-
-import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/ElementRegistryTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/ElementRegistryTest.java
@@ -4,28 +4,19 @@
  */
 package dev.tamboui.toolkit.element;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.css.cascade.PseudoClassState;
 import dev.tamboui.layout.Rect;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for ElementRegistry CSS selector support.
  */
-class ElementRegistryTest {
+class ElementRegistryTest extends AbstractElementTest {
 
     private ElementRegistry registry;
     private Rect area1;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
@@ -4,18 +4,19 @@
  */
 package dev.tamboui.toolkit.element;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.StyledAreaInfo;
 import dev.tamboui.style.StyledAreaRegistry;
 import dev.tamboui.style.Tags;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.event.EventRouter;
 import dev.tamboui.toolkit.focus.FocusManager;
-import dev.tamboui.toolkit.AbstractElementTest;
-import org.junit.jupiter.api.*;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/element/FaultTolerantRenderingTest.java
@@ -4,13 +4,6 @@
  */
 package dev.tamboui.toolkit.element;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.StyledAreaInfo;
@@ -19,13 +12,17 @@ import dev.tamboui.style.Tags;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.event.EventRouter;
 import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for fault-tolerant rendering in DefaultRenderContext.
  */
-class FaultTolerantRenderingTest {
+class FaultTolerantRenderingTest extends AbstractElementTest {
 
     private DefaultRenderContext context;
     private Frame frame;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/AttributeSelectorRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/AttributeSelectorRenderingTest.java
@@ -4,6 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -11,9 +15,6 @@ import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.toolkit.Toolkit.panel;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/AttributeSelectorRenderingTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/AttributeSelectorRenderingTest.java
@@ -4,18 +4,18 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.panel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * These tests verify end-to-end that attribute selectors like
  * {@code Panel[title="Test"]} match elements and apply styles.
  */
-class AttributeSelectorRenderingTest {
+class AttributeSelectorRenderingTest extends AbstractElementTest {
 
     private StyleEngine styleEngine;
     private DefaultRenderContext context;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/BarChartElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/BarChartElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -11,8 +14,6 @@ import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.barChart;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/BarChartElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/BarChartElementTest.java
@@ -4,24 +4,24 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.barChart;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for BarChartElement.
  */
-class BarChartElementTest {
+class BarChartElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes title")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CalendarElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CalendarElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -11,8 +14,6 @@ import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.calendar;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CalendarElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CalendarElementTest.java
@@ -4,24 +4,24 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.calendar;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for CalendarElement.
  */
-class CalendarElementTest {
+class CalendarElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes title")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CanvasElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CanvasElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -11,8 +14,6 @@ import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.canvas;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CanvasElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/CanvasElementTest.java
@@ -4,24 +4,24 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.canvas;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for CanvasElement.
  */
-class CanvasElementTest {
+class CanvasElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes title")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ChartElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ChartElementTest.java
@@ -12,6 +12,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
@@ -21,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for ChartElement.
  */
-class ChartElementTest {
+class ChartElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes title")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
@@ -4,6 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Flex;
@@ -14,9 +18,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnTest.java
@@ -4,10 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Flex;
@@ -15,8 +11,12 @@ import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for Column.
  */
-class ColumnTest {
+class ColumnTest extends AbstractElementTest {
 
     @Test
     @DisplayName("preferredWidth() returns 0 for empty column")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnsElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnsElementTest.java
@@ -4,6 +4,12 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -16,11 +22,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 import static dev.tamboui.toolkit.Toolkit.columns;
 import static dev.tamboui.toolkit.Toolkit.text;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnsElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ColumnsElementTest.java
@@ -4,12 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -19,16 +13,23 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.layout.columns.ColumnOrder;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
+import java.util.Arrays;
+
+import static dev.tamboui.toolkit.Toolkit.columns;
+import static dev.tamboui.toolkit.Toolkit.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for ColumnsElement.
  */
-class ColumnsElementTest {
+class ColumnsElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("preferredWidth() returns 0 for empty columns")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
@@ -4,15 +4,16 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.io.IOException;
+
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
-import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.AbstractElementTest;
-import org.junit.jupiter.api.*;
-
-import java.io.IOException;
+import dev.tamboui.toolkit.element.DefaultRenderContext;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ConstraintCssTest.java
@@ -4,18 +4,15 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.io.IOException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -23,7 +20,7 @@ import static dev.tamboui.toolkit.Toolkit.*;
 /**
  * Tests that Row and Column correctly consume CSS constraint properties.
  */
-class ConstraintCssTest {
+class ConstraintCssTest extends AbstractElementTest {
 
     private StyleEngine styleEngine;
     private DefaultRenderContext context;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DialogElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DialogElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.css.engine.StyleEngine;
@@ -13,8 +16,6 @@ import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DialogElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DialogElementTest.java
@@ -4,9 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.css.engine.StyleEngine;
@@ -14,7 +11,10 @@ import dev.tamboui.layout.Direction;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for DialogElement.
  */
-class DialogElementTest {
+class DialogElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes title")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DockTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/DockTest.java
@@ -17,6 +17,7 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.event.EventResult;
@@ -29,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for DockElement.
  */
-class DockTest {
+class DockTest extends AbstractElementTest {
 
     @Test
     @DisplayName("renders all 5 regions")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ElementChildStyleCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ElementChildStyleCssTest.java
@@ -4,6 +4,8 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -11,14 +13,13 @@ import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.component.Component;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.Element;
-import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.widgets.input.TextAreaState;
 import dev.tamboui.widgets.input.TextInputState;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
-import org.junit.jupiter.api.*;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ElementChildStyleCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ElementChildStyleCssTest.java
@@ -4,11 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -19,9 +14,11 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.component.Component;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.widgets.input.TextAreaState;
 import dev.tamboui.widgets.input.TextInputState;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
+import org.junit.jupiter.api.*;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -33,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * These tests verify the "explicit > CSS > default" priority pattern
  * implemented via {@link dev.tamboui.toolkit.element.StyledElement#resolveEffectiveStyle}.
  */
-class ElementChildStyleCssTest {
+class ElementChildStyleCssTest extends AbstractElementTest {
 
     /**
      * Minimal Component that mimics ProgressCard's structure:

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
@@ -4,14 +4,15 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ErrorPlaceholderTest.java
@@ -4,21 +4,22 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Tests for ErrorPlaceholder element.
  */
-class ErrorPlaceholderTest {
+class ErrorPlaceholderTest extends AbstractElementTest {
 
     @Test
     @DisplayName("from(Throwable, String) creates placeholder with element ID")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FlowTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FlowTest.java
@@ -4,6 +4,12 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -13,11 +19,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 import static dev.tamboui.toolkit.Toolkit.flow;
 import static dev.tamboui.toolkit.Toolkit.text;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FlowTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FlowTest.java
@@ -4,28 +4,29 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
+import java.util.Arrays;
+
+import static dev.tamboui.toolkit.Toolkit.flow;
+import static dev.tamboui.toolkit.Toolkit.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for FlowElement.
  */
-class FlowTest {
+class FlowTest extends AbstractElementTest {
 
     @Test
     @DisplayName("children flow left-to-right")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormElementTest.java
@@ -4,15 +4,16 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
-import dev.tamboui.widgets.form.*;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.toolkit.AbstractElementTest;
+import dev.tamboui.widgets.form.*;
 
 import static dev.tamboui.toolkit.Toolkit.form;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormElementTest.java
@@ -4,27 +4,23 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
+import dev.tamboui.widgets.form.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import dev.tamboui.widgets.form.FieldType;
-import dev.tamboui.widgets.form.FormState;
-import dev.tamboui.widgets.form.ValidationResult;
-import dev.tamboui.widgets.form.Validator;
-import dev.tamboui.widgets.form.Validators;
-
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.form;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for FormElement.
  */
-class FormElementTest {
+class FormElementTest extends AbstractElementTest {
 
     // ==================== Basic Form Building ====================
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormFieldElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormFieldElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
@@ -11,8 +14,6 @@ import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widgets.form.*;
 import dev.tamboui.widgets.input.TextInputState;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.toolkit.Toolkit.formField;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormFieldElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormFieldElementTest.java
@@ -4,28 +4,23 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.widgets.form.BooleanFieldState;
-import dev.tamboui.widgets.form.FieldType;
-import dev.tamboui.widgets.form.FormState;
-import dev.tamboui.widgets.form.SelectFieldState;
-import dev.tamboui.widgets.form.ValidationResult;
-import dev.tamboui.widgets.form.Validators;
+import dev.tamboui.widgets.form.*;
 import dev.tamboui.widgets.input.TextInputState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.formField;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for FormFieldElement.
  */
-class FormFieldElementTest {
+class FormFieldElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("formField renders label and input")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GaugeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GaugeElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -12,8 +15,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.toolkit.Toolkit.gauge;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GaugeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GaugeElementTest.java
@@ -4,24 +4,24 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
-import static org.assertj.core.api.Assertions.*;
+import static dev.tamboui.toolkit.Toolkit.gauge;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for GaugeElement.
  */
-class GaugeElementTest {
+class GaugeElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("GaugeElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.*;
 
 import dev.tamboui.buffer.Buffer;
@@ -13,6 +12,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widget.Widget;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GenericWidgetElementTest.java
@@ -4,9 +4,8 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
@@ -24,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Tests for GenericWidgetElement.
  */
-class GenericWidgetElementTest {
+class GenericWidgetElementTest extends AbstractElementTest {
 
     @Nested
     @DisplayName("Factory methods")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GridTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GridTest.java
@@ -4,6 +4,12 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -15,11 +21,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 import static dev.tamboui.toolkit.Toolkit.grid;
 import static dev.tamboui.toolkit.Toolkit.text;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GridTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/GridTest.java
@@ -4,12 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -18,16 +12,23 @@ import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
+import java.util.Arrays;
+
+import static dev.tamboui.toolkit.Toolkit.grid;
+import static dev.tamboui.toolkit.Toolkit.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for GridElement.
  */
-class GridTest {
+class GridTest extends AbstractElementTest {
 
     // ==================== Basic tests ====================
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
@@ -4,13 +4,14 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.text;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/InlineScopeElementTest.java
@@ -4,19 +4,19 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class InlineScopeElementTest {
+class InlineScopeElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("preferredHeight returns 0 when hidden")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LayoutElementsTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LayoutElementsTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.*;
 
 import dev.tamboui.assertj.BufferAssertions;
@@ -15,6 +14,7 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LayoutElementsTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LayoutElementsTest.java
@@ -4,9 +4,8 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
 
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
@@ -25,7 +24,7 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * Tests for layout elements (Panel, Row, Column, Spacer).
  */
-class LayoutElementsTest {
+class LayoutElementsTest extends AbstractElementTest {
 
     @Nested
     @DisplayName("Panel tests")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LineGaugeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/LineGaugeElementTest.java
@@ -12,6 +12,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -20,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for LineGaugeElement.
  */
-class LineGaugeElementTest {
+class LineGaugeElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes label")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ListElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ListElementTest.java
@@ -4,6 +4,12 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -15,11 +21,6 @@ import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.tui.error.TuiException;
 import dev.tamboui.widgets.common.ScrollBarPolicy;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 import static dev.tamboui.toolkit.Toolkit.list;
 import static dev.tamboui.toolkit.Toolkit.text;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ListElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ListElementTest.java
@@ -4,30 +4,32 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.tui.error.TuiException;
 import dev.tamboui.widgets.common.ScrollBarPolicy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import static dev.tamboui.toolkit.Toolkit.*;
-import static org.assertj.core.api.Assertions.*;
+import java.util.Arrays;
+
+import static dev.tamboui.toolkit.Toolkit.list;
+import static dev.tamboui.toolkit.Toolkit.text;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for ListElement.
  */
-class ListElementTest {
+class ListElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("ListElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextAreaElementTest.java
@@ -4,6 +4,11 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -13,10 +18,6 @@ import dev.tamboui.text.Text;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.markupTextArea;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextAreaElementTest.java
@@ -4,33 +4,28 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
-import dev.tamboui.style.Color;
-import dev.tamboui.style.Modifier;
-import dev.tamboui.style.RichTextState;
-import dev.tamboui.style.Style;
-import dev.tamboui.style.StyledAreaInfo;
-import dev.tamboui.style.StyledAreaRegistry;
+import dev.tamboui.style.*;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Text;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.markupTextArea;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for MarkupTextAreaElement.
  */
-class MarkupTextAreaElementTest {
+class MarkupTextAreaElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("MarkupTextAreaElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -13,8 +16,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/MarkupTextElementTest.java
@@ -4,17 +4,17 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for MarkupTextElement.
  */
-class MarkupTextElementTest {
+class MarkupTextElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("MarkupTextElement renders plain text")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelFlexCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelFlexCssTest.java
@@ -14,6 +14,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests that Panel consumes CSS flex layout properties.
  */
-class PanelFlexCssTest {
+class PanelFlexCssTest extends AbstractElementTest {
 
     private StyleEngine styleEngine;
     private DefaultRenderContext context;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelTest.java
@@ -15,6 +15,7 @@ import dev.tamboui.layout.Padding;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for Panel.
  */
-class PanelTest {
+class PanelTest extends AbstractElementTest {
 
     @Test
     @DisplayName("Panel exposes title attribute")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RichTextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RichTextAreaElementTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
@@ -17,8 +20,6 @@ import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.richTextArea;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RichTextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RichTextAreaElementTest.java
@@ -4,9 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
@@ -18,16 +15,19 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
 import dev.tamboui.text.Text;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
-import static dev.tamboui.toolkit.Toolkit.*;
+import static dev.tamboui.toolkit.Toolkit.richTextArea;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for RichTextAreaElement.
  */
-class RichTextAreaElementTest {
+class RichTextAreaElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("RichTextAreaElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowTest.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Flex;
@@ -13,8 +16,6 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowTest.java
@@ -4,17 +4,17 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for Row.
  */
-class RowTest {
+class RowTest extends AbstractElementTest {
 
     @Test
     @DisplayName("preferredWidth() returns 0 for empty row")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowWithPanelsTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/RowWithPanelsTest.java
@@ -7,6 +7,7 @@ package dev.tamboui.toolkit.elements;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.element.Size;
 
@@ -16,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for Row/Column preferredSize respecting length constraints.
  */
-class RowWithPanelsTest {
+class RowWithPanelsTest extends AbstractElementTest {
 
     @Test
     @DisplayName("Row preferredSize should respect length constraint")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpacerTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpacerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import dev.tamboui.layout.Constraint;
+import dev.tamboui.toolkit.AbstractElementTest;
 
 import static dev.tamboui.toolkit.Toolkit.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for Spacer.
  */
-class SpacerTest {
+class SpacerTest extends AbstractElementTest {
 
     @Test
     @DisplayName("preferredWidth() returns 0 for fill spacer")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SparklineElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SparklineElementTest.java
@@ -14,6 +14,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 
@@ -24,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for SparklineElement.
  */
-class SparklineElementTest {
+class SparklineElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("SparklineElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementCssTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +12,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.widgets.spinner.SpinnerFrameSet;
 import dev.tamboui.widgets.spinner.SpinnerStyle;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementCssTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementCssTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests CSS property resolution for SpinnerElement.
  */
-class SpinnerElementCssTest {
+class SpinnerElementCssTest extends AbstractElementTest {
 
     private DefaultRenderContext context;
     private StyleEngine styleEngine;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementTest.java
@@ -4,13 +4,13 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widgets.spinner.SpinnerState;
 import dev.tamboui.widgets.spinner.SpinnerStyle;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/SpinnerElementTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,7 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * Tests for {@link SpinnerElement}.
  */
-class SpinnerElementTest {
+class SpinnerElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("SpinnerElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/StackTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/StackTest.java
@@ -4,6 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -11,12 +15,9 @@ import dev.tamboui.layout.ContentAlignment;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.toolkit.AbstractElementTest;
-import org.junit.jupiter.api.*;
-
-import java.util.Arrays;
 
 import static dev.tamboui.toolkit.Toolkit.stack;
 import static dev.tamboui.toolkit.Toolkit.text;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/StackTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/StackTest.java
@@ -4,12 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
@@ -19,14 +13,19 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
 
-import static dev.tamboui.toolkit.Toolkit.*;
+import java.util.Arrays;
+
+import static dev.tamboui.toolkit.Toolkit.stack;
+import static dev.tamboui.toolkit.Toolkit.text;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for StackElement.
  */
-class StackTest {
+class StackTest extends AbstractElementTest {
 
     @Test
     @DisplayName("last child renders on top")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +13,7 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widgets.table.TableState;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TableElementTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +24,7 @@ import static org.assertj.core.api.Assertions.*;
 /**
  * Tests for TableElement.
  */
-class TableElementTest {
+class TableElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("TableElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TabsElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TabsElementTest.java
@@ -4,20 +4,21 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Arrays;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
-import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.widgets.tabs.TabsState;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TabsElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TabsElementTest.java
@@ -4,11 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
@@ -17,7 +12,12 @@ import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.widgets.tabs.TabsState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for TabsElement.
  */
-class TabsElementTest {
+class TabsElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("TabsElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -4,6 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.*;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Constraint;
@@ -11,17 +15,14 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.event.EventResult;
-import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
 import dev.tamboui.widgets.input.TextAreaState;
-import org.junit.jupiter.api.*;
-
-import java.util.concurrent.atomic.AtomicReference;
 
 import static dev.tamboui.toolkit.Toolkit.textArea;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -4,12 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Constraint;
@@ -20,18 +14,22 @@ import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
 import dev.tamboui.widgets.input.TextAreaState;
+import org.junit.jupiter.api.*;
 
-import static dev.tamboui.toolkit.Toolkit.*;
-import static org.assertj.core.api.Assertions.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static dev.tamboui.toolkit.Toolkit.textArea;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for TextAreaElement.
  */
-class TextAreaElementTest {
+class TextAreaElementTest extends AbstractElementTest {
 
     @Nested
     @DisplayName("Construction")
@@ -354,7 +352,7 @@ class TextAreaElementTest {
 
     @Nested
     @DisplayName("Text Change Listener")
-    class TextChangeListenerTest {
+    class TextChangeListenerTest extends AbstractElementTest {
 
         @Test
         @DisplayName("Listener is called on text change")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextElementTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.*;
 
 import dev.tamboui.buffer.Buffer;
@@ -17,6 +16,7 @@ import dev.tamboui.style.Overflow;
 import dev.tamboui.style.StandardProperties;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
 
 import static dev.tamboui.assertj.BufferAssertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextElementTest.java
@@ -4,9 +4,8 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import dev.tamboui.toolkit.AbstractElementTest;
+import org.junit.jupiter.api.*;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.cascade.CssStyleResolver;
@@ -27,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for TextElement.
  */
-class TextElementTest {
+class TextElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("TextElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextInputElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextInputElementTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +12,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.DefaultRenderContext;
 
 import static dev.tamboui.toolkit.Toolkit.*;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextInputElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextInputElementTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for TextInputElement.
  */
-class TextInputElementTest {
+class TextInputElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("styleAttributes exposes title")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TreeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TreeElementTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +13,7 @@ import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.Toolkit;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widgets.tree.GuideStyle;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TreeElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TreeElementTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for {@link TreeElement}.
  */
-class TreeElementTest {
+class TreeElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("TreeElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/WaveTextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/WaveTextElementTest.java
@@ -4,7 +4,6 @@
  */
 package dev.tamboui.toolkit.elements;
 
-import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +11,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.widgets.wavetext.WaveTextState;
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/WaveTextElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/WaveTextElementTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import dev.tamboui.toolkit.AbstractElementTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for WaveTextElement.
  */
-class WaveTextElementTest {
+class WaveTextElementTest extends AbstractElementTest {
 
     @Test
     @DisplayName("WaveTextElement fluent API chains correctly")

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/EventRouterTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/EventRouterTest.java
@@ -4,21 +4,22 @@
  */
 package dev.tamboui.toolkit.event;
 
-import dev.tamboui.layout.Rect;
-import dev.tamboui.toolkit.element.Element;
-import dev.tamboui.toolkit.element.ElementRegistry;
-import dev.tamboui.toolkit.elements.FormFieldElement;
-import dev.tamboui.toolkit.focus.FocusManager;
-import dev.tamboui.toolkit.AbstractElementTest;
-import dev.tamboui.tui.event.KeyCode;
-import dev.tamboui.tui.event.KeyEvent;
-import dev.tamboui.widgets.form.SelectFieldState;
-import dev.tamboui.widgets.input.TextInputState;
+import java.util.Arrays;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.toolkit.AbstractElementTest;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.ElementRegistry;
+import dev.tamboui.toolkit.elements.FormFieldElement;
+import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.form.SelectFieldState;
+import dev.tamboui.widgets.input.TextInputState;
 
 import static dev.tamboui.toolkit.Toolkit.formField;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/EventRouterTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/event/EventRouterTest.java
@@ -4,21 +4,21 @@
  */
 package dev.tamboui.toolkit.event;
 
-import java.util.Arrays;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import dev.tamboui.layout.Rect;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.ElementRegistry;
 import dev.tamboui.toolkit.elements.FormFieldElement;
 import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.toolkit.AbstractElementTest;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.form.SelectFieldState;
 import dev.tamboui.widgets.input.TextInputState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
 
 import static dev.tamboui.toolkit.Toolkit.formField;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for EventRouter focus navigation.
  */
-class EventRouterTest {
+class EventRouterTest extends AbstractElementTest {
 
     private FocusManager focusManager;
     private ElementRegistry elementRegistry;

--- a/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/AbstractElementTest.java
+++ b/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/AbstractElementTest.java
@@ -4,9 +4,10 @@
  */
 package dev.tamboui.toolkit;
 
-import dev.tamboui.tui.RenderThread;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+
+import dev.tamboui.tui.RenderThread;
 
 public abstract class AbstractElementTest {
 

--- a/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/AbstractElementTest.java
+++ b/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/AbstractElementTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit;
+
+import dev.tamboui.tui.RenderThread;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class AbstractElementTest {
+
+    @BeforeEach
+    void setUpRenderThread() {
+        RenderThread.markAsRenderThread();
+    }
+
+    @AfterEach
+    void tearDownRenderThread() {
+        RenderThread.clearRenderThread();
+    }
+
+}

--- a/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/AbstractElementTest.java
+++ b/tamboui-toolkit/src/testFixtures/java/dev/tamboui/toolkit/AbstractElementTest.java
@@ -7,18 +7,18 @@ package dev.tamboui.toolkit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-import dev.tamboui.tui.RenderThread;
+import dev.tamboui.tui.RenderThreadTestHelper;
 
 public abstract class AbstractElementTest {
 
     @BeforeEach
     void setUpRenderThread() {
-        RenderThread.markAsRenderThread();
+        RenderThreadTestHelper.markAsRenderThread();
     }
 
     @AfterEach
     void tearDownRenderThread() {
-        RenderThread.clearRenderThread();
+        RenderThreadTestHelper.clearRenderThread();
     }
 
 }

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiRunner.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiRunner.java
@@ -4,17 +4,6 @@
  */
 package dev.tamboui.tui;
 
-import dev.tamboui.inline.InlineDisplay;
-import dev.tamboui.layout.Size;
-import dev.tamboui.terminal.Backend;
-import dev.tamboui.terminal.BackendFactory;
-import dev.tamboui.terminal.Frame;
-import dev.tamboui.text.Text;
-import dev.tamboui.tui.event.Event;
-import dev.tamboui.tui.event.ResizeEvent;
-import dev.tamboui.tui.event.TickEvent;
-import dev.tamboui.tui.event.UiRunnable;
-
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -28,6 +17,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+
+import dev.tamboui.inline.InlineDisplay;
+import dev.tamboui.layout.Size;
+import dev.tamboui.terminal.Backend;
+import dev.tamboui.terminal.BackendFactory;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Text;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.ResizeEvent;
+import dev.tamboui.tui.event.TickEvent;
+import dev.tamboui.tui.event.UiRunnable;
 
 /**
  * Event loop for inline displays.

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiRunner.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiRunner.java
@@ -4,6 +4,17 @@
  */
 package dev.tamboui.tui;
 
+import dev.tamboui.inline.InlineDisplay;
+import dev.tamboui.layout.Size;
+import dev.tamboui.terminal.Backend;
+import dev.tamboui.terminal.BackendFactory;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Text;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.ResizeEvent;
+import dev.tamboui.tui.event.TickEvent;
+import dev.tamboui.tui.event.UiRunnable;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
@@ -17,17 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-
-import dev.tamboui.inline.InlineDisplay;
-import dev.tamboui.layout.Size;
-import dev.tamboui.terminal.Backend;
-import dev.tamboui.terminal.BackendFactory;
-import dev.tamboui.terminal.Frame;
-import dev.tamboui.text.Text;
-import dev.tamboui.tui.event.Event;
-import dev.tamboui.tui.event.ResizeEvent;
-import dev.tamboui.tui.event.TickEvent;
-import dev.tamboui.tui.event.UiRunnable;
 
 /**
  * Event loop for inline displays.
@@ -186,7 +186,7 @@ public final class InlineTuiRunner implements AutoCloseable {
      */
     public void run(InlineEventHandler handler, Renderer renderer) throws Exception {
         // Mark this thread as the render thread
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
 
         try {
             // Initial draw

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/RenderThread.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/RenderThread.java
@@ -4,18 +4,18 @@
  */
 package dev.tamboui.tui;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import dev.tamboui.tui.error.TuiException;
 
 /**
  * Utility class for render thread management.
  * <p>
  * TamboUI uses a dedicated render thread model similar to JavaFX. All rendering operations
- * must happen on the render thread. This class provides methods to check if the current
- * thread is the render thread and to assert that code is running on the render thread.
+ * must happen on a render thread. This class provides methods to check if the current
+ * thread is a render thread and to assert that code is running on one.
  * <p>
- * The render thread is set when {@link TuiRunner#run} starts and cleared when it exits.
+ * Multiple concurrent render threads are supported (e.g. for concurrent virtual TUIs).
+ * Each thread marks itself via {@link #markAsRenderThread()} when {@link TuiRunner#run}
+ * starts and unmarks itself when it exits.
  * <p>
  * <b>Usage:</b>
  * <pre>{@code
@@ -34,57 +34,49 @@ import dev.tamboui.tui.error.TuiException;
  */
 public final class RenderThread {
 
-    private static final AtomicReference<Thread> renderThread = new AtomicReference<>();
+    private static final ThreadLocal<Boolean> isRenderThread = new ThreadLocal<>();
 
     private RenderThread() {
         // Utility class
     }
 
     /**
-     * Returns whether the current thread is the render thread.
+     * Returns whether the current thread is a render thread.
      *
-     * @return true if called from the render thread, false otherwise
+     * @return true if called from a render thread, false otherwise
      */
     public static boolean isRenderThread() {
-        return Thread.currentThread() == renderThread.get();
+        return Boolean.TRUE.equals(isRenderThread.get());
     }
 
     /**
-     * Asserts that the current thread is the render thread.
+     * Asserts that the current thread is a render thread.
      * <p>
      * This should be called at the start of any method that must only be
-     * executed on the render thread.
-     * <p>
-     * The check only enforces when a render thread has been set (i.e., when
-     * TuiRunner.run() is active). If no render thread has been set, the check
-     * passes silently, allowing unit tests to run without special setup.
+     * executed on a render thread.
      *
-     * @throws IllegalStateException if a render thread has been set and this is not it
+     * @throws TuiException if this thread has not been marked as a render thread
      */
     public static void checkRenderThread() {
-        Thread ui = renderThread.get();
-        // Only enforce if render thread has been set
-        if (ui != null && Thread.currentThread() != ui) {
+        if (!Boolean.TRUE.equals(isRenderThread.get())) {
             Thread current = Thread.currentThread();
             throw new TuiException(
                 "Must be called on render thread. Current: " + current.getName() +
-                " (id=" + current.getId() + "), render thread: " + ui.getName());
+                " (id=" + current.getId() + ")");
         }
     }
 
     /**
-     * Sets the render thread. Package-private for use by TuiRunner.
-     *
-     * @param thread the thread to set as the render thread
+     * Marks the current thread as a render thread. Package-private for use by TuiRunner.
      */
-    static void setRenderThread(Thread thread) {
-        renderThread.set(thread);
+    static void markAsRenderThread() {
+        isRenderThread.set(Boolean.TRUE);
     }
 
     /**
-     * Clears the render thread reference. Package-private for use by TuiRunner.
+     * Clears the render thread mark from the current thread. Package-private for use by TuiRunner.
      */
     static void clearRenderThread() {
-        renderThread.set(null);
+        isRenderThread.remove();
     }
 }

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/RenderThread.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/RenderThread.java
@@ -69,14 +69,14 @@ public final class RenderThread {
     /**
      * Marks the current thread as a render thread. Package-private for use by TuiRunner.
      */
-    static void markAsRenderThread() {
+    public static void markAsRenderThread() {
         isRenderThread.set(Boolean.TRUE);
     }
 
     /**
      * Clears the render thread mark from the current thread. Package-private for use by TuiRunner.
      */
-    static void clearRenderThread() {
+    public static void clearRenderThread() {
         isRenderThread.remove();
     }
 }

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/RenderThread.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/RenderThread.java
@@ -69,14 +69,14 @@ public final class RenderThread {
     /**
      * Marks the current thread as a render thread. Package-private for use by TuiRunner.
      */
-    public static void markAsRenderThread() {
+    static void markAsRenderThread() {
         isRenderThread.set(Boolean.TRUE);
     }
 
     /**
      * Clears the render thread mark from the current thread. Package-private for use by TuiRunner.
      */
-    public static void clearRenderThread() {
+    static void clearRenderThread() {
         isRenderThread.remove();
     }
 }

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TuiRunner.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TuiRunner.java
@@ -4,21 +4,6 @@
  */
 package dev.tamboui.tui;
 
-import java.io.IOException;
-import java.io.PrintStream;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.error.TamboUIException;
 import dev.tamboui.layout.Rect;
@@ -39,16 +24,26 @@ import dev.tamboui.tui.error.ErrorAction;
 import dev.tamboui.tui.error.ErrorContext;
 import dev.tamboui.tui.error.RenderError;
 import dev.tamboui.tui.error.RenderErrorHandler;
-import dev.tamboui.tui.event.Event;
-import dev.tamboui.tui.event.KeyCode;
-import dev.tamboui.tui.event.KeyEvent;
-import dev.tamboui.tui.event.ResizeEvent;
-import dev.tamboui.tui.event.TickEvent;
-import dev.tamboui.tui.event.UiRunnable;
+import dev.tamboui.tui.event.*;
 import dev.tamboui.tui.overlay.DebugOverlay;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Borders;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * Main entry point for running TUI applications.
@@ -225,7 +220,7 @@ public final class TuiRunner implements AutoCloseable {
      */
     public void run(EventHandler handler, Renderer renderer) throws Exception {
         // Mark this thread as the render thread
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
 
         try {
             // Wrap renderer to add post-render processors and FPS overlay

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TuiRunner.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TuiRunner.java
@@ -4,6 +4,21 @@
  */
 package dev.tamboui.tui;
 
+import java.io.IOException;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.error.TamboUIException;
 import dev.tamboui.layout.Rect;
@@ -29,21 +44,6 @@ import dev.tamboui.tui.overlay.DebugOverlay;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Borders;
-
-import java.io.IOException;
-import java.io.PrintStream;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 
 /**
  * Main entry point for running TUI applications.

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/RenderThreadTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/RenderThreadTest.java
@@ -35,14 +35,14 @@ class RenderThreadTest {
     @Test
     @DisplayName("isRenderThread returns true when called from the render thread")
     void isRenderThread_returnsTrue_whenCalledFromRenderThread() {
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
         assertThat(RenderThread.isRenderThread()).isTrue();
     }
 
     @Test
     @DisplayName("isRenderThread returns false when called from a different thread")
     void isRenderThread_returnsFalse_whenCalledFromDifferentThread() throws Exception {
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
 
         AtomicBoolean isRenderThread = new AtomicBoolean(true);
         CountDownLatch latch = new CountDownLatch(1);
@@ -58,18 +58,17 @@ class RenderThreadTest {
     }
 
     @Test
-    @DisplayName("checkRenderThread succeeds when no render thread is set (allows testing)")
-    void checkRenderThread_succeeds_whenNoRenderThreadSet() {
+    @DisplayName("checkRenderThread throws when current thread is not marked as render thread")
+    void checkRenderThread_throws_whenNotMarked() {
         RenderThread.clearRenderThread();
 
-        // Should not throw - allows unit tests to run without special setup
-        assertThatCode(RenderThread::checkRenderThread).doesNotThrowAnyException();
+        assertThatThrownBy(RenderThread::checkRenderThread).isInstanceOf(TuiException.class);
     }
 
     @Test
     @DisplayName("checkRenderThread throws with informative message when called from wrong thread")
     void checkRenderThread_throwsInformativeException_whenCalledFromWrongThread() throws Exception {
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
 
         AtomicReference<Throwable> caught = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);
@@ -94,7 +93,7 @@ class RenderThreadTest {
     @Test
     @DisplayName("checkRenderThread succeeds when on render thread")
     void checkRenderThread_succeeds_whenOnRenderThread() {
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
 
         // Should not throw
         assertThatCode(RenderThread::checkRenderThread).doesNotThrowAnyException();
@@ -103,7 +102,7 @@ class RenderThreadTest {
     @Test
     @DisplayName("clearRenderThread resets the render thread reference")
     void clearRenderThread_resetsReference() {
-        RenderThread.setRenderThread(Thread.currentThread());
+        RenderThread.markAsRenderThread();
         assertThat(RenderThread.isRenderThread()).isTrue();
 
         RenderThread.clearRenderThread();

--- a/tamboui-tui/src/testFixtures/java/dev/tamboui/tui/RenderThreadTestHelper.java
+++ b/tamboui-tui/src/testFixtures/java/dev/tamboui/tui/RenderThreadTestHelper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.tui;
+
+public final class RenderThreadTestHelper {
+
+    private RenderThreadTestHelper() {
+    }
+
+    public static void markAsRenderThread() {
+        RenderThread.markAsRenderThread();
+    }
+
+    public static void clearRenderThread() {
+        RenderThread.clearRenderThread();
+    }
+}


### PR DESCRIPTION
This commit updates the behavior of the `RenderThread` utility, so that it checks if the current thread is marked as a render thread or not.

Technically speaking, the behavior is similar to what we had before: calling the `run()` method on the TuiRunner automatically sets the current thread as the render thread. The difference is that if there are *multiple* runners, then we won't overwrite the render thread anymore. Therefore, the callers are free to start the event loop on whatever thread they want. The Aesh demo has therefore been modified to use virtual threads for the event loop.

Closes #309 