### PR TITLE
feat: Allow JLineBackend to accept an existing Terminal

### DIFF
--- a/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
+++ b/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
@@ -26,6 +26,15 @@ import dev.tamboui.terminal.Mode2027Support;
  * <p>
  * This backend uses the aesh-readline library's TerminalConnection abstraction
  * for terminal I/O operations.
+ * <p>
+ * Two construction modes are supported:
+ * <ul>
+ *   <li>{@link #AeshBackend()} — creates and owns a system terminal connection;
+ *       {@link #close()} will close it.</li>
+ *   <li>{@link #AeshBackend(Connection)} — uses an externally provided connection
+ *       (e.g., from SSH or HTTP); the caller retains ownership and {@link #close()}
+ *       will <em>not</em> close the connection.</li>
+ * </ul>
  */
 public class AeshBackend extends AbstractBackend {
 
@@ -33,6 +42,7 @@ public class AeshBackend extends AbstractBackend {
     private static final String CSI = ESC + "[";
 
     private final Connection connection;
+    private final boolean ownConnection;
     private final StringBuilder outputBuffer;
     private final BlockingQueue<Integer> inputQueue;
     private boolean inAlternateScreen;
@@ -42,23 +52,32 @@ public class AeshBackend extends AbstractBackend {
 
     /**
      * Creates a new Aesh backend using a default TerminalConnection.
+     * <p>
+     * The backend owns the connection and will close it when {@link #close()} is called.
      *
      * @throws IOException if the terminal cannot be initialized
      */
     public AeshBackend() throws IOException {
-        this(new TerminalConnection());
+        this(new TerminalConnection(), true);
     }
 
     /**
      * Creates a new Aesh backend using the provided Connection.
      * <p>
      * This constructor allows creating backends from SSH or HTTP connections.
+     * The caller retains ownership of the connection; it will not be closed
+     * when this backend is closed.
      *
      * @param connection the connection to use for terminal I/O
      * @throws IOException if the terminal cannot be initialized
      */
     public AeshBackend(Connection connection) throws IOException {
+        this(connection, false);
+    }
+
+    private AeshBackend(Connection connection, boolean ownConnection) throws IOException {
         this.connection = Objects.requireNonNull(connection, "connection cannot be null");
+        this.ownConnection = ownConnection;
         this.connection.openNonBlocking();
         this.outputBuffer = new StringBuilder();
         this.inputQueue = new LinkedBlockingQueue<>();
@@ -305,6 +324,14 @@ public class AeshBackend extends AbstractBackend {
         return val == null ? -2 : val;
     }
 
+    /**
+     * Closes this backend, resetting terminal state (mouse capture, alternate screen,
+     * cursor visibility, raw mode).
+     * <p>
+     * If this backend owns the connection (created via {@link #AeshBackend()}), the
+     * connection is closed. If an external connection was provided via
+     * {@link #AeshBackend(Connection)}, it is left open for the caller to manage.
+     */
     @Override
     public void close() throws IOException {
         try {
@@ -324,7 +351,9 @@ public class AeshBackend extends AbstractBackend {
 
             flush();
         } finally {
-            connection.close();
+            if (ownConnection) {
+                connection.close();
+            }
         }
     }
 

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -6,6 +6,7 @@ package dev.tamboui.backend.jline3;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Objects;
 
 import org.jline.terminal.Attributes;
 import org.jline.terminal.Terminal;
@@ -22,6 +23,15 @@ import dev.tamboui.terminal.Mode2027Support;
 
 /**
  * JLine 3 based backend for terminal operations.
+ * <p>
+ * Two construction modes are supported:
+ * <ul>
+ *   <li>{@link #JLineBackend()} — creates and owns a system terminal;
+ *       {@link #close()} will close it.</li>
+ *   <li>{@link #JLineBackend(Terminal)} — uses an externally provided terminal
+ *       (e.g., from a JLine shell); the caller retains ownership and {@link #close()}
+ *       will <em>not</em> close the terminal.</li>
+ * </ul>
  */
 public class JLineBackend extends AbstractBackend {
 
@@ -39,6 +49,8 @@ public class JLineBackend extends AbstractBackend {
 
     /**
      * Creates a new JLine 3 backend using the system terminal.
+     * <p>
+     * The backend owns the terminal and will close it when {@link #close()} is called.
      *
      * @throws IOException if the terminal cannot be opened
      */
@@ -48,17 +60,19 @@ public class JLineBackend extends AbstractBackend {
 
     /**
      * Creates a new JLine 3 backend using an existing terminal.
+     * <p>
      * The caller retains ownership of the terminal; it will not be closed
-     * when this backend is closed.
+     * when this backend is closed. This is useful when embedding TamboUI
+     * inside a host application that already owns the terminal (e.g., a JLine shell).
      *
-     * @param terminal the terminal to use
+     * @param terminal the JLine terminal to use
      */
     public JLineBackend(Terminal terminal) {
         this(terminal, false);
     }
 
     private JLineBackend(Terminal terminal, boolean ownTerminal) {
-        this.terminal = terminal;
+        this.terminal = Objects.requireNonNull(terminal, "terminal cannot be null");
         this.ownTerminal = ownTerminal;
         this.writer = terminal.writer();
         this.reader = terminal.reader();
@@ -290,6 +304,14 @@ public class JLineBackend extends AbstractBackend {
         return c;
     }
 
+    /**
+     * Closes this backend, resetting terminal state (mouse capture, alternate screen,
+     * cursor visibility, raw mode).
+     * <p>
+     * If this backend owns the terminal (created via {@link #JLineBackend()}), the
+     * terminal is closed. If an external terminal was provided via
+     * {@link #JLineBackend(Terminal)}, it is left open for the caller to manage.
+     */
     @Override
     public void close() throws IOException {
         // Reset state

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -29,6 +29,7 @@ public class JLineBackend extends AbstractBackend {
     private static final String CSI = ESC + "[";
 
     private final Terminal terminal;
+    private final boolean ownTerminal;
     private final PrintWriter writer;
     private final NonBlockingReader reader;
     private Attributes savedAttributes;
@@ -42,10 +43,23 @@ public class JLineBackend extends AbstractBackend {
      * @throws IOException if the terminal cannot be opened
      */
     public JLineBackend() throws IOException {
-        this.terminal = TerminalBuilder.builder()
-            .system(true)
-            .jansi(true)
-            .build();
+        this(TerminalBuilder.builder().system(true).jansi(true).build(), true);
+    }
+
+    /**
+     * Creates a new JLine 3 backend using an existing terminal.
+     * The caller retains ownership of the terminal; it will not be closed
+     * when this backend is closed.
+     *
+     * @param terminal the terminal to use
+     */
+    public JLineBackend(Terminal terminal) {
+        this(terminal, false);
+    }
+
+    private JLineBackend(Terminal terminal, boolean ownTerminal) {
+        this.terminal = terminal;
+        this.ownTerminal = ownTerminal;
         this.writer = terminal.writer();
         this.reader = terminal.reader();
         this.inAlternateScreen = false;
@@ -293,7 +307,9 @@ public class JLineBackend extends AbstractBackend {
         disableRawMode();
 
         writer.flush();
-        terminal.close();
+        if (ownTerminal) {
+            terminal.close();
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

When a TamboUI application runs inside a host that already owns the system terminal (e.g., a JLine-based interactive shell), `JLineBackend()` tries to create a second system terminal via `TerminalBuilder.builder().system(true).build()`. This fails with a `Stream Closed` IOException because stdin is already consumed by the host shell's terminal.

## Solution

Add a `JLineBackend(Terminal terminal)` constructor that accepts an existing JLine `Terminal` instance:

- The caller retains ownership — the backend **will not close** the terminal on `close()`
- The existing no-arg constructor is unchanged (creates and owns a new system terminal)
- A private `JLineBackend(Terminal, boolean ownTerminal)` delegates both constructors

Combined with the existing `TuiConfig.builder().backend(backend).build()` path, host applications can now pass their terminal through:

```java
Terminal shellTerminal = getActiveTerminal();
Backend backend = new JLineBackend(shellTerminal);
try (var tui = TuiRunner.create(TuiConfig.builder().backend(backend).build())) {
    tui.run(handler, renderer);
}
```

## Use case

Apache Camel JBang has an interactive shell (`camel shell`) built on JLine. Subcommands like `tui` (a TamboUI dashboard) need to reuse the shell's terminal rather than creating their own. Without this change, running `tui` from inside `camel shell` crashes immediately.

_Claude Code on behalf of Guillaume Nodet_