### PR TITLE
Fix JLine terminal close hanging on macOS

### DIFF
--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -293,7 +293,27 @@ public class JLineBackend extends AbstractBackend {
         disableRawMode();
 
         writer.flush();
-        terminal.close();
+
+        // Close terminal with a timeout to work around a macOS deadlock:
+        // JLine's internal reader thread blocks in native FileInputStream.read0()
+        // on stdin, and FileDescriptor.close0() blocks until that read completes.
+        // On macOS, close() never unblocks a concurrent read() on the same FD.
+        // All terminal state is already restored above, so skipping close on
+        // timeout is safe — JVM exit handles FD cleanup.
+        Thread closeThread = new Thread(() -> {
+            try {
+                terminal.close();
+            } catch (IOException e) {
+                // best effort
+            }
+        }, "jline-terminal-close");
+        closeThread.setDaemon(true);
+        closeThread.start();
+        try {
+            closeThread.join(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     /**

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TerminalInputReader.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TerminalInputReader.java
@@ -74,6 +74,7 @@ public final class TerminalInputReader implements Runnable {
     public void stop(long timeoutMs) {
         Thread t = thread;
         if (t != null && t.isAlive()) {
+            t.interrupt();
             try {
                 t.join(timeoutMs);
             } catch (InterruptedException e) {


### PR DESCRIPTION
Fixes #354

## Summary

- Run `terminal.close()` in a daemon thread with a 2-second timeout in `JLineBackend.close()` to work around a macOS deadlock where `FileDescriptor.close0()` blocks indefinitely when JLine's internal reader thread is in a native `read0()` on stdin
- Interrupt the input reader thread in `TerminalInputReader.stop()` so it exits its JLine `read()` wait faster

## Root Cause

On macOS, the `close()` syscall on a file descriptor blocks if another thread is in a `read()` syscall on the same FD. JLine's internal "non blocking reader thread" sits in `FileInputStream.read0()` on stdin, and `Thread.interrupt()` has no effect on native I/O. When `terminal.close()` calls `FileDescriptor.close0()`, it deadlocks.

## Approach

All terminal state (raw mode, alternate screen, cursor, mouse capture) is already restored before `terminal.close()` is called. The close just releases the underlying streams. By running it in a daemon thread with a timeout, if it hangs (macOS), the JVM exits cleanly. If it works (Linux), it completes within the timeout.

## Thread dump showing the deadlock

```
"main" RUNNABLE
  at java.io.FileDescriptor.close0(Native Method)  ← blocks here
  at java.io.FileInputStream.close(...)
  at org.jline.utils.NonBlockingInputStreamImpl.close(...)
  at dev.tamboui.backend.jline3.JLineBackend.close(...)

"JLine terminal non blocking reader thread" RUNNABLE
  at java.io.FileInputStream.read0(Native Method)   ← stuck here
  at org.jline.utils.NonBlockingInputStreamImpl.run(...)
```

## Test plan

- [ ] Start any TamboUI TUI app on macOS, press `q` to quit — should exit cleanly without hanging
- [ ] Same test on Linux — should still exit cleanly (close completes within timeout)