### PR TITLE
fix: clean up Kitty graphics images when Image widget is removed

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
@@ -30,6 +30,7 @@ public final class Frame {
     private Position cursorPosition;
     private boolean cursorVisible;
     private final Deque<String> contextKeyStack = new ArrayDeque<>();
+    private boolean hadRawOutput;
 
     Frame(Buffer buffer, OutputStream rawOutput) {
         this.buffer = buffer;
@@ -98,6 +99,7 @@ public final class Frame {
     public void renderWidget(Widget widget, Rect area) {
         if (widget instanceof RawOutputCapable) {
             ((RawOutputCapable) widget).render(area, buffer, rawOutput);
+            hadRawOutput = true;
         } else {
             widget.render(area, buffer);
         }
@@ -218,6 +220,13 @@ public final class Frame {
         if (!contextKeyStack.isEmpty()) {
             contextKeyStack.pop();
         }
+    }
+
+    /**
+     * Returns whether any {@link RawOutputCapable} widget was rendered in this frame.
+     */
+    boolean hadRawOutput() {
+        return hadRawOutput;
     }
 
     /**

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
@@ -6,7 +6,10 @@ package dev.tamboui.terminal;
 
 import java.io.OutputStream;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
 import java.util.Optional;
 
 import dev.tamboui.buffer.Buffer;
@@ -31,6 +34,7 @@ public final class Frame {
     private boolean cursorVisible;
     private final Deque<String> contextKeyStack = new ArrayDeque<>();
     private boolean hadRawOutput;
+    private List<Rect> rawOutputAreas;
 
     Frame(Buffer buffer, OutputStream rawOutput) {
         this.buffer = buffer;
@@ -100,6 +104,10 @@ public final class Frame {
         if (widget instanceof RawOutputCapable) {
             ((RawOutputCapable) widget).render(area, buffer, rawOutput);
             hadRawOutput = true;
+            if (rawOutputAreas == null) {
+                rawOutputAreas = new ArrayList<>();
+            }
+            rawOutputAreas.add(area);
         } else {
             widget.render(area, buffer);
         }
@@ -227,6 +235,13 @@ public final class Frame {
      */
     boolean hadRawOutput() {
         return hadRawOutput;
+    }
+
+    /**
+     * Returns the areas where {@link RawOutputCapable} widgets rendered in this frame.
+     */
+    List<Rect> rawOutputAreas() {
+        return rawOutputAreas != null ? rawOutputAreas : Collections.emptyList();
     }
 
     /**

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Frame.java
@@ -123,6 +123,13 @@ public final class Frame {
      */
     public <S> void renderStatefulWidget(StatefulWidget<S> widget, Rect area, S state) {
         widget.render(area, buffer, state);
+        if (widget instanceof RawOutputCapable) {
+            hadRawOutput = true;
+            if (rawOutputAreas == null) {
+                rawOutputAreas = new ArrayList<>();
+            }
+            rawOutputAreas.add(area);
+        }
     }
 
     /**

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -6,6 +6,7 @@ package dev.tamboui.terminal;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Consumer;
 
 import dev.tamboui.buffer.Buffer;
@@ -23,12 +24,16 @@ import dev.tamboui.layout.Size;
  */
 public final class Terminal<B extends Backend> implements AutoCloseable {
 
+    private static final byte[] KITTY_DELETE_ALL =
+            "\033_Ga=d,d=a\033\\".getBytes(StandardCharsets.US_ASCII);
+
     private final B backend;
     private final OutputStream rawOutput;
     private final DiffResult diffResult;
     private Buffer currentBuffer;
     private Buffer previousBuffer;
     private boolean hiddenCursor;
+    private boolean previousFrameHadRawOutput;
 
     /**
      * Creates a new terminal instance with the given backend.
@@ -133,6 +138,11 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                 Frame frame = new Frame(currentBuffer, rawOutput);
                 renderer.accept(frame);
 
+                // Clean up Kitty graphics layer when images are no longer rendered
+                if (previousFrameHadRawOutput && !frame.hadRawOutput()) {
+                    rawOutput.write(KITTY_DELETE_ALL);
+                }
+
                 // Calculate diff and draw (zero-allocation DoD variant)
                 previousBuffer.diff(currentBuffer, diffResult);
                 if (!diffResult.isEmpty()) {
@@ -171,6 +181,8 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                 previousBuffer = currentBuffer;
                 currentBuffer = temp;
 
+                previousFrameHadRawOutput = frame.hadRawOutput();
+
                 return new CompletedFrame(previousBuffer, area);
             } catch (IOException e) {
                 throw new RuntimeIOException("Failed to draw frame: " + e.getMessage(), e);
@@ -192,6 +204,10 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
         currentBuffer = Buffer.empty(area);
         previousBuffer = Buffer.empty(area);
         try {
+            if (previousFrameHadRawOutput) {
+                rawOutput.write(KITTY_DELETE_ALL);
+                previousFrameHadRawOutput = false;
+            }
             backend.clear();
         } catch (IOException e) {
             throw new RuntimeIOException("Failed to clear terminal during resize: " + e.getMessage(), e);

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -7,6 +7,7 @@ package dev.tamboui.terminal;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,8 @@ import dev.tamboui.layout.Size;
  */
 public final class Terminal<B extends Backend> implements AutoCloseable {
 
+    // Kitty graphics protocol: delete all images from the graphics layer.
+    // Non-Kitty terminals safely ignore this APC sequence.
     private static final byte[] KITTY_DELETE_ALL =
             "\033_Ga=d,d=a\033\\".getBytes(StandardCharsets.US_ASCII);
 
@@ -142,21 +145,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                 Frame frame = new Frame(currentBuffer, rawOutput);
                 renderer.accept(frame);
 
-                // Clean up images when raw-output widgets are no longer rendered.
-                // Kitty: delete-all removes the separate graphics layer.
-                // iTerm2/Sixel: overwrite previous image areas with spaces.
-                if (previousFrameHadRawOutput && !frame.hadRawOutput()) {
-                    rawOutput.write(KITTY_DELETE_ALL);
-                    for (Rect imageArea : previousRawOutputAreas) {
-                        for (int y = imageArea.y(); y < imageArea.y() + imageArea.height(); y++) {
-                            String move = String.format("\033[%d;%dH", y + 1, imageArea.x() + 1);
-                            rawOutput.write(move.getBytes(StandardCharsets.US_ASCII));
-                            byte[] spaces = new byte[imageArea.width()];
-                            Arrays.fill(spaces, (byte) ' ');
-                            rawOutput.write(spaces);
-                        }
-                    }
-                }
+                cleanupRawOutput(frame.rawOutputAreas());
 
                 // Calculate diff and draw (zero-allocation DoD variant)
                 previousBuffer.diff(currentBuffer, diffResult);
@@ -220,14 +209,66 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
         currentBuffer = Buffer.empty(area);
         previousBuffer = Buffer.empty(area);
         try {
-            if (previousFrameHadRawOutput) {
-                rawOutput.write(KITTY_DELETE_ALL);
-                previousFrameHadRawOutput = false;
-                previousRawOutputAreas = Collections.emptyList();
-            }
+            cleanupRawOutput(Collections.emptyList());
+            previousFrameHadRawOutput = false;
+            previousRawOutputAreas = Collections.emptyList();
             backend.clear();
         } catch (IOException e) {
             throw new RuntimeIOException("Failed to clear terminal during resize: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Cleans up raw output artifacts from previous frames.
+     * <p>
+     * When raw-output widgets (Kitty/iTerm2/Sixel) are removed or moved between
+     * frames, their artifacts must be explicitly cleared:
+     * <ul>
+     *   <li>Kitty: images live on a separate graphics layer, so a delete-all
+     *       command is sent when all images are removed.</li>
+     *   <li>iTerm2/Sixel: images occupy terminal cells, so stale areas are
+     *       overwritten with spaces.</li>
+     * </ul>
+     *
+     * @param currentAreas the raw output areas rendered in the current frame
+     *                     (empty list when no images are present)
+     * @throws IOException if writing cleanup sequences fails
+     */
+    private void cleanupRawOutput(List<Rect> currentAreas) throws IOException {
+        if (!previousFrameHadRawOutput) {
+            return;
+        }
+
+        List<Rect> staleAreas;
+        if (currentAreas.isEmpty()) {
+            rawOutput.write(KITTY_DELETE_ALL);
+            staleAreas = previousRawOutputAreas;
+        } else {
+            staleAreas = new ArrayList<>();
+            for (Rect prev : previousRawOutputAreas) {
+                if (!currentAreas.contains(prev)) {
+                    staleAreas.add(prev);
+                }
+            }
+        }
+
+        if (!staleAreas.isEmpty()) {
+            int maxWidth = 0;
+            for (Rect area : staleAreas) {
+                if (area.width() > maxWidth) {
+                    maxWidth = area.width();
+                }
+            }
+            byte[] spaces = new byte[maxWidth];
+            Arrays.fill(spaces, (byte) ' ');
+
+            for (Rect imageArea : staleAreas) {
+                for (int y = imageArea.y(); y < imageArea.y() + imageArea.height(); y++) {
+                    String move = String.format("\033[%d;%dH", y + 1, imageArea.x() + 1);
+                    rawOutput.write(move.getBytes(StandardCharsets.US_ASCII));
+                    rawOutput.write(spaces, 0, imageArea.width());
+                }
+            }
         }
     }
 
@@ -238,6 +279,9 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
      */
     public void clear() {
         try {
+            cleanupRawOutput(Collections.emptyList());
+            previousFrameHadRawOutput = false;
+            previousRawOutputAreas = Collections.emptyList();
             backend.clear();
             Rect area = currentBuffer.area();
             currentBuffer = Buffer.empty(area);
@@ -292,6 +336,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
     @Override
     public void close() {
         try {
+            cleanupRawOutput(Collections.emptyList());
             if (hiddenCursor) {
                 backend.showCursor();
             }

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -7,6 +7,9 @@ package dev.tamboui.terminal;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 
 import dev.tamboui.buffer.Buffer;
@@ -34,6 +37,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
     private Buffer previousBuffer;
     private boolean hiddenCursor;
     private boolean previousFrameHadRawOutput;
+    private List<Rect> previousRawOutputAreas = Collections.emptyList();
 
     /**
      * Creates a new terminal instance with the given backend.
@@ -138,9 +142,20 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                 Frame frame = new Frame(currentBuffer, rawOutput);
                 renderer.accept(frame);
 
-                // Clean up Kitty graphics layer when images are no longer rendered
+                // Clean up images when raw-output widgets are no longer rendered.
+                // Kitty: delete-all removes the separate graphics layer.
+                // iTerm2/Sixel: overwrite previous image areas with spaces.
                 if (previousFrameHadRawOutput && !frame.hadRawOutput()) {
                     rawOutput.write(KITTY_DELETE_ALL);
+                    for (Rect imageArea : previousRawOutputAreas) {
+                        for (int y = imageArea.y(); y < imageArea.y() + imageArea.height(); y++) {
+                            String move = String.format("\033[%d;%dH", y + 1, imageArea.x() + 1);
+                            rawOutput.write(move.getBytes(StandardCharsets.US_ASCII));
+                            byte[] spaces = new byte[imageArea.width()];
+                            Arrays.fill(spaces, (byte) ' ');
+                            rawOutput.write(spaces);
+                        }
+                    }
                 }
 
                 // Calculate diff and draw (zero-allocation DoD variant)
@@ -182,6 +197,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                 currentBuffer = temp;
 
                 previousFrameHadRawOutput = frame.hadRawOutput();
+                previousRawOutputAreas = frame.rawOutputAreas();
 
                 return new CompletedFrame(previousBuffer, area);
             } catch (IOException e) {
@@ -207,6 +223,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
             if (previousFrameHadRawOutput) {
                 rawOutput.write(KITTY_DELETE_ALL);
                 previousFrameHadRawOutput = false;
+                previousRawOutputAreas = Collections.emptyList();
             }
             backend.clear();
         } catch (IOException e) {

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/RawOutputCleanupTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/RawOutputCleanupTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.terminal;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.widget.RawOutputCapable;
+import dev.tamboui.widget.StatefulWidget;
+import dev.tamboui.widget.Widget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RawOutputCleanupTest {
+
+    private static final String KITTY_DELETE_ALL = "\033_Ga=d,d=a\033\\";
+
+    static class RawWidget implements Widget, RawOutputCapable {
+        @Override
+        public void render(Rect area, Buffer buffer) {
+        }
+
+        @Override
+        public void render(Rect area, Buffer buffer, OutputStream rawOutput) {
+            try {
+                rawOutput.write("IMG".getBytes(StandardCharsets.US_ASCII));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    static class PlainWidget implements Widget {
+        @Override
+        public void render(Rect area, Buffer buffer) {
+        }
+    }
+
+    static class RawStatefulWidget implements StatefulWidget<Void>, RawOutputCapable {
+        @Override
+        public void render(Rect area, Buffer buffer, Void state) {
+        }
+
+        @Override
+        public void render(Rect area, Buffer buffer, OutputStream rawOutput) {
+        }
+    }
+
+    @Nested
+    @DisplayName("Frame raw output tracking")
+    class FrameTracking {
+
+        @Test
+        @DisplayName("renderWidget tracks RawOutputCapable widget")
+        void renderWidgetTracksRawOutput() {
+            Buffer buf = Buffer.empty(Rect.of(10, 5));
+            Frame frame = new Frame(buf, new NullOutputStream());
+
+            frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3));
+
+            assertThat(frame.hadRawOutput()).isTrue();
+            assertThat(frame.rawOutputAreas()).containsExactly(new Rect(0, 0, 5, 3));
+        }
+
+        @Test
+        @DisplayName("renderWidget does not track plain widget")
+        void renderWidgetNoTrackingForPlain() {
+            Buffer buf = Buffer.empty(Rect.of(10, 5));
+            Frame frame = new Frame(buf, new NullOutputStream());
+
+            frame.renderWidget(new PlainWidget(), new Rect(0, 0, 5, 3));
+
+            assertThat(frame.hadRawOutput()).isFalse();
+            assertThat(frame.rawOutputAreas()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("renderStatefulWidget tracks RawOutputCapable widget")
+        void renderStatefulWidgetTracksRawOutput() {
+            Buffer buf = Buffer.empty(Rect.of(10, 5));
+            Frame frame = new Frame(buf, new NullOutputStream());
+
+            frame.renderStatefulWidget(new RawStatefulWidget(), new Rect(1, 1, 4, 2), null);
+
+            assertThat(frame.hadRawOutput()).isTrue();
+            assertThat(frame.rawOutputAreas()).containsExactly(new Rect(1, 1, 4, 2));
+        }
+
+        @Test
+        @DisplayName("multiple raw widgets accumulate areas")
+        void multipleRawWidgets() {
+            Buffer buf = Buffer.empty(Rect.of(20, 10));
+            Frame frame = new Frame(buf, new NullOutputStream());
+
+            frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3));
+            frame.renderWidget(new RawWidget(), new Rect(10, 0, 5, 3));
+
+            assertThat(frame.hadRawOutput()).isTrue();
+            assertThat(frame.rawOutputAreas()).containsExactly(
+                    new Rect(0, 0, 5, 3),
+                    new Rect(10, 0, 5, 3));
+        }
+    }
+
+    @Nested
+    @DisplayName("Terminal cleanup on image removal")
+    class TerminalCleanup {
+
+        private TestBackend backend;
+        private Terminal<TestBackend> terminal;
+
+        @BeforeEach
+        void setUp() {
+            backend = new TestBackend(20, 10);
+            terminal = new Terminal<>(backend);
+        }
+
+        @Test
+        @DisplayName("sends Kitty delete-all and space overwrite when image removed")
+        void cleanupOnImageRemoval() {
+            // Frame 1: render with raw output widget
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3)));
+
+            backend.reset();
+
+            // Frame 2: render without raw output widget
+            terminal.draw(frame -> frame.renderWidget(new PlainWidget(), new Rect(0, 0, 5, 3)));
+
+            String raw = backend.rawOutput();
+            assertThat(raw).contains(KITTY_DELETE_ALL);
+            // Should contain cursor moves and spaces for the 5x3 area
+            assertThat(raw).contains("\033[1;1H");
+            assertThat(raw).contains("\033[2;1H");
+            assertThat(raw).contains("\033[3;1H");
+        }
+
+        @Test
+        @DisplayName("no cleanup when no previous raw output")
+        void noCleanupWithoutPreviousRawOutput() {
+            // Frame 1: render plain widget
+            terminal.draw(frame -> frame.renderWidget(new PlainWidget(), new Rect(0, 0, 5, 3)));
+
+            backend.reset();
+
+            // Frame 2: another plain widget
+            terminal.draw(frame -> frame.renderWidget(new PlainWidget(), new Rect(0, 0, 5, 3)));
+
+            String raw = backend.rawOutput();
+            assertThat(raw).doesNotContain(KITTY_DELETE_ALL);
+        }
+
+        @Test
+        @DisplayName("no cleanup when image stays in same area")
+        void noCleanupWhenImageStays() {
+            Rect imageArea = new Rect(0, 0, 5, 3);
+
+            // Frame 1: raw widget at position
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), imageArea));
+
+            backend.reset();
+
+            // Frame 2: raw widget at same position
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), imageArea));
+
+            String raw = backend.rawOutput();
+            // Should NOT contain delete-all (image still present)
+            assertThat(raw).doesNotContain(KITTY_DELETE_ALL);
+            // Should NOT contain space overwrites (area unchanged)
+            assertThat(raw).doesNotContain("\033[1;1H");
+        }
+
+        @Test
+        @DisplayName("overwrites stale area when image moves")
+        void cleanupWhenImageMoves() {
+            // Frame 1: raw widget at position A
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3)));
+
+            backend.reset();
+
+            // Frame 2: raw widget at position B (moved)
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), new Rect(10, 0, 5, 3)));
+
+            String raw = backend.rawOutput();
+            // Should NOT delete-all (current frame still has an image)
+            assertThat(raw).doesNotContain(KITTY_DELETE_ALL);
+            // Should overwrite the OLD area (0,0 5x3) with spaces
+            assertThat(raw).contains("\033[1;1H");
+            assertThat(raw).contains("\033[2;1H");
+            assertThat(raw).contains("\033[3;1H");
+        }
+
+        @Test
+        @DisplayName("cleanup on terminal clear()")
+        void cleanupOnClear() {
+            // Render with raw output
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3)));
+
+            backend.reset();
+
+            terminal.clear();
+
+            String raw = backend.rawOutput();
+            assertThat(raw).contains(KITTY_DELETE_ALL);
+        }
+
+        @Test
+        @DisplayName("cleanup on terminal close()")
+        void cleanupOnClose() {
+            // Render with raw output
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3)));
+
+            backend.reset();
+
+            terminal.close();
+
+            String raw = backend.rawOutput();
+            assertThat(raw).contains(KITTY_DELETE_ALL);
+        }
+
+        @Test
+        @DisplayName("cleanup on terminal resize")
+        void cleanupOnResize() {
+            // Render with raw output
+            terminal.draw(frame -> frame.renderWidget(new RawWidget(), new Rect(0, 0, 5, 3)));
+
+            backend.reset();
+
+            // Trigger resize by changing backend size
+            backend.resize(40, 20);
+            terminal.draw(frame -> frame.renderWidget(new PlainWidget(), new Rect(0, 0, 5, 3)));
+
+            String raw = backend.rawOutput();
+            assertThat(raw).contains(KITTY_DELETE_ALL);
+        }
+    }
+
+    private static class NullOutputStream extends OutputStream {
+        @Override
+        public void write(int b) {
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Track areas where `RawOutputCapable` widgets render per frame via `Frame.rawOutputAreas()`
- When transitioning from a frame with raw output to one without:
  - **Kitty**: send delete-all command (`\033_Ga=d,d=a\033\`) to clear the separate graphics layer
  - **iTerm2/Sixel**: overwrite previous image areas with spaces via raw output, since these protocols render images inline in cells that the buffer diff system doesn't track
- Also clean up on terminal resize, since images persist across screen clears

## Context
Raw-output image protocols (Kitty, iTerm2, Sixel) bypass the text buffer and write directly to the terminal. When an `Image` widget is rendered in one frame but absent from the next, the buffer diff detects no change for those cells, so no overwrite is sent — the image lingers on screen.

Kitty is the worst case because its graphics layer is fully independent of the text buffer. iTerm2 and Sixel render inline but the cells aren't tracked by the buffer, producing the same effect.

Braille and HalfBlock protocols are unaffected — they write Unicode characters directly into the buffer, so the diff handles cleanup naturally.

## Test plan
- [ ] Display an `Image` widget using Kitty protocol, then navigate away — image should disappear
- [ ] Same test with iTerm2 protocol
- [ ] Resize the terminal while an image is displayed — image should be cleaned up
- [ ] Verify existing tests pass (`./gradlew :tamboui-core:test` — 527 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)