### PR TITLE
Add new Scrollable element

### DIFF
--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -402,6 +402,15 @@ ListElement provides methods for navigation:
 include::{snippets-dir}/dev/tamboui/docs/snippets/ApiLevelsSnippets.java[tags=list-element-navigation]
 ----
 
+=== Scrolling
+
+For a convenient vertical scrolling container that works out of the box with keyboard and mouse controls, use `scrollable()`:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ApiLevelsSnippets.java[tags=scrollable-usage]
+----
+
 === Event Handling
 
 Attach handlers to elements:

--- a/docs/src/snippets/java/dev/tamboui/docs/snippets/ApiLevelsSnippets.java
+++ b/docs/src/snippets/java/dev/tamboui/docs/snippets/ApiLevelsSnippets.java
@@ -588,6 +588,14 @@ public class ApiLevelsSnippets {
         // end::list-element-navigation[]
     }
 
+    void scrollableUsage() {
+        // tag::scrollable-usage[]
+        scrollable(children)
+            .scrollUpIndicator(text("[scroll up to see more...]").dim())
+            .scrollDownIndicator(text("[scroll down to see more...]").dim());
+        // end::scrollable-usage[]
+    }
+
     void eventHandling() {
         // tag::event-handling[]
         panel("Interactive")

--- a/docs/video/scrollable-demo.tape
+++ b/docs/video/scrollable-demo.tape
@@ -1,0 +1,14 @@
+Source shared_.tape
+
+# Setup
+Hide
+Type jbang scrollable-demo
+Enter
+Sleep 2
+Show
+
+# Recording
+Type "jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj"
+Screenshot screenshots/scrollable-demo.svg
+Type "kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk"
+Sleep 2

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -112,6 +112,9 @@
     "richtext-demo": {
       "script-ref": "tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java"
     },
+    "scrollable-demo": {
+      "script-ref": "tamboui-toolkit/demos/scrollable-demo/src/main/java/dev/tamboui/demo/ScrollableDemo.java"
+    },
     "textarea-demo": {
       "script-ref": "tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java"
     },

--- a/tamboui-toolkit/demos/scrollable-demo/build.gradle.kts
+++ b/tamboui-toolkit/demos/scrollable-demo/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Demo showing Scrollable viewport on a list"
+
+demo {
+    displayName = "Scrollable"
+    tags = setOf("toolkit", "layout")
+}
+
+dependencies {
+    implementation(projects.tambouiToolkit)
+    // Note: tamboui-panama-backend is used via jbang script header
+    // If building with Gradle, ensure tamboui-panama-backend is available
+    // either as a project dependency or from Maven repositories
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.ScrollableDemo")
+}
+

--- a/tamboui-toolkit/demos/scrollable-demo/src/main/java/dev/tamboui/demo/ScrollableDemo.java
+++ b/tamboui-toolkit/demos/scrollable-demo/src/main/java/dev/tamboui/demo/ScrollableDemo.java
@@ -1,0 +1,67 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS dev.tamboui:tamboui-toolkit:LATEST
+//DEPS dev.tamboui:tamboui-jline3-backend:LATEST
+
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo;
+
+import java.time.Duration;
+import java.util.stream.IntStream;
+
+import dev.tamboui.toolkit.app.ToolkitApp;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.elements.ScrollableElement;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.bindings.BindingSets;
+import dev.tamboui.widgets.form.BooleanFieldState;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+
+/**
+ * Scrollable demo with a large list of items.
+ */
+public final class ScrollableDemo extends ToolkitApp {
+
+    private final ScrollableElement scrollable;
+
+    private ScrollableDemo() {
+        this.scrollable = scrollable(
+            IntStream.range(0, 100)
+                .mapToObj(i -> formField("Row " + i, new BooleanFieldState()))
+                .toArray(Element[]::new)
+        )
+          .scrollUpIndicator(text("[scroll up to see more...]").dim())
+          .scrollDownIndicator(text("[scroll down to see more...]").dim())
+          .fill();
+    }
+
+    /**
+     * Demo entry point.
+     * @param args the CLI arguments
+     * @throws Exception on unexpected error
+     */
+    public static void main(String[] args) throws Exception {
+        new ScrollableDemo().run();
+    }
+
+    @Override
+    protected TuiConfig configure() {
+        return TuiConfig.builder()
+            .tickRate(Duration.ofMillis(100))
+            .mouseCapture(false)
+            .bindings(BindingSets.vim())
+            .build();
+    }
+
+    @Override
+    protected Element render() {
+        return panel(this.scrollable)
+            .id("root")
+            .focusable()
+            .rounded()
+            .bottomTitle("[jk or scroll] Scroll");
+    }
+}

--- a/tamboui-toolkit/demos/scrollable-demo/src/main/java/dev/tamboui/demo/ScrollableDemo.java
+++ b/tamboui-toolkit/demos/scrollable-demo/src/main/java/dev/tamboui/demo/ScrollableDemo.java
@@ -51,7 +51,7 @@ public final class ScrollableDemo extends ToolkitApp {
     protected TuiConfig configure() {
         return TuiConfig.builder()
             .tickRate(Duration.ofMillis(100))
-            .mouseCapture(false)
+            .mouseCapture(true)
             .bindings(BindingSets.vim())
             .build();
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -37,7 +37,7 @@ import dev.tamboui.toolkit.elements.Panel;
 import dev.tamboui.toolkit.elements.RichTextAreaElement;
 import dev.tamboui.toolkit.elements.RichTextElement;
 import dev.tamboui.toolkit.elements.Row;
-import dev.tamboui.toolkit.elements.Scrollable;
+import dev.tamboui.toolkit.elements.ScrollableElement;
 import dev.tamboui.toolkit.elements.ScrollbarElement;
 import dev.tamboui.toolkit.elements.Spacer;
 import dev.tamboui.toolkit.elements.SparklineElement;
@@ -364,8 +364,8 @@ public final class Toolkit {
      * @param children the child elements
      * @return a new scrollable
      */
-    public static Scrollable scrollable(ScrollbarElement scrollbar, Element... children) {
-        return new Scrollable(scrollbar).add(children);
+    public static ScrollableElement scrollable(ScrollbarElement scrollbar, Element... children) {
+        return new ScrollableElement(scrollbar).add(children);
     }
 
     /**
@@ -374,8 +374,8 @@ public final class Toolkit {
      * @param children the child elements
      * @return a new scrollable
      */
-    public static Scrollable scrollable(Element... children) {
-        return new Scrollable(children);
+    public static ScrollableElement scrollable(Element... children) {
+        return new ScrollableElement(children);
     }
 
     /**
@@ -383,8 +383,8 @@ public final class Toolkit {
      *
      * @return a new empty scrollable
      */
-    public static Scrollable scrollable() {
-        return new Scrollable();
+    public static ScrollableElement scrollable() {
+        return new ScrollableElement();
     }
 
     // ==================== Columns ====================

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -37,6 +37,7 @@ import dev.tamboui.toolkit.elements.Panel;
 import dev.tamboui.toolkit.elements.RichTextAreaElement;
 import dev.tamboui.toolkit.elements.RichTextElement;
 import dev.tamboui.toolkit.elements.Row;
+import dev.tamboui.toolkit.elements.Scrollable;
 import dev.tamboui.toolkit.elements.ScrollbarElement;
 import dev.tamboui.toolkit.elements.Spacer;
 import dev.tamboui.toolkit.elements.SparklineElement;
@@ -354,6 +355,36 @@ public final class Toolkit {
      */
     public static Column column() {
         return new Column();
+    }
+
+    /**
+     * Creates a scrollable with a scrollbar and children.
+     *
+     * @param scrollbar the scrollbar to use
+     * @param children the child elements
+     * @return a new scrollable
+     */
+    public static Scrollable scrollable(ScrollbarElement scrollbar, Element... children) {
+        return new Scrollable(scrollbar).add(children);
+    }
+
+    /**
+     * Creates a scrollable with a set of children.
+     *
+     * @param children the child elements
+     * @return a new scrollable
+     */
+    public static Scrollable scrollable(Element... children) {
+        return new Scrollable(children);
+    }
+
+    /**
+     * Creates an empty scrollable.
+     *
+     * @return a new empty scrollable
+     */
+    public static Scrollable scrollable() {
+        return new Scrollable();
     }
 
     // ==================== Columns ====================

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -358,17 +358,6 @@ public final class Toolkit {
     }
 
     /**
-     * Creates a scrollable with a scrollbar and children.
-     *
-     * @param scrollbar the scrollbar to use
-     * @param children the child elements
-     * @return a new scrollable
-     */
-    public static ScrollableElement scrollable(ScrollbarElement scrollbar, Element... children) {
-        return new ScrollableElement(scrollbar).add(children);
-    }
-
-    /**
      * Creates a scrollable with a set of children.
      *
      * @param children the child elements

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Scrollable.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Scrollable.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.css.Styleable;
+import dev.tamboui.css.cascade.CssStyleResolver;
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.ContainerElement;
+import dev.tamboui.toolkit.element.Element;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.element.Size;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.event.MouseEventKind;
+import dev.tamboui.widgets.scrollbar.Scrollbar;
+import dev.tamboui.widgets.scrollbar.ScrollbarOrientation;
+import dev.tamboui.widgets.scrollbar.ScrollbarState;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A container element with a scrollbar that allows a vertical list that overflows its bounds.
+ *
+ * Note that each child counts as one scrollable unit; children will not be split across page boundaries.
+ */
+public final class Scrollable extends ContainerElement<Scrollable> {
+
+    private final Scrollbar scrollbar;
+    private final ScrollbarState state;
+    private Element scrollUpIndicator = null;
+    private Element scrollDownIndicator = null;
+
+    /** Creates an empty scrollable container. */
+    public Scrollable() {
+        this(new Element[0]);
+    }
+
+    /**
+     * Creates a scrollable with children.
+     *
+     * @param children the child elements
+     */
+    public Scrollable(Element... children) {
+        this.scrollbar = Scrollbar.builder().orientation(ScrollbarOrientation.VERTICAL_RIGHT).build();
+        this.state = new ScrollbarState();
+        this.children.addAll(Arrays.asList(children));
+
+        this.registerHandlers();
+    }
+
+    /**
+     * Creates a scrollable with a custom scrollbar and children.
+     *
+     * @param scrollbar the scrollbar element
+     * @param children the child elements
+     */
+    public Scrollable(Scrollbar scrollbar, Element... children) {
+        this.scrollbar = scrollbar;
+        this.state = new ScrollbarState();
+        this.children.addAll(Arrays.asList(children));
+
+        this.registerHandlers();
+    }
+
+    private void registerHandlers() {
+        this.mouseHandler =
+            (MouseEvent event) -> {
+                if (event.kind() == MouseEventKind.SCROLL_UP) {
+                    this.state.prev();
+                    return EventResult.HANDLED;
+                } else if (event.kind() == MouseEventKind.SCROLL_DOWN) {
+                    this.state.next();
+                    return EventResult.HANDLED;
+                }
+                return EventResult.UNHANDLED;
+            };
+
+        this.keyHandler =
+            (KeyEvent event) -> {
+                if (event.isUp()) {
+                    this.state.prev();
+                    return EventResult.HANDLED;
+                } else if (event.isDown()) {
+                    this.state.next();
+                    return EventResult.HANDLED;
+                } else if (event.isPageUp()) {
+                    this.state.pageUp();
+                    return EventResult.HANDLED;
+                } else if (event.isPageDown()) {
+                    this.state.pageDown();
+                    return EventResult.HANDLED;
+                }
+                return EventResult.UNHANDLED;
+            };
+    }
+
+    /**
+     * Element of height 1 that will be displayed at the top of the area if there are
+     * results above the current view.
+     * @param scrollUpIndicator the indicator to use
+     * @return this, for fluent operations
+     */
+    public Scrollable scrollUpIndicator(Element scrollUpIndicator) {
+        this.scrollUpIndicator = scrollUpIndicator;
+        return this;
+    }
+
+    /**
+     * Element of height 1 that will be displayed at the bottom of the area if there are
+     * results below the current view.
+     * @param scrollDownIndicator the indicator to use
+     * @return this, for fluent operations
+     */
+    public Scrollable scrollDownIndicator(Element scrollDownIndicator) {
+        this.scrollDownIndicator = scrollDownIndicator;
+        return this;
+    }
+
+    @Override
+    public Size preferredSize(int availableWidth, int availableHeight, RenderContext context) {
+        // Calculate width (+1 for scrollbar size)
+        int width = 1;
+        if (!children.isEmpty()) {
+            // Vertical: max width of all children
+            for (Element child : children) {
+                Size childSize = child.preferredSize(availableWidth - 1, availableHeight, context);
+                width = Math.max(width, childSize.widthOr(0) + 1);
+            }
+        }
+
+        // Calculate height
+        int height = 0;
+
+        if (!children.isEmpty()) {
+            // Content width for child height calculation
+            int contentWidth = availableWidth > 0 ? Math.max(1, availableWidth - 1) : -1;
+
+            for (Element child : children) {
+                Size childSize = child.preferredSize(contentWidth, -1, context);
+                height += childSize.heightOr(1);
+            }
+        }
+
+        return Size.of(width, height);
+    }
+
+    @Override
+    protected void renderContent(Frame frame, Rect area, RenderContext context) {
+        if (area.isEmpty() || children.isEmpty()) {
+            return;
+        }
+
+        // Get inner area for children (-1 width to fit scrollbar)
+        Rect innerArea;
+        Rect scrollbarArea;
+        if (scrollbar.orientation() == ScrollbarOrientation.VERTICAL_LEFT) {
+            innerArea = new Rect(area.x() + 1, area.y(), area.width() - 1, area.height());
+            scrollbarArea = new Rect(area.x(), area.y(), 1, area.height());
+        } else if (scrollbar.orientation() == ScrollbarOrientation.VERTICAL_RIGHT) {
+            innerArea = new Rect(area.x(), area.y(), area.width() - 1, area.height());
+            scrollbarArea = new Rect(area.x() + area.width() - 1, area.y(), 1, area.height());
+        } else {
+            throw new IllegalArgumentException("Scrollable only supports vertical scrollbars.");
+        }
+        if (innerArea.isEmpty() || children.isEmpty()) {
+            return;
+        }
+
+        // Get child layout constraints
+        List<Constraint> constraints = new ArrayList<>();
+        for (Element child : children) {
+            Constraint c = child.constraint();
+            // Check CSS constraint if programmatic is null (width for horizontal, height for vertical)
+            if (c == null && child instanceof Styleable) {
+                CssStyleResolver childCss = context.resolveStyle((Styleable) child).orElse(null);
+                if (childCss != null) {
+                    c = childCss.heightConstraint().orElse(null);
+                }
+            }
+            // Handle null constraint by querying preferred size
+            if (c == null) {
+                Size size = child.preferredSize(innerArea.width(), -1, context);
+                int preferred = size.height();
+                c = preferred >= 0 ? Constraint.length(preferred) : Constraint.fill();
+            }
+            constraints.add(c);
+        }
+
+        int totalRequiredHeight = constraints
+            .stream()
+            .mapToInt(c -> {
+                if (c instanceof Constraint.Length) {
+                    return ((Constraint.Length) c).value();
+                } else {
+                    return 1;
+                }
+            })
+            .sum();
+
+        state.contentLength(totalRequiredHeight);
+
+        // go to top if all fit on the screen (or something happened and we passed the bottom)
+        if (totalRequiredHeight <= innerArea.height() || state.position() >= children.size()) {
+            state.position(0);
+        }
+
+        List<Element> visibleChildren = new ArrayList<>();
+        int heightUtilized = 0;
+        if (scrollUpIndicator != null && state.position() > 0) {
+            Rect topIndicatorArea = new Rect(innerArea.x(), innerArea.y(), innerArea.width(), 1);
+            innerArea = new Rect(innerArea.x(), innerArea.y() + 1, innerArea.width(), innerArea.height() - 1);
+            scrollUpIndicator.render(frame, topIndicatorArea, context);
+        }
+        boolean moreBelow = false;
+        int startingPosition = state.position();
+        if (startingPosition != 0 && scrollUpIndicator != null) {
+            startingPosition++;
+        }
+        for (int i = startingPosition; i < children.size(); i++) {
+            if (constraints.get(i) instanceof Constraint.Length) {
+                Constraint.Length constraint = (Constraint.Length) constraints.get(i);
+                if (heightUtilized + constraint.value() > innerArea.height()) {
+                    moreBelow = true;
+                    break;
+                }
+                heightUtilized += constraint.value();
+            } else {
+                heightUtilized += 1;
+            }
+            visibleChildren.add(children.get(i));
+        }
+
+        if (moreBelow && scrollDownIndicator != null) {
+            if (heightUtilized == innerArea.height()) {
+                // remove last child to fit indicator
+                visibleChildren.remove(visibleChildren.size() - 1);
+            }
+            Rect bottomIndicatorArea = new Rect(innerArea.x(), innerArea.y() + innerArea.height() - 1, innerArea.width(), 1);
+            innerArea = new Rect(innerArea.x(), innerArea.y(), innerArea.width(), innerArea.height() - 1);
+            scrollDownIndicator.render(frame, bottomIndicatorArea, context);
+        }
+
+        state.contentLength(children.size()).viewportContentLength(visibleChildren.size());
+
+        frame.renderStatefulWidget(scrollbar, scrollbarArea, state);
+
+        Layout layout = Layout.vertical().constraints(constraints.toArray(new Constraint[0]));
+        List<Rect> areas = layout.split(innerArea);
+
+        // Render children
+        for (int i = 0; i < visibleChildren.size() && i < areas.size(); i++) {
+            Element child = visibleChildren.get(i);
+            Rect childArea = areas.get(i);
+            context.renderChild(child, frame, childArea);
+        }
+    }
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * Note that each child counts as one scrollable unit; children will not be split across page boundaries.
  */
-public final class Scrollable extends ContainerElement<Scrollable> {
+public final class ScrollableElement extends ContainerElement<ScrollableElement> {
 
     private final Scrollbar scrollbar;
     private final ScrollbarState state;
@@ -38,7 +38,7 @@ public final class Scrollable extends ContainerElement<Scrollable> {
     private Element scrollDownIndicator = null;
 
     /** Creates an empty scrollable container. */
-    public Scrollable() {
+    public ScrollableElement() {
         this(new Element[0]);
     }
 
@@ -47,7 +47,7 @@ public final class Scrollable extends ContainerElement<Scrollable> {
      *
      * @param children the child elements
      */
-    public Scrollable(Element... children) {
+    public ScrollableElement(Element... children) {
         this.scrollbar = Scrollbar.builder().orientation(ScrollbarOrientation.VERTICAL_RIGHT).build();
         this.state = new ScrollbarState();
         this.children.addAll(Arrays.asList(children));
@@ -61,7 +61,7 @@ public final class Scrollable extends ContainerElement<Scrollable> {
      * @param scrollbar the scrollbar element
      * @param children the child elements
      */
-    public Scrollable(Scrollbar scrollbar, Element... children) {
+    public ScrollableElement(Scrollbar scrollbar, Element... children) {
         this.scrollbar = scrollbar;
         this.state = new ScrollbarState();
         this.children.addAll(Arrays.asList(children));
@@ -107,7 +107,7 @@ public final class Scrollable extends ContainerElement<Scrollable> {
      * @param scrollUpIndicator the indicator to use
      * @return this, for fluent operations
      */
-    public Scrollable scrollUpIndicator(Element scrollUpIndicator) {
+    public ScrollableElement scrollUpIndicator(Element scrollUpIndicator) {
         this.scrollUpIndicator = scrollUpIndicator;
         return this;
     }
@@ -118,7 +118,7 @@ public final class Scrollable extends ContainerElement<Scrollable> {
      * @param scrollDownIndicator the indicator to use
      * @return this, for fluent operations
      */
-    public Scrollable scrollDownIndicator(Element scrollDownIndicator) {
+    public ScrollableElement scrollDownIndicator(Element scrollDownIndicator) {
         this.scrollDownIndicator = scrollDownIndicator;
         return this;
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
@@ -102,6 +102,15 @@ public final class ScrollableElement extends ContainerElement<ScrollableElement>
     }
 
     /**
+     * Return the internal {@link ScrollbarState}.
+     *
+     * @return the scrollbar state
+     */
+    public ScrollbarState getState() {
+        return this.state;
+    }
+
+    /**
      * Element of height 1 that will be displayed at the top of the area if there are
      * results above the current view.
      * @param scrollUpIndicator the indicator to use

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
@@ -4,6 +4,10 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import dev.tamboui.css.Styleable;
 import dev.tamboui.css.cascade.CssStyleResolver;
 import dev.tamboui.layout.Constraint;
@@ -21,9 +25,6 @@ import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.scrollbar.Scrollbar;
 import dev.tamboui.widgets.scrollbar.ScrollbarOrientation;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * A container element with a scrollbar that allows a vertical list that overflows its bounds.

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ScrollableElement.java
@@ -27,9 +27,21 @@ import dev.tamboui.widgets.scrollbar.ScrollbarOrientation;
 import dev.tamboui.widgets.scrollbar.ScrollbarState;
 
 /**
- * A container element with a scrollbar that allows a vertical list that overflows its bounds.
+ * A scrollable container element with a built-in vertical scrollbar.
+ * <p>
+ * Each child counts as one scrollable unit; children will not be split across page boundaries.
+ * The scrollbar automatically adjusts based on the number of children and the visible viewport.
  *
- * Note that each child counts as one scrollable unit; children will not be split across page boundaries.
+ * <h2>Keyboard Bindings</h2>
+ * <ul>
+ *   <li>Up / Down — scroll one item</li>
+ *   <li>Page Up / Page Down — scroll one page</li>
+ * </ul>
+ *
+ * <h2>Mouse Bindings</h2>
+ * <ul>
+ *   <li>Scroll wheel up/down — scroll one item</li>
+ * </ul>
  */
 public final class ScrollableElement extends ContainerElement<ScrollableElement> {
 
@@ -103,19 +115,20 @@ public final class ScrollableElement extends ContainerElement<ScrollableElement>
     }
 
     /**
-     * Return the internal {@link ScrollbarState}.
+     * Returns the internal {@link ScrollbarState}.
      *
      * @return the scrollbar state
      */
-    public ScrollbarState getState() {
+    public ScrollbarState state() {
         return this.state;
     }
 
     /**
-     * Element of height 1 that will be displayed at the top of the area if there are
-     * results above the current view.
-     * @param scrollUpIndicator the indicator to use
-     * @return this, for fluent operations
+     * Sets an indicator element (height 1) displayed at the top of the area when there
+     * are items above the current view.
+     *
+     * @param scrollUpIndicator the indicator element
+     * @return this element for chaining
      */
     public ScrollableElement scrollUpIndicator(Element scrollUpIndicator) {
         this.scrollUpIndicator = scrollUpIndicator;
@@ -123,10 +136,11 @@ public final class ScrollableElement extends ContainerElement<ScrollableElement>
     }
 
     /**
-     * Element of height 1 that will be displayed at the bottom of the area if there are
-     * results below the current view.
-     * @param scrollDownIndicator the indicator to use
-     * @return this, for fluent operations
+     * Sets an indicator element (height 1) displayed at the bottom of the area when there
+     * are items below the current view.
+     *
+     * @param scrollDownIndicator the indicator element
+     * @return this element for chaining
      */
     public ScrollableElement scrollDownIndicator(Element scrollDownIndicator) {
         this.scrollDownIndicator = scrollDownIndicator;
@@ -203,16 +217,12 @@ public final class ScrollableElement extends ContainerElement<ScrollableElement>
             constraints.add(c);
         }
 
-        int totalRequiredHeight = constraints
-            .stream()
-            .mapToInt(c -> {
-                if (c instanceof Constraint.Length) {
-                    return ((Constraint.Length) c).value();
-                } else {
-                    return 1;
-                }
-            })
-            .sum();
+        int totalRequiredHeight = 0;
+        for (Constraint c : constraints) {
+            totalRequiredHeight += (c instanceof Constraint.Length)
+                    ? ((Constraint.Length) c).value()
+                    : 1;
+        }
 
         state.contentLength(totalRequiredHeight);
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ScrollableElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/ScrollableElementTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.AbstractElementTest;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseEvent;
+
+import static dev.tamboui.toolkit.Toolkit.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ScrollableElement}.
+ */
+class ScrollableElementTest extends AbstractElementTest {
+
+    @Test
+    @DisplayName("renders children within area")
+    void rendersChildren() {
+        // 10 wide, 3 tall — room for 3 items; last column is scrollbar
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        scrollable(
+            text("AAA").length(1),
+            text("BBB").length(1),
+            text("CCC").length(1)
+        ).render(frame, area, RenderContext.empty());
+
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        assertThat(buffer.get(0, 1).symbol()).isEqualTo("B");
+        assertThat(buffer.get(0, 2).symbol()).isEqualTo("C");
+    }
+
+    @Test
+    @DisplayName("all content fits — no scrolling needed")
+    void allContentFitsNoScrolling() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1)
+        );
+
+        Rect area = new Rect(0, 0, 10, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        // Position should stay at 0 when all content fits
+        assertThat(element.state().position()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("scroll position advances on down key")
+    void scrollPositionAdvancesOnDown() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1),
+            text("D").length(1),
+            text("E").length(1)
+        );
+
+        // Render first to initialize state
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        assertThat(element.state().position()).isEqualTo(0);
+
+        // Simulate down key
+        element.handleKeyEvent(KeyEvent.ofKey(KeyCode.DOWN), true);
+        assertThat(element.state().position()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("scroll position decreases on up key")
+    void scrollPositionDecreasesOnUp() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1),
+            text("D").length(1),
+            text("E").length(1)
+        );
+
+        // Render to initialize
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        // Go down then back up
+        element.handleKeyEvent(KeyEvent.ofKey(KeyCode.DOWN), true);
+        element.handleKeyEvent(KeyEvent.ofKey(KeyCode.DOWN), true);
+        assertThat(element.state().position()).isEqualTo(2);
+
+        element.handleKeyEvent(KeyEvent.ofKey(KeyCode.UP), true);
+        assertThat(element.state().position()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("scroll wheel down advances position")
+    void scrollWheelDownAdvancesPosition() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1),
+            text("D").length(1)
+        );
+
+        Rect area = new Rect(0, 0, 10, 2);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        element.handleMouseEvent(MouseEvent.scrollDown(0, 0));
+        assertThat(element.state().position()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("scroll wheel up decreases position")
+    void scrollWheelUpDecreasesPosition() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1),
+            text("D").length(1)
+        );
+
+        Rect area = new Rect(0, 0, 10, 2);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        element.handleMouseEvent(MouseEvent.scrollDown(0, 0));
+        element.handleMouseEvent(MouseEvent.scrollDown(0, 0));
+        assertThat(element.state().position()).isEqualTo(2);
+
+        element.handleMouseEvent(MouseEvent.scrollUp(0, 0));
+        assertThat(element.state().position()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("up indicator shown when scrolled down")
+    void upIndicatorShownWhenScrolledDown() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1),
+            text("D").length(1)
+        ).scrollUpIndicator(text("^^^").length(1));
+
+        Rect area = new Rect(0, 0, 10, 2);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        // Render first to initialize content length, then scroll down
+        element.render(frame, area, RenderContext.empty());
+        element.state().next();
+
+        // Re-render with scrolled position
+        buffer = Buffer.empty(area);
+        frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        // Top row should have the indicator
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("^");
+    }
+
+    @Test
+    @DisplayName("up indicator not shown at top")
+    void upIndicatorNotShownAtTop() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1)
+        ).scrollUpIndicator(text("^^^").length(1));
+
+        Rect area = new Rect(0, 0, 10, 2);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        // At top, should show content not indicator
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+    }
+
+    @Test
+    @DisplayName("down indicator shown when more content below")
+    void downIndicatorShownWhenMoreBelow() {
+        ScrollableElement element = scrollable(
+            text("A").length(1),
+            text("B").length(1),
+            text("C").length(1),
+            text("D").length(1)
+        ).scrollDownIndicator(text("vvv").length(1));
+
+        Rect area = new Rect(0, 0, 10, 2);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        element.render(frame, area, RenderContext.empty());
+
+        // Bottom row should have the indicator
+        assertThat(buffer.get(0, 1).symbol()).isEqualTo("v");
+    }
+
+    @Test
+    @DisplayName("empty area does not throw")
+    void emptyAreaDoesNotThrow() {
+        Rect area = new Rect(0, 0, 0, 0);
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 1, 1));
+        Frame frame = Frame.forTesting(buffer);
+
+        scrollable(text("A")).render(frame, area, RenderContext.empty());
+    }
+
+    @Test
+    @DisplayName("empty children does not throw")
+    void emptyChildrenDoesNotThrow() {
+        Rect area = new Rect(0, 0, 10, 5);
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+
+        scrollable().render(frame, area, RenderContext.empty());
+    }
+
+    @Test
+    @DisplayName("state() returns the scrollbar state")
+    void stateReturnsScrollbarState() {
+        ScrollableElement element = scrollable(text("A"), text("B"));
+        assertThat(element.state()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("preferredSize accounts for scrollbar width")
+    void preferredSizeAccountsForScrollbar() {
+        ScrollableElement element = scrollable(
+            text("Hello").length(1),
+            text("World").length(1)
+        );
+
+        // "Hello" = 5 chars, + 1 for scrollbar = 6
+        assertThat(element.preferredSize(20, 10, null).widthOr(0)).isEqualTo(6);
+        // 2 children of height 1 each
+        assertThat(element.preferredSize(20, 10, null).heightOr(0)).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
This adds a new `ScrollableElement` that functions similarly to a `Panel` or other container element with the added benefit of a built-in `Scrollbar`. This scrollbar will automatically adjust based on the children inside the container and automatically handles up/down keyboard events and scroll up/down mouse events.

This closes #289 and provides a super simple API for most scenarios where there are long lists or lines of text.

Includes:
- Automatic keyboard/mouse event handling;
- Plays nicely with fill-mode elements like `spacer()`;
- Works in DSL and immediate mode;
- Allows customization of the `Scrollbar`
- Works nicely with `VERTICAL_LEFT` and `VERTICAL_RIGHT` scrollbars (no horizontal support is included)
- Allows adding indicators for when content has gone off the screen (`scrollUpIndicator` and `scrollDownIndicator`)

Here's a demo with a long list of checkboxes:

https://github.com/user-attachments/assets/f48075c4-2bc5-444e-b4ab-5f84d7480738

Please let me know what else needs to be added to this PR; I added some notes in the documentation but couldn't find a more appropriate place than that one.

Also, are there any tests I can use as a good reference to write some for this code? This is mostly just a `Panel` with the majority of options removed, however, removing the options doesn't leave me much to test (and the same preferred size calculations, so it feels weird duplicating this test). I can be a bit more redundant but wanted to ask the best approach before I spend significant time on that.
