### PR TITLE
Fix #343: replace C0 control chars in Buffer.setString to prevent cursor corruption

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
+++ b/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
@@ -290,7 +290,13 @@ public final class Buffer {
             }
             appendToLast = false;
 
-            String symbol = codePoint < 128 ? ASCII_STRINGS[codePoint] : new String(Character.toChars(codePoint));
+            // C0 control chars (U+0000–U+001F) and DEL (U+007F) are not displayable glyphs.
+            // Writing them to the terminal moves the cursor unpredictably (e.g. \t jumps to
+            // the next tab stop, \r resets to column 0), which breaks the cursor-adjacency
+            // optimisation in AbstractBackend and corrupts all subsequent cells in the row.
+            String symbol = (codePoint < 0x20 || codePoint == 0x7F)
+                    ? " "
+                    : codePoint < 128 ? ASCII_STRINGS[codePoint] : new String(Character.toChars(codePoint));
 
             if (charWidth == 2 && col + 1 >= area.right()) {
                 // Wide char at rightmost column: no room for continuation, replace with space

--- a/tamboui-core/src/test/java/dev/tamboui/buffer/BufferTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/buffer/BufferTest.java
@@ -64,6 +64,27 @@ class BufferTest {
     }
 
     @Test
+    @DisplayName("Buffer setString replaces C0 control characters with space")
+    void setStringControlCharsReplacedWithSpace() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+        // Tab (\t) is the most common culprit: terminals jump to the next tab stop
+        // rather than advancing one column, breaking cursor-adjacency tracking.
+        buffer.setString(0, 0, "a\tb", Style.EMPTY);
+
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("a");
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo(" "); // \t replaced with space
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo("b");
+
+        // Other C0 control chars and DEL are also replaced with space
+        Buffer buffer2 = Buffer.empty(new Rect(0, 0, 10, 1));
+        buffer2.setString(0, 0, "\r\n\u0001\u007f", Style.EMPTY);
+        assertThat(buffer2.get(0, 0).symbol()).isEqualTo(" "); // \r replaced
+        assertThat(buffer2.get(1, 0).symbol()).isEqualTo(" "); // \n replaced
+        assertThat(buffer2.get(2, 0).symbol()).isEqualTo(" "); // NUL+1 replaced
+        assertThat(buffer2.get(3, 0).symbol()).isEqualTo(" "); // DEL replaced
+    }
+
+    @Test
     @DisplayName("Buffer setString with style")
     void setStringWithStyle() {
         Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));


### PR DESCRIPTION
## Problem

Closes #343.

C0 control characters (U+0000–U+001F) and DEL (U+007F) written into a `Buffer` via `setString()` are stored verbatim as `Cell` symbols. `CharWidth.of('\t')` returns 1, so `Buffer.setString()` stores `"\t"` as a 1-wide cell. In `AbstractBackend.draw()`, after writing that cell, `cursorX = x + 1` is assumed — but the terminal actually moves the cursor to the **next tab stop** (column 8, 16, …), not `x+1`.

The adjacency optimisation then skips emitting `\e[y;xH` for the next cell because `cursorX` appears to already match. That cell lands at the tab-stop column instead of `x+1`, corrupting the rest of the row. The corruption persists across frames because `diff()` only catches changed cells — not positions that were misrendered due to cursor state drift.

The same issue applies to `\r` (resets to column 0), `\n` (moves to next line), and all other C0 control characters.

## Fix

Sanitise in `Buffer.setString()` by replacing any C0/DEL code point with a space before it reaches the cell model. This is the correct abstraction boundary: the buffer represents displayable terminal state, and control characters have no valid display representation there. Fixing here also protects `toAnsiString()`, `diff()`, and all other buffer consumers.

```java
// Before
String symbol = codePoint < 128 ? ASCII_STRINGS[codePoint] : new String(Character.toChars(codePoint));

// After
String symbol = (codePoint < 0x20 || codePoint == 0x7F)
        ? " "
        : codePoint < 128 ? ASCII_STRINGS[codePoint] : new String(Character.toChars(codePoint));
```

## Test

Added `setStringControlCharsReplacedWithSpace()` to `BufferTest` covering `\t`, `\r`, `\n`, NUL+1, and DEL.

---
_Discovered while using TamboUI in [Apache Camel JBang TUI](https://github.com/apache/camel). Stack traces in log output contain tab-indented lines which triggered this bug, causing garbage rendering on all other TUI tabs._