### PR TITLE
fix(tui): recognize ESC[Z as Shift+Tab (backtab)

### DIFF
--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
@@ -159,6 +159,9 @@ public final class EventParser {
                 return KeyEvent.ofKey(KeyCode.HOME, bindings);
             case 'F':
                 return KeyEvent.ofKey(KeyCode.END, bindings);
+            case 'Z':
+                // Shift+Tab (backtab) - ESC[Z
+                return KeyEvent.ofKey(KeyCode.TAB, KeyModifiers.SHIFT, bindings);
             default:
                 return parseExtendedCSI(c, backend, bindings);
         }

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
@@ -28,6 +28,21 @@ class EventParserTest {
         assertThat(keyEvent.modifiers()).isEqualTo(KeyModifiers.NONE);
     }
 
+    @Test
+    @DisplayName("readEvent recognizes ESC[Z as Shift+Tab")
+    void readEventRecognizesShiftTab() throws IOException {
+        // ESC[Z is the standard escape sequence for Shift+Tab (backtab)
+        QueueBackend backend = new QueueBackend(27, '[', 'Z');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.TAB);
+        assertThat(keyEvent.modifiers()).isEqualTo(KeyModifiers.SHIFT);
+        assertThat(keyEvent.hasShift()).isTrue();
+    }
+
     private static final class QueueBackend extends TestBackend {
 
         private final int[] input;


### PR DESCRIPTION
EventParser now properly handles the standard terminal escape sequence ESC[Z for Shift+Tab, returning KeyCode.TAB with KeyModifiers.SHIFT instead of KeyCode.UNKNOWN. This eliminates the need for workarounds in downstream projects like https://github.com/Sanne/incus-spawn/pull/49/changes#diff-06813ea49b4ea1b2443b3f925b747ffd2a14650a9feb1d145ef56571c8644973

Assisted-By: Claude Code <noreply@anthropic.com>