### PR TITLE
Fix IllegalArgumentException in replaceEmoji for unknown codes with dollar signs

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/text/MarkupParser.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/MarkupParser.java
@@ -621,7 +621,7 @@ public final class MarkupParser {
                 matcher.appendReplacement(result, Matcher.quoteReplacement(emoji));
             } else {
                 // Unknown emoji code - leave it as-is
-                matcher.appendReplacement(result, matcher.group(0));
+                matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(0)));
             }
         }
         matcher.appendTail(result);

--- a/tamboui-core/src/test/java/dev/tamboui/text/EmojiMarkupParserTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/text/EmojiMarkupParserTest.java
@@ -81,6 +81,13 @@ class EmojiMarkupParserTest {
     }
 
     @Test
+    @DisplayName("unknown emoji codes with dollar signs do not throw")
+    void unknownEmojiCodesWithDollarSign() {
+        assertThat(replaceEmoji(":unknown$1: text")).isEqualTo(":unknown$1: text");
+        assertThat(replaceEmoji("before :no$match: after")).isEqualTo("before :no$match: after");
+    }
+
+    @Test
     @DisplayName("MarkupParser.parse can disable emoji replacement")
     void markupParserCanDisableEmoji() {
         Text text = MarkupParser.parse(":warning: Alert!", null, false);


### PR DESCRIPTION
When an unknown emoji code contained a dollar sign (e.g. `:unknown$1:`), `Matcher.appendReplacement()` interpreted it as a group reference, throwing:

```
java.lang.IllegalArgumentException: Illegal group reference
    at java.base/java.util.regex.Matcher.appendExpandedReplacement(Matcher.java:1111)
    at java.base/java.util.regex.Matcher.appendReplacement(Matcher.java:949)
    at dev.tamboui.text.MarkupParser.replaceEmoji(MarkupParser.java:624)
```

**Fix:** Wrap `matcher.group(0)` in `Matcher.quoteReplacement()` in the unknown-emoji branch, matching the handling already used for resolved emoji values on the line above.

**Regression test added** for unknown emoji codes containing `$` characters.