### PR TITLE
fix: Ctrl+letter and Shift+letter keys dropped during tape replay

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/internal/record/InteractionPlayer.java
+++ b/tamboui-core/src/main/java/dev/tamboui/internal/record/InteractionPlayer.java
@@ -272,8 +272,8 @@ final class InteractionPlayer {
                 break;
 
             default:
-                // Check for Ctrl+key patterns
-                if (command.startsWith("ctrl+")) {
+                // Check for modifier+key patterns (Ctrl+x, Shift+x)
+                if (command.startsWith("ctrl+") || command.startsWith("shift+")) {
                     addRepeatedKey(command, repeatCount, repeatDelayMs, interactions);
                 }
                 break;
@@ -462,11 +462,13 @@ final class InteractionPlayer {
         // Check for modifier prefixes
         boolean ctrl = false;
         boolean shift = false;
+        String keyName = keySpec;
 
         while (lower.contains("+")) {
             int plusIdx = lower.indexOf('+');
             String prefix = lower.substring(0, plusIdx);
             lower = lower.substring(plusIdx + 1);
+            keyName = keyName.substring(keyName.indexOf('+') + 1);
 
             switch (prefix) {
                 case "ctrl":
@@ -554,9 +556,9 @@ final class InteractionPlayer {
                 pendingBytes.add((int) '~');
                 break;
             default:
-                // Single character - use original keySpec to preserve case
-                if (keySpec.length() == 1) {
-                    char c = keySpec.charAt(0);
+                // Single character - use keyName (with modifiers stripped) to preserve case
+                if (keyName.length() == 1) {
+                    char c = keyName.charAt(0);
                     if (ctrl && Character.isLetter(c)) {
                         // Ctrl+letter = letter - 'a' + 1
                         pendingBytes.add(Character.toLowerCase(c) - 'a' + 1);

--- a/tamboui-core/src/test/java/dev/tamboui/internal/record/InteractionPlayerTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/internal/record/InteractionPlayerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.internal.record;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.*;
+
+class InteractionPlayerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void ctrlLetterKeysShouldProduceCorrectBytes() throws IOException {
+        Path tape = tempDir.resolve("test.tape");
+        Files.write(tape, "Ctrl+t\nCtrl+d\nCtrl+a\nCtrl+c\n".getBytes(StandardCharsets.UTF_8));
+
+        List<Interaction> interactions = InteractionPlayer.loadFromFile(tape, tempDir.resolve("out.cast"));
+        InteractionPlayer player = new InteractionPlayer(interactions, null);
+
+        List<Integer> bytes = collectKeyBytes(player);
+
+        assertThat(bytes).containsExactly(
+                0x14, // Ctrl+T = 't' - 'a' + 1 = 20
+                0x04, // Ctrl+D = 'd' - 'a' + 1 = 4
+                0x01, // Ctrl+A = 'a' - 'a' + 1 = 1
+                0x03  // Ctrl+C = 'c' - 'a' + 1 = 3
+        );
+    }
+
+    @Test
+    void shiftLetterShouldProduceUppercase() throws IOException {
+        Path tape = tempDir.resolve("test.tape");
+        Files.write(tape, "Shift+d\n".getBytes(StandardCharsets.UTF_8));
+
+        List<Interaction> interactions = InteractionPlayer.loadFromFile(tape, tempDir.resolve("out.cast"));
+        InteractionPlayer player = new InteractionPlayer(interactions, null);
+
+        List<Integer> bytes = collectKeyBytes(player);
+
+        assertThat(bytes).containsExactly((int) 'D');
+    }
+
+    @Test
+    void typedTextShouldProduceCharacterBytes() throws IOException {
+        Path tape = tempDir.resolve("test.tape");
+        Files.write(tape, "Type \"abc\"\n".getBytes(StandardCharsets.UTF_8));
+
+        List<Interaction> interactions = InteractionPlayer.loadFromFile(tape, tempDir.resolve("out.cast"));
+        InteractionPlayer player = new InteractionPlayer(interactions, null);
+
+        List<Integer> bytes = collectKeyBytes(player);
+
+        assertThat(bytes).containsExactly((int) 'a', (int) 'b', (int) 'c');
+    }
+
+    @Test
+    void ctrlKeysInMixedTapeShouldWork() throws IOException {
+        Path tape = tempDir.resolve("test.tape");
+        Files.write(tape, "Ctrl+t\nType \"hi\"\nEnter\n".getBytes(StandardCharsets.UTF_8));
+
+        List<Interaction> interactions = InteractionPlayer.loadFromFile(tape, tempDir.resolve("out.cast"));
+        InteractionPlayer player = new InteractionPlayer(interactions, null);
+
+        List<Integer> bytes = collectKeyBytes(player);
+
+        assertThat(bytes).containsExactly(
+                0x14,        // Ctrl+T
+                (int) 'h',   // Type "hi"
+                (int) 'i',
+                (int) '\r'   // Enter
+        );
+    }
+
+    private static List<Integer> collectKeyBytes(InteractionPlayer player) {
+        List<Integer> bytes = new ArrayList<>();
+        while (!player.isFinished()) {
+            int b = player.nextCodePoint(0);
+            if (b >= 0) {
+                bytes.add(b);
+            } else if (b == -2) {
+                // timeout/wait — skip
+            } else {
+                break;
+            }
+        }
+        return bytes;
+    }
+}


### PR DESCRIPTION
## Summary

- Fix `InteractionPlayer.enqueueKey()` where `Ctrl+letter` key combinations (e.g., `Ctrl+t`, `Ctrl+d`) were silently dropped during tape replay. The modifier prefix was stripped from the lowercase copy but `keySpec` still held the full string — `keySpec.length() == 1` failed for `"ctrl+t"` (length 6), so no byte was ever emitted.
- Also fix `parseVhsCommand()` to accept `Shift+key` patterns (previously only `Ctrl+` was allowed through).
- Add `InteractionPlayerTest` with 4 test cases covering Ctrl+letter, Shift+letter, typed text, and mixed tape sequences.

## Test plan

- [x] All 4 new tests pass
- [ ] Verify `Ctrl+t` in a tape file produces byte 0x14 during replay
- [ ] Verify `Shift+D` in a tape file produces uppercase 'D' during replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)