### PR TITLE
Allow rendering form field inputs before their labels

### DIFF
--- a/docs/src/snippets/java/dev/tamboui/docs/snippets/FormsSnippets.java
+++ b/docs/src/snippets/java/dev/tamboui/docs/snippets/FormsSnippets.java
@@ -90,13 +90,16 @@ public class FormsSnippets {
 
     void booleanFields() {
         // tag::boolean-fields[]
-        BooleanFieldState subscribeState = new BooleanFieldState(false);
+        BooleanFieldState state = new BooleanFieldState(false);
 
-        // Checkbox style: [x] or [ ]
-        formField("Subscribe", subscribeState);
+        // Checkbox style: “Subscribe [x]” or “Subscribe [ ]”
+        formField("Subscribe", state);
 
-        // Toggle style: [ON] or [OFF]
-        formField("Dark Mode", subscribeState, FieldType.TOGGLE);
+        // Toggle style: “● Yes / ○ No”
+        formField("Dark Mode", state, FieldType.TOGGLE);
+
+        // Display the checkbox before the label “[x] Overdrive”
+        formField("Overdrive", state).inputBeforeLabel(true);
         // end::boolean-fields[]
     }
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/FormElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/FormElement.java
@@ -7,10 +7,12 @@ package dev.tamboui.toolkit.elements;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import dev.tamboui.layout.Rect;
@@ -95,6 +97,9 @@ public final class FormElement extends StyledElement<FormElement> {
     private Color focusedBorderColor;
     private Color errorBorderColor;
     private boolean showInlineErrors = false;
+
+    // List of FieldTypes to render input before label
+    private final Set<FieldType> inputBeforeLabelTypes = new HashSet<>();
 
     // Group styling
     private Style groupTitleStyle;
@@ -328,6 +333,20 @@ public final class FormElement extends StyledElement<FormElement> {
      */
     public FormElement groupTitleStyle(Style style) {
         this.groupTitleStyle = style;
+        return this;
+    }
+
+    /**
+     * Sets the field types that should render their input before label.
+     * 
+     * @see FormFieldElement#inputBeforeLabel(boolean)
+     *
+     * @param types the field types
+     * @return this element for chaining
+     */
+    public FormElement inputBeforeLabelTypes(FieldType... types) {
+        this.inputBeforeLabelTypes.clear();
+        Collections.addAll(this.inputBeforeLabelTypes, types);
         return this;
     }
 
@@ -642,6 +661,10 @@ public final class FormElement extends StyledElement<FormElement> {
         }
         if (showInlineErrors) {
             field.showInlineErrors(true);
+        }
+
+        if (inputBeforeLabelTypes.contains(config.type)) {
+            field.inputBeforeLabel(true);
         }
 
         // Apply validators

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/FormFieldElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/FormFieldElement.java
@@ -86,6 +86,7 @@ public final class FormFieldElement extends StyledElement<FormFieldElement> {
     // Layout
     private int labelWidth = DEFAULT_LABEL_WIDTH;
     private int spacing = DEFAULT_SPACING;
+    private boolean inputBeforeLabel = false;
 
     // Styling
     private Style labelStyle;
@@ -275,6 +276,30 @@ public final class FormFieldElement extends StyledElement<FormFieldElement> {
      */
     public FormFieldElement spacing(int spacing) {
         this.spacing = Math.max(0, spacing);
+        return this;
+    }
+
+    /**
+     * Sets if the input should be displayed before the label.
+     *
+     * For example, a checkbox with {@code inputBeforeLabel=false} (default) will render
+     * as "Label [x]" whereas {@code inputBeforeLabel=true} will render "[x] Label"
+     *
+     * @param inputBeforeLabel true if the input should be before the label, false otherwise
+     * @return this element for chaining
+     */
+    public FormFieldElement inputBeforeLabel(boolean inputBeforeLabel) {
+        this.inputBeforeLabel = inputBeforeLabel;
+        return this;
+    }
+
+    /**
+     * Sets the input to be displayed before the label ("[x] Label")
+     *
+     * @return this element for chaining
+     */
+    public FormFieldElement inputBeforeLabel() {
+        inputBeforeLabel(true);
         return this;
     }
 
@@ -715,9 +740,18 @@ public final class FormFieldElement extends StyledElement<FormFieldElement> {
         Style effectiveErrorStyle = resolveEffectiveStyle(context, "error", errorStyle, DEFAULT_ERROR_STYLE);
 
         // Calculate layout
-        int effectiveLabelWidth = Math.min(labelWidth, area.width() - 1);
-        int inputX = area.x() + effectiveLabelWidth + spacing;
-        int inputWidth = area.width() - effectiveLabelWidth - spacing;
+        int inputX, labelX, effectiveLabelWidth, inputWidth;
+        if (inputBeforeLabel) {
+            inputWidth = area.width() - labelWidth - spacing;
+            effectiveLabelWidth = Math.min(labelWidth, area.width() - 1);
+            inputX = area.x();
+            labelX = area.x() + inputWidth + spacing;
+        } else {
+            effectiveLabelWidth = Math.min(labelWidth, area.width() - 1);
+            inputWidth = area.width() - effectiveLabelWidth - spacing;
+            labelX = area.x();
+            inputX = area.x() + effectiveLabelWidth + spacing;
+        }
 
         // Determine if we need error row
         boolean hasError = !lastValidation().isValid();
@@ -725,7 +759,7 @@ public final class FormFieldElement extends StyledElement<FormFieldElement> {
         int totalHeight = showInlineErrors && hasError ? inputHeight + 1 : inputHeight;
 
         // Render label
-        Rect labelArea = new Rect(area.x(), area.y(), effectiveLabelWidth, inputHeight);
+        Rect labelArea = new Rect(labelX, area.y(), effectiveLabelWidth, inputHeight);
         renderLabel(frame, labelArea, effectiveLabelStyle);
 
         // Render input

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormFieldElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/FormFieldElementTest.java
@@ -113,6 +113,46 @@ class FormFieldElementTest extends AbstractElementTest {
     }
 
     @Test
+    @DisplayName("formField checkbox with inputBeforeLabel=true renders checkbox before label")
+    void formFieldWithInputBeforeLabelShowsInputFirst() {
+        BooleanFieldState state = new BooleanFieldState(true);
+        FormFieldElement field = formField("Subscribe", state).labelWidth(9).inputBeforeLabel();
+
+        Rect area = new Rect(0, 0, 13, 1);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        field.render(frame, area, RenderContext.empty());
+
+        // Should render properly
+        String result = "";
+        for (int x = 0; x < buffer.width(); x++) {
+            result += buffer.get(x, 0).symbol();
+        }
+        assertThat(result).isEqualTo("[x] Subscribe");
+    }
+
+    @Test
+    @DisplayName("formField checkbox with inputBeforeLabel=false renders checkbox after label")
+    void formFieldWithInputBeforeLabelShowsInputLast() {
+        BooleanFieldState state = new BooleanFieldState(true);
+        FormFieldElement field = formField("Subscribe", state).labelWidth(9).inputBeforeLabel(false);
+
+        Rect area = new Rect(0, 0, 13, 1);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        field.render(frame, area, RenderContext.empty());
+
+        // Should render properly
+        String result = "";
+        for (int x = 0; x < buffer.width(); x++) {
+            result += buffer.get(x, 0).symbol();
+        }
+        assertThat(result).isEqualTo("Subscribe [x]");
+    }
+
+    @Test
     @DisplayName("formField with SelectFieldState renders select")
     void formFieldWithSelectRendersSelect() {
         SelectFieldState state = new SelectFieldState("USA", "UK", "Germany");


### PR DESCRIPTION
This adds a property `inputBeforeLabel` to `FormFieldElement` which will render a field's input before the label. This is helpful for a left-aligned form; my particular use case has a lot of checkboxes.

### Usage

This is entirely opt-in; **no breaking changes** are included here.

```java
// single field usage
formField("Overdrive", state).inputBeforeLabel(true);
// form usage
form(state)
  .field("foo", "Overdrive", FieldType.CHECKBOX)
  // can specify as many as applicable
  // works before or after fields are specified, too
  .inputBeforeLabelTypes(FieldType.CHECKBOX, FieldType.TOGGLE);
```

### Results

This allows a much more natural look:
```
[x] Option 1
[ ] Option 2 (not as cool)
[x] Option 3
...
```

compared to the more awkward (particularly with long labels)
```
Option 1 [x]
Option 2 (not as cool) [ ]
Option 3 [x]
...
```