### PR TITLE
feat: Add alignment to table Cell widget

### DIFF
--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Cell.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Cell.java
@@ -4,6 +4,9 @@
  */
 package dev.tamboui.widgets.table;
 
+import java.util.Objects;
+
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -13,7 +16,8 @@ import dev.tamboui.text.Text;
  * A cell in a {@link Table}.
  * <p>
  * A cell contains styled text content that can be a single line or multi-line text.
- * Cells can have their own style which takes precedence over row and table styles.
+ * Cells can have their own style which takes precedence over row and table styles,
+ * and an {@link Alignment} that controls horizontal placement within the column.
  *
  * <pre>{@code
  * // Simple cell
@@ -24,16 +28,21 @@ import dev.tamboui.text.Text;
  *
  * // Multi-line cell
  * Cell.from(Text.from("Line 1\nLine 2"))
+ *
+ * // Right-aligned cell
+ * Cell.from("42").alignment(Alignment.RIGHT)
  * }</pre>
  */
 public final class Cell {
 
     private final Text content;
     private final Style style;
+    private final Alignment alignment;
 
-    private Cell(Text content, Style style) {
+    private Cell(Text content, Style style, Alignment alignment) {
         this.content = content;
         this.style = style;
+        this.alignment = alignment;
     }
 
     /**
@@ -43,7 +52,7 @@ public final class Cell {
      * @return a new cell
      */
     public static Cell from(String content) {
-        return new Cell(Text.from(content), Style.EMPTY);
+        return new Cell(Text.from(content), Style.EMPTY, Alignment.LEFT);
     }
 
     /**
@@ -53,7 +62,7 @@ public final class Cell {
      * @return a new cell
      */
     public static Cell from(Span span) {
-        return new Cell(Text.from(span), Style.EMPTY);
+        return new Cell(Text.from(span), Style.EMPTY, Alignment.LEFT);
     }
 
     /**
@@ -63,7 +72,7 @@ public final class Cell {
      * @return a new cell
      */
     public static Cell from(Line line) {
-        return new Cell(Text.from(line), Style.EMPTY);
+        return new Cell(Text.from(line), Style.EMPTY, Alignment.LEFT);
     }
 
     /**
@@ -73,7 +82,7 @@ public final class Cell {
      * @return a new cell
      */
     public static Cell from(Text text) {
-        return new Cell(text, Style.EMPTY);
+        return new Cell(text, Style.EMPTY, Alignment.LEFT);
     }
 
     /**
@@ -82,7 +91,7 @@ public final class Cell {
      * @return a new empty cell
      */
     public static Cell empty() {
-        return new Cell(Text.empty(), Style.EMPTY);
+        return new Cell(Text.empty(), Style.EMPTY, Alignment.LEFT);
     }
 
     /**
@@ -104,13 +113,36 @@ public final class Cell {
     }
 
     /**
+     * Returns the horizontal alignment for this cell.
+     *
+     * @return the cell alignment
+     */
+    public Alignment alignment() {
+        return alignment;
+    }
+
+    /**
      * Returns a new cell with the given style.
      *
      * @param style the style to apply
      * @return a new cell with the style
      */
     public Cell style(Style style) {
-        return new Cell(this.content, style);
+        return new Cell(this.content, style, this.alignment);
+    }
+
+    /**
+     * Returns a new cell with the given horizontal alignment.
+     * <p>
+     * Alignment controls the placement of cell content within the column width:
+     * {@link Alignment#LEFT} (the default), {@link Alignment#CENTER}, or
+     * {@link Alignment#RIGHT}.
+     *
+     * @param alignment the alignment to apply
+     * @return a new cell with the alignment
+     */
+    public Cell alignment(Alignment alignment) {
+        return new Cell(this.content, this.style, Objects.requireNonNull(alignment, "alignment"));
     }
 
     /**

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 
 import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
@@ -283,6 +284,7 @@ public final class Table implements StatefulWidget<TableState> {
                 Cell cell = cells.get(col);
                 Style cellStyle = rowStyle.patch(cell.style());
                 Text content = cell.content();
+                Alignment alignment = cell.alignment();
 
                 // Render each line of the cell
                 List<Line> lines = content.lines();
@@ -293,8 +295,29 @@ public final class Table implements StatefulWidget<TableState> {
                         break;
                     }
 
+                    // Apply horizontal alignment within the column when content fits.
+                    // If the line is wider than the column it is clipped from the left edge.
+                    int lineWidth = line.width();
+                    int alignmentOffset;
+                    if (lineWidth >= colWidth) {
+                        alignmentOffset = 0;
+                    } else {
+                        switch (alignment) {
+                            case CENTER:
+                                alignmentOffset = (colWidth - lineWidth) / 2;
+                                break;
+                            case RIGHT:
+                                alignmentOffset = colWidth - lineWidth;
+                                break;
+                            case LEFT:
+                            default:
+                                alignmentOffset = 0;
+                                break;
+                        }
+                    }
+
                     // Render line content, truncated to column width
-                    int col_x = x;
+                    int col_x = x + alignmentOffset;
                     List<Span> patchedSpans = line.patchStyle(cellStyle).spans();
                     for (int spanIdx = 0; spanIdx < patchedSpans.size(); spanIdx++) {
                         Span span = patchedSpans.get(spanIdx);

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/table/CellTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/table/CellTest.java
@@ -7,6 +7,7 @@ package dev.tamboui.widgets.table;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.text.Line;
@@ -68,5 +69,40 @@ class CellTest {
         assertThat(styled.style().fg()).contains(Color.RED);
         // Original is unchanged
         assertThat(cell.style()).isEqualTo(Style.EMPTY);
+    }
+
+    @Test
+    @DisplayName("Cell defaults to left alignment")
+    void defaultAlignment() {
+        assertThat(Cell.from("Test").alignment()).isEqualTo(Alignment.LEFT);
+        assertThat(Cell.empty().alignment()).isEqualTo(Alignment.LEFT);
+    }
+
+    @Test
+    @DisplayName("Cell.alignment returns new cell with alignment")
+    void withAlignment() {
+        Cell cell = Cell.from("Test");
+        Cell right = cell.alignment(Alignment.RIGHT);
+
+        assertThat(right.alignment()).isEqualTo(Alignment.RIGHT);
+        // Original is unchanged
+        assertThat(cell.alignment()).isEqualTo(Alignment.LEFT);
+    }
+
+    @Test
+    @DisplayName("Cell.alignment preserves content and style")
+    void alignmentPreservesContentAndStyle() {
+        Style style = Style.EMPTY.fg(Color.RED).bold();
+        Cell cell = Cell.from("Hello").style(style).alignment(Alignment.CENTER);
+
+        assertThat(cell.content().width()).isEqualTo(5);
+        assertThat(cell.style()).isEqualTo(style);
+        assertThat(cell.alignment()).isEqualTo(Alignment.CENTER);
+    }
+
+    @Test
+    @DisplayName("Cell.alignment rejects null")
+    void alignmentRejectsNull() {
+        assertThatNullPointerException().isThrownBy(() -> Cell.from("Test").alignment(null));
     }
 }

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/table/TableTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/table/TableTest.java
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.Test;
 
 import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 import dev.tamboui.style.TestStylePropertyResolver;
+import dev.tamboui.text.Text;
 import dev.tamboui.widgets.block.Block;
 
 import static org.assertj.core.api.Assertions.*;
@@ -298,5 +300,137 @@ class TableTest {
 
         // Second row "Bob" starts at y=1 and should have blue background
         BufferAssertions.assertThat(buffer).at(0, 1).hasBackground(Color.BLUE);
+    }
+
+    @Test
+    @DisplayName("Cell alignment LEFT places content at column start")
+    void cellAlignmentLeft() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from(Cell.from("Hi").alignment(Alignment.LEFT))))
+            .widths(Constraint.length(10))
+            .highlightSymbol("")
+            .build();
+
+        Rect area = new Rect(0, 0, 10, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        table.render(area, buffer, new TableState());
+
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("i");
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("Cell alignment CENTER centers content within column")
+    void cellAlignmentCenter() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from(Cell.from("Hi").alignment(Alignment.CENTER))))
+            .widths(Constraint.length(10))
+            .highlightSymbol("")
+            .build();
+
+        Rect area = new Rect(0, 0, 10, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        table.render(area, buffer, new TableState());
+
+        // (10 - 2) / 2 = 4
+        assertThat(buffer.get(3, 0).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(4, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(5, 0).symbol()).isEqualTo("i");
+        assertThat(buffer.get(6, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("Cell alignment RIGHT places content at column end")
+    void cellAlignmentRight() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from(Cell.from("Hi").alignment(Alignment.RIGHT))))
+            .widths(Constraint.length(10))
+            .highlightSymbol("")
+            .build();
+
+        Rect area = new Rect(0, 0, 10, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        table.render(area, buffer, new TableState());
+
+        assertThat(buffer.get(7, 0).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(8, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(9, 0).symbol()).isEqualTo("i");
+    }
+
+    @Test
+    @DisplayName("Cell alignment RIGHT applies to second column with column spacing")
+    void cellAlignmentRightInSecondColumn() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from(
+                Cell.from("A"),
+                Cell.from("42").alignment(Alignment.RIGHT)
+            )))
+            .widths(Constraint.length(3), Constraint.length(5))
+            .columnSpacing(1)
+            .highlightSymbol("")
+            .build();
+
+        Rect area = new Rect(0, 0, 9, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        table.render(area, buffer, new TableState());
+
+        // First column left-aligned at x=0
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A");
+        // Second column starts at x=4 (3 + 1 spacing), width 5; "42" right-aligned at x=7,8
+        assertThat(buffer.get(6, 0).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(7, 0).symbol()).isEqualTo("4");
+        assertThat(buffer.get(8, 0).symbol()).isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("Cell alignment applies per-line for multi-line cells")
+    void cellAlignmentMultiLine() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(
+                Row.from(Cell.from(Text.from("Hi\nThere"))
+                    .alignment(Alignment.RIGHT))
+                .height(2)
+            ))
+            .widths(Constraint.length(10))
+            .highlightSymbol("")
+            .build();
+
+        Rect area = new Rect(0, 0, 10, 2);
+        Buffer buffer = Buffer.empty(area);
+
+        table.render(area, buffer, new TableState());
+
+        // "Hi" right-aligned on row 0
+        assertThat(buffer.get(8, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(9, 0).symbol()).isEqualTo("i");
+        // "There" right-aligned on row 1
+        assertThat(buffer.get(5, 1).symbol()).isEqualTo("T");
+        assertThat(buffer.get(9, 1).symbol()).isEqualTo("e");
+    }
+
+    @Test
+    @DisplayName("Cell content wider than column is clipped from left edge regardless of alignment")
+    void cellAlignmentClipsOverflowFromLeft() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from(
+                Cell.from("HelloWorld").alignment(Alignment.RIGHT)
+            )))
+            .widths(Constraint.length(5))
+            .highlightSymbol("")
+            .build();
+
+        Rect area = new Rect(0, 0, 5, 1);
+        Buffer buffer = Buffer.empty(area);
+
+        table.render(area, buffer, new TableState());
+
+        // Overflow: clipped from left edge, first 5 chars rendered
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(4, 0).symbol()).isEqualTo("o");
     }
 }


### PR DESCRIPTION
Fixes #320 

Re: Acceptable Use of LLMs

Claude Code/Opus 4.7 was used to bootstrap this pull request, then code was edited by me for style and to improve docs.

Prompt
```
❯ Start by considering AGENTS.md. Then note text-align support in Paragraph, class
dev.tamboui.widgets.paragraph.Paragraph, implemented via alignment(Alignment)
method. Implement similar functionality in Cell, class dev.tamboui.widgets.table.Cell.
```