### PR TITLE
Fix arrow key handling on Windows terminals (Panama backend)

### DIFF
--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/windows/WindowsTerminal.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/windows/WindowsTerminal.java
@@ -4,16 +4,15 @@
  */
 package dev.tamboui.backend.panama.windows;
 
+import dev.tamboui.backend.panama.PlatformTerminal;
+import dev.tamboui.error.RuntimeIOException;
+import dev.tamboui.layout.Size;
 import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-
-import dev.tamboui.backend.panama.PlatformTerminal;
-import dev.tamboui.error.RuntimeIOException;
-import dev.tamboui.layout.Size;
 
 /**
  * Windows terminal operations using Panama FFI.
@@ -35,6 +34,8 @@ public final class WindowsTerminal implements PlatformTerminal {
     private boolean rawModeEnabled;
     private volatile Runnable resizeHandler;
     private int pendingSurrogate;
+
+    private int peekedChar = Integer.MIN_VALUE; // empty until peek() fills it
 
     /**
      * Creates a new Windows terminal instance.
@@ -139,6 +140,26 @@ public final class WindowsTerminal implements PlatformTerminal {
 
     @Override
     public int read(int timeoutMs) throws IOException {
+        if (peekedChar != Integer.MIN_VALUE) {
+            int c = peekedChar;
+            peekedChar = Integer.MIN_VALUE;
+            return c;
+        }
+        return readFromConsole(timeoutMs);
+    }
+
+    @Override
+    public int peek(int timeoutMs) throws IOException {
+        if (peekedChar == Integer.MIN_VALUE) {
+            int c = readFromConsole(timeoutMs);
+            if (c != -2) {
+                peekedChar = c;
+            }
+        }
+        return peekedChar == Integer.MIN_VALUE ? -2 : peekedChar;
+    }
+
+    private int readFromConsole(int timeoutMs) throws IOException {
         if (Kernel32.getNumberOfConsoleInputEvents(inputHandle, intBuffer) == 0) {
             throw new RuntimeIOException("Failed to get number of console input events");
         }
@@ -177,7 +198,7 @@ public final class WindowsTerminal implements PlatformTerminal {
                         // Windows sends supplementary characters as two KEY_EVENTs with surrogates;
                         // read the low surrogate immediately with a short wait.
                         pendingSurrogate = c;
-                        return read(50);
+                        return readFromConsole(50);
                     }
                     if (Character.isLowSurrogate((char) c) && pendingSurrogate != 0) {
                         int codePoint = Character.toCodePoint((char) pendingSurrogate, (char) c);
@@ -196,14 +217,6 @@ public final class WindowsTerminal implements PlatformTerminal {
         }
 
         return -2; // No relevant data
-    }
-
-    @Override
-    public int peek(int timeoutMs) throws IOException {
-        if (Kernel32.getNumberOfConsoleInputEvents(inputHandle, intBuffer) == 0) {
-            throw new RuntimeIOException("Failed to get number of console input events");
-        }
-        return intBuffer.get(ValueLayout.JAVA_INT, 0) > 0 ? 0 : -2;
     }
 
     @Override

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/windows/WindowsTerminal.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/windows/WindowsTerminal.java
@@ -4,15 +4,16 @@
  */
 package dev.tamboui.backend.panama.windows;
 
-import dev.tamboui.backend.panama.PlatformTerminal;
-import dev.tamboui.error.RuntimeIOException;
-import dev.tamboui.layout.Size;
 import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
+import dev.tamboui.backend.panama.PlatformTerminal;
+import dev.tamboui.error.RuntimeIOException;
+import dev.tamboui.layout.Size;
 
 /**
  * Windows terminal operations using Panama FFI.

--- a/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/windows/WindowsTerminalPeekTest.java
+++ b/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/windows/WindowsTerminalPeekTest.java
@@ -4,14 +4,14 @@
  */
 package dev.tamboui.backend.panama.windows;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Verifies the {@code peek()}/{@code read()} contract on Windows.

--- a/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/windows/WindowsTerminalPeekTest.java
+++ b/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/windows/WindowsTerminalPeekTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.backend.panama.windows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Verifies the {@code peek()}/{@code read()} contract on Windows.
+ *
+ * <p>Ensures {@code peek()} returns the actual character (or -2 if empty),
+ * which is critical for CSI escape sequence parsing.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class WindowsTerminalPeekTest {
+
+    private WindowsTerminal terminal;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        terminal = new WindowsTerminal();
+        terminal.enableRawMode();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (terminal != null) {
+            terminal.close();
+        }
+    }
+
+    @Test
+    @DisplayName("peek() with no queued input returns -2, not 0")
+    void peekWithNoInputReturnsMinusTwo() throws Exception {
+        // Non-blocking peek (timeout=0): nothing is in the buffer so the contract
+        // requires -2. The broken implementation returned 0 here because it checked
+        // GetNumberOfConsoleInputEvents and returned the count directly as its result.
+        int result = terminal.peek(0);
+
+        assertThat(result)
+            .as("peek() with no queued input must return -2, never 0")
+            .isEqualTo(-2);
+    }
+
+    @Test
+    @DisplayName("read() with no queued input returns -2")
+    void readWithNoInputReturnsMinusTwo() throws Exception {
+        int result = terminal.read(0);
+
+        assertThat(result).isEqualTo(-2);
+    }
+
+    @Test
+    @DisplayName("peek() followed by read() both return -2 when nothing is queued")
+    void peekThenReadBothReturnMinusTwoWhenEmpty() throws Exception {
+        // Verifies that peek() doesn't corrupt the peekedChar field in a way that
+        // causes a subsequent read() to return a stale non-negative value.
+        int peeked = terminal.peek(0);
+        int read   = terminal.read(0);
+
+        assertThat(peeked).isEqualTo(-2);
+        assertThat(read)
+            .as("read() after an empty peek() must still return -2, not a stale value")
+            .isEqualTo(-2);
+    }
+}

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
@@ -168,6 +168,93 @@ class EventParserTest {
         assertThat(keyEvent.hasAlt()).isTrue();
     }
 
+    // -- Arrow key CSI sequences (ESC [ A/B/C/D) --
+
+    @Test
+    @DisplayName("ESC[A is parsed as UP arrow")
+    void arrowUpParsedFromCsiSequence() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', 'A');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        assertThat(((KeyEvent) event).code()).isEqualTo(KeyCode.UP);
+    }
+
+    @Test
+    @DisplayName("ESC[B is parsed as DOWN arrow")
+    void arrowDownParsedFromCsiSequence() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', 'B');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        assertThat(((KeyEvent) event).code()).isEqualTo(KeyCode.DOWN);
+    }
+
+    @Test
+    @DisplayName("ESC[C is parsed as RIGHT arrow")
+    void arrowRightParsedFromCsiSequence() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', 'C');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        assertThat(((KeyEvent) event).code()).isEqualTo(KeyCode.RIGHT);
+    }
+
+    @Test
+    @DisplayName("ESC[D is parsed as LEFT arrow")
+    void arrowLeftParsedFromCsiSequence() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', 'D');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        assertThat(((KeyEvent) event).code()).isEqualTo(KeyCode.LEFT);
+    }
+
+    @Test
+    @DisplayName("consecutive arrow keys are each parsed independently")
+    void consecutiveArrowKeysEachParsedIndependently() throws IOException {
+        // ESC[A ESC[B — two separate UP and DOWN events
+        QueueBackend backend = new QueueBackend(27, '[', 'A', 27, '[', 'B');
+
+        Event first  = EventParser.readEvent(backend, 0);
+        Event second = EventParser.readEvent(backend, 0);
+
+        assertThat(((KeyEvent) first).code()).isEqualTo(KeyCode.UP);
+        assertThat(((KeyEvent) second).code()).isEqualTo(KeyCode.DOWN);
+    }
+
+    @Test
+    @DisplayName("arrow keys become UNKNOWN when peek() returns 0 instead of the actual char")
+    void arrowKeyBecomesUnknownWhenPeekReturnsFlagInsteadOfChar() throws IOException {
+        // Simulates the broken WindowsTerminal.peek() that returned 0 (flag) rather
+        // than the next character. ESC [A should be UP, but with wrong peek it is UNKNOWN.
+        BrokenPeekBackend backend = new BrokenPeekBackend(27, '[', 'A');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        assertThat(((KeyEvent) event).code())
+            .as("peek() returning 0 instead of '[' prevents CSI detection")
+            .isEqualTo(KeyCode.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("arrow keys are correctly parsed when peek() returns the actual char")
+    void arrowKeyCorrectlyParsedWhenPeekReturnsActualChar() throws IOException {
+        // The correct implementation: peek() returns the real next character value.
+        // This is the contract required by EventParser and fulfilled by the fix.
+        QueueBackend backend = new QueueBackend(27, '[', 'A');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        assertThat(((KeyEvent) event).code()).isEqualTo(KeyCode.UP);
+    }
+
     private static final class QueueBackend extends TestBackend {
 
         private final int[] input;
@@ -194,6 +281,38 @@ class EventParserTest {
                 return -2;
             }
             return input[index];
+        }
+    }
+
+    /**
+     * Reproduces the broken WindowsTerminal.peek() behaviour: returns 0 when input is
+     * available instead of the actual next character value. Used to document and lock in
+     * the regression so it is immediately obvious if peek() is ever broken this way again.
+     */
+    private static final class BrokenPeekBackend extends TestBackend {
+
+        private final int[] input;
+        private int index;
+
+        private BrokenPeekBackend(int... input) {
+            super(80, 24);
+            this.input = input;
+            this.index = 0;
+        }
+
+        @Override
+        public int read(int timeoutMs) {
+            if (index >= input.length) {
+                return -2;
+            }
+            return input[index++];
+        }
+
+        @Override
+        public int peek(int timeoutMs) {
+            // Intentionally broken: returns 0 (events available) instead of the actual char.
+            // This is exactly what WindowsTerminal.peek() did before the fix.
+            return index < input.length ? 0 : -2;
         }
     }
 }


### PR DESCRIPTION
## Quick Gist
Arrow key navigation (Up, Down, Left, Right) did not work in TUI applications running on Windows as a native image. Pressing an arrow key produced no response or triggered an UNKNOWN key event instead of KeyCode.UP / KeyCode.DOWN / etc.

## Bug
`WindowsTerminal.peek()` did **not** return the next character. It only checked
whether any input events were queued and returned a flag:

```java
// BEFORE (broken)
@Override
public int peek(int timeoutMs) throws IOException {
    if (Kernel32.getNumberOfConsoleInputEvents(inputHandle, intBuffer) == 0) {
        throw new RuntimeIOException("...");
    }
    return intBuffer.get(ValueLayout.JAVA_INT, 0) > 0 ? 0 : -2;
    //                                                   ^
    //                           always 0 when events exist, never the actual char
}
```

## Workaround
https://github.com/acltabontabon/mod-scope/commit/eeeb89dd1b090de49605ca1ea821f230ce169721

---

Fixes #359 