### PR TITLE
Upgrade aesh terminal dependencies from 3.2 to 3.7

### DIFF
--- a/demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java
+++ b/demos/aesh-ssh-http-demo/src/main/java/dev/tamboui/demo/aesh/AeshSshHttpDemo.java
@@ -98,8 +98,8 @@ public class AeshSshHttpDemo implements java.util.function.Consumer<Connection> 
     private void startSshServer() {
         try {
             NettySshTtyBootstrap bootstrap = new NettySshTtyBootstrap();
-            bootstrap.setPort(SSH_PORT);
-            bootstrap.setHost("localhost");
+            bootstrap.port(SSH_PORT);
+            bootstrap.host("localhost");
             bootstrap.start(this).get(10, TimeUnit.SECONDS);
             System.out.println("SSH server started on port " + SSH_PORT);
         } catch (Exception e) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jline = "3.25.1"
-aesh-terminal = "3.2"
+aesh-terminal = "3.7"
 junit = "5.14.3"
 assertj = "3.27.7"
 native-build-tools = "0.11.4"

--- a/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
+++ b/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
@@ -12,7 +12,6 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.aesh.terminal.Connection;
-import org.aesh.terminal.tty.Point;
 import org.aesh.terminal.tty.TerminalConnection;
 
 import dev.tamboui.layout.Position;
@@ -120,14 +119,8 @@ public class AeshBackend extends AbstractBackend {
 
     @Override
     public Position getCursorPosition() throws IOException {
-        try {
-            Point point = connection.getCursorPosition();
-            if (point != null) {
-                return new Position(point.x(), point.y());
-            }
-        } catch (Exception e) {
-            // Fall through to return origin
-        }
+        // Connection no longer provides getCursorPosition() as of aesh 3.7.
+        // Return origin as fallback, consistent with the JLine backend.
         return Position.ORIGIN;
     }
 


### PR DESCRIPTION
Upgrades all aesh terminal dependencies (terminal-tty, terminal-ssh, terminal-http) from 3.2 to 3.7 to align with the version used in JBang.

### Changes

- **`gradle/libs.versions.toml`** — bump `aesh-terminal` from `3.2` → `3.7`
- **`AeshBackend.java`** — remove usage of `Connection.getCursorPosition()` which was removed in aesh 3.7; return `Position.ORIGIN` as fallback (consistent with JLine backend)
- **`AeshSshHttpDemo.java`** — replace deprecated `setPort()`/`setHost()` with fluent `port()`/`host()` methods on `NettySshTtyBootstrap`

Full build passes ✅