### PR TITLE
Add new ButtonElement

### DIFF
--- a/docs/src/snippets/java/dev/tamboui/docs/snippets/FormsSnippets.java
+++ b/docs/src/snippets/java/dev/tamboui/docs/snippets/FormsSnippets.java
@@ -316,7 +316,8 @@ public class FormsSnippets {
         // Render form with submit button
         column(
             loginForm,
-            text(" Login ").bold()  // Note: button() is not yet available
+            button(text(" Login ").bold())
+                .onPress(() -> loginForm.submit())
         );
         // end::programmatic-submit[]
     }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/Toolkit.java
@@ -15,6 +15,7 @@ import dev.tamboui.text.Text;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.toolkit.elements.BarChartElement;
+import dev.tamboui.toolkit.elements.ButtonElement;
 import dev.tamboui.toolkit.elements.CalendarElement;
 import dev.tamboui.toolkit.elements.CanvasElement;
 import dev.tamboui.toolkit.elements.ChartElement;
@@ -949,6 +950,18 @@ public final class Toolkit {
      */
     public static TextAreaElement textArea() {
         return new TextAreaElement();
+    }
+
+    // ==================== Button ====================
+
+    /**
+     * Creates a button with the given inner element.
+     *
+     * @param innerElement the inner element of the button
+     * @return a new button element
+     */
+    public static ButtonElement button(StyledElement<?> innerElement) {
+        return new ButtonElement(innerElement);
     }
 
     // ==================== Form Field ====================

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.elements;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Modifier;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.toolkit.element.RenderContext;
+import dev.tamboui.toolkit.element.Size;
+import dev.tamboui.toolkit.element.StyledElement;
+import dev.tamboui.toolkit.event.EventHandler;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+
+/**
+ * A button element that wraps a {@link StyledElement} to provide built-in focus styles
+ * (default reversed) and key event handling.
+ */
+public final class ButtonElement extends StyledElement<ButtonElement> {
+
+    private StyledElement<?> innerElement;
+    private Style innerElementStyle;
+    private Style innerElementFocusedStyle;
+    private EventHandler onPress;
+
+    private boolean isFocused = false;
+
+    /** Creates a button with the specified inner element. */
+    public ButtonElement(StyledElement<?> innerElement) {
+        this.innerElement = innerElement;
+        this.innerElementStyle = innerElement.getStyle();
+        if (this.innerElementStyle.effectiveModifiers().contains(Modifier.REVERSED)) {
+            this.innerElementFocusedStyle = innerElement.getStyle().notReversed();
+        } else {
+            this.innerElementFocusedStyle = innerElement.getStyle().reversed();
+        }
+        this.focusable();
+
+        this.registerHandlers();
+    }
+
+    private void registerHandlers() {
+        this.keyHandler =
+            (KeyEvent event) -> {
+                if (event.isConfirm()) {
+                    return this.onPress.handle(event);
+                }
+                return EventResult.UNHANDLED;
+            };
+    }
+
+    /**
+     * Sets the button's onPress event handler.
+     *
+     * @param onPress the event handler to be called when the button is pressed
+     * @return this button for chaining
+     */
+    public ButtonElement onPress(EventHandler onPress) {
+        this.onPress = onPress;
+        return this;
+    }
+
+    /**
+     * Sets the style to be used for the inner element when focused.
+     *
+     * @param innerElementFocusedStyle the style to use
+     * @return this button for chaining
+     */
+    public ButtonElement innerElementFocusedStyle(Style innerElementFocusedStyle) {
+        this.innerElementFocusedStyle = innerElementFocusedStyle;
+        return this;
+    }
+
+    /**
+     * Return if the button was focused <i>on the last render cycle</i>.
+     * This lags behind by one cycle and should not be relied upon for proactive focus checks;
+     * its intention is to provide information for rendering things such as help text only.
+     *
+     * @return true if the button was focused, false otherwise
+     */
+    public boolean isFocused() {
+        return this.isFocused;
+    }
+
+    @Override
+    public Size preferredSize(int availableWidth, int availableHeight, RenderContext context) {
+        return this.innerElement.preferredSize(availableWidth, availableHeight, context);
+    }
+
+    @Override
+    protected void renderContent(Frame frame, Rect area, RenderContext context) {
+        // Get current style from context (already resolved by StyledElement.render)
+        Style effectiveStyle = context.currentStyle();
+
+        // if focused, toggle style
+        this.isFocused = elementId != null && context.isFocused(elementId);
+        if (this.isFocused) {
+            if (effectiveStyle.effectiveModifiers().contains(Modifier.REVERSED)) {
+                effectiveStyle.notReversed();
+            } else {
+                effectiveStyle.reversed();
+            }
+
+            this.innerElement.style(innerElementFocusedStyle);
+        } else {
+            this.innerElement.style(innerElementStyle);
+        }
+
+        // Build the block - CSS properties are resolved by the widget
+        Block block = Block.builder().style(effectiveStyle).build();
+
+        // Render the block
+        frame.renderWidget(block, area);
+
+        context.renderChild(this.innerElement, frame, area);
+    }
+}

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
@@ -27,8 +27,6 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
     private Style innerElementFocusedStyle;
     private EventHandler onPress;
 
-    private boolean isFocused = false;
-
     /** Creates a button with the specified inner element. */
     public ButtonElement(StyledElement<?> innerElement) {
         this.innerElement = innerElement;
@@ -75,17 +73,6 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
         return this;
     }
 
-    /**
-     * Return if the button was focused <i>on the last render cycle</i>.
-     * This lags behind by one cycle and should not be relied upon for proactive focus checks;
-     * its intention is to provide information for rendering things such as help text only.
-     *
-     * @return true if the button was focused, false otherwise
-     */
-    public boolean isFocused() {
-        return this.isFocused;
-    }
-
     @Override
     public Size preferredSize(int availableWidth, int availableHeight, RenderContext context) {
         return this.innerElement.preferredSize(availableWidth, availableHeight, context);
@@ -97,8 +84,8 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
         Style effectiveStyle = context.currentStyle();
 
         // if focused, toggle style
-        this.isFocused = elementId != null && context.isFocused(elementId);
-        if (this.isFocused) {
+        boolean isFocused = elementId != null && context.isFocused(elementId);
+        if (isFocused) {
             if (effectiveStyle.effectiveModifiers().contains(Modifier.REVERSED)) {
                 effectiveStyle.notReversed();
             } else {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
@@ -27,7 +27,11 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
     private Style innerElementFocusedStyle;
     private EventHandler onPress;
 
-    /** Creates a button with the specified inner element. */
+    /**
+     * Creates a button with the specified inner element.
+     *
+     * @param innerElement the inner element to be wrapped by the button
+     */
     public ButtonElement(StyledElement<?> innerElement) {
         this.innerElement = innerElement;
         this.innerElementStyle = innerElement.getStyle();

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/ButtonElement.java
@@ -25,7 +25,7 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
     private StyledElement<?> innerElement;
     private Style innerElementStyle;
     private Style innerElementFocusedStyle;
-    private EventHandler onPress;
+    private EventHandler onPress = null;
 
     /**
      * Creates a button with the specified inner element.
@@ -48,7 +48,7 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
     private void registerHandlers() {
         this.keyHandler =
             (KeyEvent event) -> {
-                if (event.isConfirm()) {
+                if (event.isConfirm() && this.onPress != null) {
                     return this.onPress.handle(event);
                 }
                 return EventResult.UNHANDLED;
@@ -91,9 +91,9 @@ public final class ButtonElement extends StyledElement<ButtonElement> {
         boolean isFocused = elementId != null && context.isFocused(elementId);
         if (isFocused) {
             if (effectiveStyle.effectiveModifiers().contains(Modifier.REVERSED)) {
-                effectiveStyle.notReversed();
+                effectiveStyle = effectiveStyle.notReversed();
             } else {
-                effectiveStyle.reversed();
+                effectiveStyle = effectiveStyle.reversed();
             }
 
             this.innerElement.style(innerElementFocusedStyle);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventHandler.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventHandler.java
@@ -12,10 +12,10 @@ import dev.tamboui.tui.event.Event;
  * Global handlers can intercept events before they reach elements, allowing
  * for application-wide keyboard shortcuts or action handling.
  *
- * @see EventRouter#addGlobalHandler(GlobalEventHandler)
+ * @see EventRouter#addGlobalHandler(EventHandler)
  */
 @FunctionalInterface
-public interface GlobalEventHandler {
+public interface EventHandler {
 
     /**
      * Handles an event.

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventRouter.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/event/EventRouter.java
@@ -53,7 +53,7 @@ public final class EventRouter implements AutoCloseable {
     private final AtomicLong routeIdCounter = new AtomicLong();
     private final List<Element> elements = new ArrayList<>();
     private final IdentityHashMap<Element, Rect> elementAreas = new IdentityHashMap<>();
-    private final List<GlobalEventHandler> globalHandlers = new ArrayList<>();
+    private final List<EventHandler> globalHandlers = new ArrayList<>();
 
     // Drag state
     private Element draggingElement;
@@ -78,7 +78,7 @@ public final class EventRouter implements AutoCloseable {
      *
      * @param handler the handler to add
      */
-    public void addGlobalHandler(GlobalEventHandler handler) {
+    public void addGlobalHandler(EventHandler handler) {
         globalHandlers.add(handler);
     }
 
@@ -101,7 +101,7 @@ public final class EventRouter implements AutoCloseable {
      *
      * @param handler the handler to remove
      */
-    public void removeGlobalHandler(GlobalEventHandler handler) {
+    public void removeGlobalHandler(EventHandler handler) {
         globalHandlers.remove(handler);
     }
 


### PR DESCRIPTION
This adds a new `ButtonElement` element that wraps an element to add focus styles and built-in key event handling.

It features:
- Automatic focus handling (will apply `reversed` to the inner element by default, or a custom style if specified)
- Built-in handling of confirm keyboard events

---

Please let me know what else needs to be added to this PR; I added basic usage to the documentation (for programmatic submission, now the example actually works too).
