### PR TITLE
Fix image aspect ratio distortion in Kitty and iTerm2 protocols

### DIFF
--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/ITermProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/ITermProtocol.java
@@ -64,8 +64,22 @@ public final class ITermProtocol implements ImageProtocol {
             return;
         }
 
-        // Move cursor to position
-        String cursorMove = String.format("\033[%d;%dH", area.y() + 1, area.x() + 1);
+        // Compute the actual cell dimensions from the (already scaled) image pixel size.
+        // Same logic as KittyProtocol: the image was pre-scaled to fit within the pixel
+        // grid while preserving aspect ratio, so we must use the actual image cell size
+        // to avoid the terminal stretching the image to fill the full area.
+        Resolution res = resolution();
+        int imageCols = Math.max(1, (image.width() + res.widthMultiplier() - 1) / res.widthMultiplier());
+        int imageRows = Math.max(1, (image.height() + res.heightMultiplier() - 1) / res.heightMultiplier());
+        imageCols = Math.min(imageCols, area.width());
+        imageRows = Math.min(imageRows, area.height());
+
+        // Center image within the area
+        int offsetX = (area.width() - imageCols) / 2;
+        int offsetY = (area.height() - imageRows) / 2;
+
+        // Move cursor to centered position
+        String cursorMove = String.format("\033[%d;%dH", area.y() + offsetY + 1, area.x() + offsetX + 1);
         rawOutput.write(cursorMove.getBytes(StandardCharsets.US_ASCII));
 
         // Encode image as PNG
@@ -78,11 +92,11 @@ public final class ITermProtocol implements ImageProtocol {
 
         // Arguments:
         // inline=1: display inline (not as download)
-        // width=N: display width in cells
-        // height=N: display height in cells
-        // preserveAspectRatio=0: do not apply additional scaling (Image.scaleImage() handles it)
+        // width=N: display width in cells (computed from actual image size)
+        // height=N: display height in cells (computed from actual image size)
+        // preserveAspectRatio=0: no additional scaling needed since dimensions already match
         cmd.append(String.format("inline=1;width=%d;height=%d;preserveAspectRatio=0:",
-            area.width(), area.height()));
+            imageCols, imageRows));
 
         // Append base64 data
         cmd.append(base64Data);

--- a/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
+++ b/tamboui-image/src/main/java/dev/tamboui/image/protocol/KittyProtocol.java
@@ -52,17 +52,32 @@ public final class KittyProtocol implements ImageProtocol {
             return;
         }
 
-        // Move cursor to position
-        String cursorMove = String.format("\033[%d;%dH", area.y() + 1, area.x() + 1);
+        // Compute the actual cell dimensions from the (already scaled) image pixel size.
+        // The image was pre-scaled by Image.scaleImage() to fit within the pixel grid
+        // (area.width() * widthMultiplier × area.height() * heightMultiplier) while
+        // preserving aspect ratio. We must tell the terminal to display the image over
+        // exactly the number of cells the scaled image occupies — not the full area —
+        // otherwise the terminal stretches the image to fill, distorting the aspect ratio.
+        Resolution res = resolution();
+        int imageCols = Math.max(1, (image.width() + res.widthMultiplier() - 1) / res.widthMultiplier());
+        int imageRows = Math.max(1, (image.height() + res.heightMultiplier() - 1) / res.heightMultiplier());
+        imageCols = Math.min(imageCols, area.width());
+        imageRows = Math.min(imageRows, area.height());
+
+        // Center image within the area
+        int offsetX = (area.width() - imageCols) / 2;
+        int offsetY = (area.height() - imageRows) / 2;
+
+        // Move cursor to centered position
+        String cursorMove = String.format("\033[%d;%dH", area.y() + offsetY + 1, area.x() + offsetX + 1);
         rawOutput.write(cursorMove.getBytes(StandardCharsets.US_ASCII));
 
         // Encode image as PNG and then base64
-        // The image should already be scaled by Image.scaleImage() based on the scaling mode
         byte[] pngData = image.toPng();
         String base64Data = Base64.getEncoder().encodeToString(pngData);
 
-        // Send image using chunked transmission
-        sendChunked(rawOutput, base64Data, area.width(), area.height());
+        // Send image using chunked transmission with correct cell dimensions
+        sendChunked(rawOutput, base64Data, imageCols, imageRows);
 
         rawOutput.flush();
     }


### PR DESCRIPTION
## Summary
- Fix 2x horizontal stretching of images when using Kitty/iTerm2 native protocols
- Compute actual cell dimensions from the scaled image pixel size instead of using the full display area
- Center images within the available area when they don't fill it completely

## Details
`Image.scaleImage()` pre-scales images to fit within the pixel grid while preserving aspect ratio. For portrait/tall images, the scaled result is narrower than the grid. However, `KittyProtocol` and `ITermProtocol` were passing the **full area** dimensions (`c=area.width(), r=area.height()`) to the terminal, which then stretched the narrower image to fill, distorting the aspect ratio.

## Test plan
- [x] All 71 existing tests pass
- [x] Visual verification with Camel route diagrams in Ghostty (Kitty protocol)
- [ ] Visual verification in iTerm2

🤖 Generated with [Claude Code](https://claude.com/claude-code)