### PR TITLE
Fix blurry image rendering for native protocols

### DIFF
--- a/tamboui-image/src/main/java/dev/tamboui/image/Image.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/Image.java
@@ -133,11 +133,10 @@ public final class Image implements Widget, RawOutputCapable {
             return;
         }
 
-        if (protocol.requiresRawOutput()) {
-            // Native protocols (Kitty, iTerm2): send original full-resolution image
-            // and let the terminal handle pixel scaling via c=/r= or width=/height=.
-            // This avoids double scaling (app downscale then terminal upscale) which
-            // causes blurry rendering.
+        if (protocol.handlesOwnScaling()) {
+            // Kitty, iTerm2: send original full-resolution image and let the terminal
+            // handle pixel scaling via c=/r= or width=/height=. This avoids double
+            // scaling (app downscale then terminal upscale) which causes blurry rendering.
             Rect displayArea = computeNativeDisplayArea(data, imageArea);
             try {
                 protocol.render(data, displayArea, buffer, rawOutput);
@@ -145,7 +144,7 @@ public final class Image implements Widget, RawOutputCapable {
                 throw new RuntimeIOException("Failed to render image using protocol " + protocol.name(), e);
             }
         } else {
-            // Character-based protocols (half-block, braille): pre-scale to pixel grid
+            // Sixel and character-based protocols (half-block, braille): pre-scale to pixel grid
             ImageProtocol.Resolution res = protocol.resolution();
             int gridWidth = imageArea.width() * res.widthMultiplier();
             int gridHeight = imageArea.height() * res.heightMultiplier();
@@ -183,9 +182,11 @@ public final class Image implements Widget, RawOutputCapable {
                     displayRows = area.height();
                     displayCols = Math.max(1, (int) Math.round(displayRows * cellPxH * imgAspect / cellPxW));
                 }
-                return new Rect(area.x(), area.y(),
-                    Math.min(displayCols, area.width()),
-                    Math.min(displayRows, area.height()));
+                int fitW = Math.min(displayCols, area.width());
+                int fitH = Math.min(displayRows, area.height());
+                int offsetX = (area.width() - fitW) / 2;
+                int offsetY = (area.height() - fitH) / 2;
+                return new Rect(area.x() + offsetX, area.y() + offsetY, fitW, fitH);
             }
             case FILL:
             case STRETCH:
@@ -194,9 +195,11 @@ public final class Image implements Widget, RawOutputCapable {
             default: {
                 int naturalCols = Math.max(1, (int) Math.ceil(source.width() / cellPxW));
                 int naturalRows = Math.max(1, (int) Math.ceil(source.height() / cellPxH));
-                return new Rect(area.x(), area.y(),
-                    Math.min(naturalCols, area.width()),
-                    Math.min(naturalRows, area.height()));
+                int noneW = Math.min(naturalCols, area.width());
+                int noneH = Math.min(naturalRows, area.height());
+                int noneOffX = (area.width() - noneW) / 2;
+                int noneOffY = (area.height() - noneH) / 2;
+                return new Rect(area.x() + noneOffX, area.y() + noneOffY, noneW, noneH);
             }
         }
     }

--- a/tamboui-image/src/main/java/dev/tamboui/image/Image.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/Image.java
@@ -133,18 +133,71 @@ public final class Image implements Widget, RawOutputCapable {
             return;
         }
 
-        // Scale image based on scaling mode and protocol resolution
+        if (protocol.requiresRawOutput()) {
+            // Native protocols (Kitty, iTerm2): send original full-resolution image
+            // and let the terminal handle pixel scaling via c=/r= or width=/height=.
+            // This avoids double scaling (app downscale then terminal upscale) which
+            // causes blurry rendering.
+            Rect displayArea = computeNativeDisplayArea(data, imageArea);
+            try {
+                protocol.render(data, displayArea, buffer, rawOutput);
+            } catch (IOException e) {
+                throw new RuntimeIOException("Failed to render image using protocol " + protocol.name(), e);
+            }
+        } else {
+            // Character-based protocols (half-block, braille): pre-scale to pixel grid
+            ImageProtocol.Resolution res = protocol.resolution();
+            int gridWidth = imageArea.width() * res.widthMultiplier();
+            int gridHeight = imageArea.height() * res.heightMultiplier();
+            ImageData scaledData = scaleImage(data, gridWidth, gridHeight);
+            try {
+                protocol.render(scaledData, imageArea, buffer, rawOutput);
+            } catch (IOException e) {
+                throw new RuntimeIOException("Failed to render image using protocol " + protocol.name(), e);
+            }
+        }
+    }
+
+    /**
+     * Computes the display area in cells for native protocols that handle their own
+     * pixel scaling (Kitty, iTerm2). Uses the protocol's resolution ratio for
+     * cell aspect ratio calculations.
+     */
+    private Rect computeNativeDisplayArea(ImageData source, Rect area) {
         ImageProtocol.Resolution res = protocol.resolution();
-        int gridWidth = imageArea.width() * res.widthMultiplier();
-        int gridHeight = imageArea.height() * res.heightMultiplier();
+        double cellPxW = res.widthMultiplier();
+        double cellPxH = res.heightMultiplier();
 
-        ImageData scaledData = scaleImage(data, gridWidth, gridHeight);
+        switch (scaling) {
+            case FIT: {
+                double imgAspect = (double) source.width() / source.height();
+                double areaPxW = area.width() * cellPxW;
+                double areaPxH = area.height() * cellPxH;
+                double areaAspect = areaPxW / areaPxH;
 
-        // Render using the selected protocol
-        try {
-            protocol.render(scaledData, imageArea, buffer, rawOutput);
-        } catch (IOException e) {
-            throw new RuntimeIOException("Failed to render image using protocol " + protocol.name(), e);
+                int displayCols, displayRows;
+                if (imgAspect > areaAspect) {
+                    displayCols = area.width();
+                    displayRows = Math.max(1, (int) Math.round(displayCols * cellPxW / (imgAspect * cellPxH)));
+                } else {
+                    displayRows = area.height();
+                    displayCols = Math.max(1, (int) Math.round(displayRows * cellPxH * imgAspect / cellPxW));
+                }
+                return new Rect(area.x(), area.y(),
+                    Math.min(displayCols, area.width()),
+                    Math.min(displayRows, area.height()));
+            }
+            case FILL:
+            case STRETCH:
+                return area;
+            case NONE:
+            default: {
+                int naturalCols = Math.max(1, (int) Math.ceil(source.width() / cellPxW));
+                int naturalRows = Math.max(1, (int) Math.ceil(source.height() / cellPxH));
+                return new Rect(area.x(), area.y(),
+                    Math.min(naturalCols, area.width()),
+                    Math.min(naturalRows, area.height()));
+            }
         }
     }
 

--- a/tamboui-image/src/main/java/dev/tamboui/image/ImageData.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/ImageData.java
@@ -273,7 +273,7 @@ public final class ImageData {
         BufferedImage resized = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = resized.createGraphics();
         try {
-            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
             g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
             g.drawImage(source, 0, 0, newWidth, newHeight, null);
         } finally {

--- a/tamboui-image/src/main/java/dev/tamboui/image/ImageData.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/ImageData.java
@@ -273,7 +273,7 @@ public final class ImageData {
         BufferedImage resized = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = resized.createGraphics();
         try {
-            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+            g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
             g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
             g.drawImage(source, 0, 0, newWidth, newHeight, null);
         } finally {

--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/ITermProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/ITermProtocol.java
@@ -100,6 +100,11 @@ public final class ITermProtocol implements ImageProtocol {
     }
 
     @Override
+    public boolean handlesOwnScaling() {
+        return true;
+    }
+
+    @Override
     public Resolution resolution() {
         // iTerm2 renders at pixel level, report typical cell pixel ratio
         return new Resolution(8, 16);

--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/ImageProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/ImageProtocol.java
@@ -45,6 +45,20 @@ public interface ImageProtocol {
     boolean requiresRawOutput();
 
     /**
+     * Returns true if this protocol handles its own pixel scaling via cell dimensions
+     * (e.g. Kitty's c=/r= or iTerm2's width=/height=).
+     * <p>
+     * Protocols that return true receive the original full-resolution image and a
+     * display area computed in cells. Protocols that return false (Sixel, character-based)
+     * receive a pre-scaled image.
+     *
+     * @return true if the protocol handles scaling internally
+     */
+    default boolean handlesOwnScaling() {
+        return false;
+    }
+
+    /**
      * Returns the resolution multiplier for this protocol.
      * <p>
      * This indicates how many "virtual pixels" each terminal cell can represent:

--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
@@ -111,6 +111,7 @@ public final class KittyProtocol implements ImageProtocol {
                 // a=T: action = transmit and display
                 // f=100: format = PNG
                 // t=d: transmission = direct (embedded in escape code)
+                // q=2: quiet mode — suppress terminal OK/error responses on stdin
                 // c=cols: display width in cells
                 // r=rows: display height in cells
                 // m=0/1: more chunks follow

--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
@@ -114,7 +114,7 @@ public final class KittyProtocol implements ImageProtocol {
                 // c=cols: display width in cells
                 // r=rows: display height in cells
                 // m=0/1: more chunks follow
-                cmd.append(String.format("a=T,f=100,t=d,c=%d,r=%d,m=%d;", cols, rows, more ? 1 : 0));
+                cmd.append(String.format("a=T,f=100,t=d,q=2,c=%d,r=%d,m=%d;", cols, rows, more ? 1 : 0));
                 first = false;
             } else {
                 // Subsequent chunks only need the 'm' flag
@@ -140,7 +140,7 @@ public final class KittyProtocol implements ImageProtocol {
         // f=100: format = PNG
         // t=d: transmission = direct
         // c=cols, r=rows: display size in cells
-        String cmd = String.format("%sa=T,f=100,t=d,c=%d,r=%d;%s%s",
+        String cmd = String.format("%sa=T,f=100,t=d,q=2,c=%d,r=%d;%s%s",
             APC, cols, rows, base64Data, ST);
         out.write(cmd.getBytes(StandardCharsets.US_ASCII));
     }

--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
@@ -73,6 +73,11 @@ public final class KittyProtocol implements ImageProtocol {
     }
 
     @Override
+    public boolean handlesOwnScaling() {
+        return true;
+    }
+
+    @Override
     public Resolution resolution() {
         // Kitty renders at pixel level, report typical cell pixel ratio
         return new Resolution(8, 16);


### PR DESCRIPTION
## Summary

- **Native protocols** (Kitty, iTerm2) now receive the original full-resolution image instead of a pre-scaled copy. The terminal handles a single clean downscale pass via `c=/r=` (Kitty) or `width=/height=` (iTerm2), eliminating the double-scaling blur (app downscale → terminal upscale)
- Added `q=2` (quiet mode) to Kitty protocol escape sequences to suppress terminal response messages
- Upgraded character-based protocol resize interpolation from bilinear to bicubic

## Details

Images rendered via native protocols appeared blurry because `Image.render()` was pre-scaling them to a tiny pixel grid (`cols×8 × rows×16`) before sending them to the terminal. The terminal then scaled this small image back up to fill the actual display area — two scaling passes that degraded quality.

The fix splits the render path:
- **Native protocols**: send the original image, compute a display area in cells respecting the scaling mode (FIT/FILL/STRETCH/NONE) with cell aspect ratio correction
- **Character-based protocols**: unchanged (pre-scale to virtual pixel grid)

## Test plan

- [x] All 71 existing `ImageTest` tests pass
- [ ] Visual comparison in Kitty-compatible terminal (WezTerm, Ghostty, Kitty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)