### PR TITLE
Fix MarkdownView to render partial code blocks

### DIFF
--- a/tamboui-markdown/src/main/java/dev/tamboui/markdown/MarkdownView.java
+++ b/tamboui-markdown/src/main/java/dev/tamboui/markdown/MarkdownView.java
@@ -261,12 +261,11 @@ public final class MarkdownView implements Widget {
                 continue;
             }
             if (chunk instanceof WidgetChunk) {
-                // Block-bordered widgets (code blocks, tables) need their full
-                // geometry to render correctly — a partial slice paints only
-                // the top border with no closure. Skip when we can't fit it
-                // whole; the user scrolls to align with its top.
-                if (chunkSkip == 0 && visibleHeight == chunkHeight) {
-                    Rect target = new Rect(contentArea.left(), y, contentArea.width(), chunkHeight);
+                // Render block-bordered widgets (code blocks, tables) when
+                // their top is visible. Paragraph and Block clip naturally
+                // when the available height is less than the full chunk.
+                if (chunkSkip == 0) {
+                    Rect target = new Rect(contentArea.left(), y, contentArea.width(), visibleHeight);
                     chunk.render(target, buffer);
                 }
             } else if (chunk instanceof LinesChunk) {

--- a/tamboui-markdown/src/main/java/dev/tamboui/markdown/MarkdownView.java
+++ b/tamboui-markdown/src/main/java/dev/tamboui/markdown/MarkdownView.java
@@ -261,12 +261,22 @@ public final class MarkdownView implements Widget {
                 continue;
             }
             if (chunk instanceof WidgetChunk) {
-                // Render block-bordered widgets (code blocks, tables) when
-                // their top is visible. Paragraph and Block clip naturally
-                // when the available height is less than the full chunk.
                 if (chunkSkip == 0) {
+                    // Top of widget is visible — render directly, clipped at the bottom.
                     Rect target = new Rect(contentArea.left(), y, contentArea.width(), visibleHeight);
                     chunk.render(target, buffer);
+                } else {
+                    // Top of widget is scrolled off-screen. Render to a scratch buffer
+                    // at full height, then copy only the visible rows into the output.
+                    Rect full = new Rect(0, 0, contentArea.width(), chunkHeight);
+                    Buffer scratch = Buffer.empty(full);
+                    chunk.render(full, scratch);
+                    for (int row = 0; row < visibleHeight; row++) {
+                        for (int col = 0; col < contentArea.width(); col++) {
+                            buffer.set(contentArea.left() + col, y + row,
+                                scratch.get(col, chunkSkip + row));
+                        }
+                    }
                 }
             } else if (chunk instanceof LinesChunk) {
                 LinesChunk lc = (LinesChunk) chunk;

--- a/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
+++ b/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
@@ -255,6 +255,37 @@ class MarkdownViewTest {
     }
 
     @Test
+    @DisplayName("renders bottom of a code block when top is scrolled off-screen")
+    void rendersCodeBlockScrolledFromTop() {
+        // 1-line code block = 3 rows (top border + content + bottom border).
+        // Scroll by 1 so the top border is off-screen — should show content + bottom border.
+        MarkdownView view = MarkdownView.builder()
+            .source("```\ncode\n```")
+            .scroll(1)
+            .build();
+        Buffer buffer = renderInto(view, 20, 3);
+
+        // Row 0: code content (top border scrolled away)
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("c");
+        // Row 1: bottom border
+        assertThat(buffer.get(0, 1).symbol()).isEqualTo("╰");
+    }
+
+    @Test
+    @DisplayName("renders only bottom border when code block is mostly scrolled off")
+    void rendersCodeBlockBottomBorderOnly() {
+        // 1-line code block = 3 rows. Scroll by 2 — only bottom border remains visible.
+        MarkdownView view = MarkdownView.builder()
+            .source("```\ncode\n```")
+            .scroll(2)
+            .build();
+        Buffer buffer = renderInto(view, 20, 3);
+
+        // Row 0: bottom border only
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("╰");
+    }
+
+    @Test
     @DisplayName("computeHeight returns 0 for non-positive widths")
     void computeHeightZero() {
         MarkdownView view = MarkdownView.builder().source("# Title").build();

--- a/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
+++ b/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
@@ -218,6 +218,43 @@ class MarkdownViewTest {
     }
 
     @Test
+    @DisplayName("partially renders a fenced code block when viewport is shorter than the block")
+    void rendersPartialCodeBlock() {
+        // 3-line code block = 5 rows total (top border + 3 lines + bottom border).
+        // Give only 3 rows — Block renders: top border, 1 content line, bottom border.
+        MarkdownView view = MarkdownView.builder()
+            .source("```\nline1\nline2\nline3\n```")
+            .build();
+        Buffer buffer = renderInto(view, 20, 3);
+
+        // Top border visible
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("╭");
+        // First code line visible
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo("l");
+        assertThat(buffer.get(5, 1).symbol()).isEqualTo("1");
+        // Bottom border (Block closes within available height)
+        assertThat(buffer.get(0, 2).symbol()).isEqualTo("╰");
+    }
+
+    @Test
+    @DisplayName("renders a code block preceded by text when only partial code block fits")
+    void rendersPartialCodeBlockAfterText() {
+        // Paragraph takes 1 row, spacer 1 row, code block needs 3 rows (border + 1 line + border).
+        // Give 4 rows total — paragraph(1) + spacer(1) + partial code block(2 of 3).
+        MarkdownView view = MarkdownView.builder()
+            .source("hello\n\n```\ncode\n```")
+            .build();
+        Buffer buffer = renderInto(view, 20, 4);
+
+        // First row: paragraph
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("h");
+        // Row 3 (index 2): top border of code block
+        assertThat(buffer.get(0, 2).symbol()).isEqualTo("╭");
+        // Row 4 (index 3): bottom border (only 2 rows for a 3-row code block)
+        assertThat(buffer.get(0, 3).symbol()).isEqualTo("╰");
+    }
+
+    @Test
     @DisplayName("computeHeight returns 0 for non-positive widths")
     void computeHeightZero() {
         MarkdownView view = MarkdownView.builder().source("# Title").build();


### PR DESCRIPTION
## Summary

- Fix `MarkdownView` to render fenced code blocks and tables even when they don't fully fit in the remaining viewport height
- Previously, `WidgetChunk`-based elements were completely skipped if `visibleHeight != chunkHeight`, leaving blank space
- Now passes the available `visibleHeight` to the widget's render target, allowing `Block` and `Paragraph` to clip naturally

## Changes

Removed the `visibleHeight == chunkHeight` guard in `MarkdownView.render()` and pass `visibleHeight` instead of `chunkHeight` to the `Rect` target. The `chunkSkip == 0` guard is preserved since scrolling past the top of a bordered widget requires more work.

## Tests

- Added `rendersPartialCodeBlock` — verifies a 5-row code block renders correctly when only 3 rows are available (top border + 1 content line + bottom border)
- Added `rendersPartialCodeBlockAfterText` — verifies a code block preceded by a paragraph renders its top border even when only 2 of 3 rows fit

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code) on behalf of Claus Ibsen