### PR TITLE
Add HIDDEN mode to image stress test

### DIFF
--- a/tamboui-image/demos/image-stress-test/src/main/java/dev/tamboui/demo/ImageStressTest.java
+++ b/tamboui-image/demos/image-stress-test/src/main/java/dev/tamboui/demo/ImageStressTest.java
@@ -69,7 +69,7 @@ import dev.tamboui.widgets.paragraph.Paragraph;
  */
 public class ImageStressTest {
 
-    private enum Mode { SAME, CHANGING }
+    private enum Mode { SAME, CHANGING, HIDDEN }
 
     private boolean running = true;
     private Mode mode = Mode.SAME;
@@ -122,7 +122,11 @@ public class ImageStressTest {
                 running = false;
                 break;
             case 'c': case 'C':
-                mode = (mode == Mode.SAME) ? Mode.CHANGING : Mode.SAME;
+                switch (mode) {
+                    case SAME: mode = Mode.CHANGING; break;
+                    case CHANGING: mode = Mode.HIDDEN; break;
+                    case HIDDEN: mode = Mode.SAME; break;
+                }
                 break;
             case 'f':
                 scaling = ImageScaling.FIT;
@@ -176,9 +180,9 @@ public class ImageStressTest {
         var lines = Text.from(
             Line.from(
                 Span.raw("  Mode: ").dim(),
-                mode == Mode.SAME
-                    ? Span.raw("SAME IMAGE (skip expected)").green().bold()
-                    : Span.raw("CHANGING IMAGE (re-transmit every frame)").red().bold()
+                mode == Mode.SAME ? Span.raw("SAME IMAGE (skip expected)").green().bold()
+                    : mode == Mode.CHANGING ? Span.raw("CHANGING IMAGE (re-transmit every frame)").red().bold()
+                    : Span.raw("HIDDEN (no image rendered)").yellow().bold()
             ),
             Line.from(
                 Span.raw("  Protocol: ").dim(),
@@ -218,6 +222,23 @@ public class ImageStressTest {
     }
 
     private void renderImage(Frame frame, Rect area) {
+        if (mode == Mode.HIDDEN) {
+            // Render just the block with a label — no image widget, so the terminal's
+            // raw-output cleanup should remove any previously shown image.
+            var placeholder = Paragraph.builder()
+                .text(Text.from(Line.empty(), Line.from(Span.raw("Image hidden — press c to cycle back").dim())))
+                .centered()
+                .block(Block.builder()
+                    .borders(Borders.ALL)
+                    .borderType(BorderType.ROUNDED)
+                    .borderStyle(Style.EMPTY.fg(Color.DARK_GRAY))
+                    .title(Title.from(Line.from(Span.raw(" hidden ").dim())))
+                    .build())
+                .build();
+            frame.renderWidget(placeholder, area);
+            return;
+        }
+
         var imageData = (mode == Mode.CHANGING)
             ? generateRandomImage(256, 256)
             : staticImage;
@@ -242,7 +263,7 @@ public class ImageStressTest {
     private void renderHelp(Frame frame, Rect area) {
         var help = Paragraph.builder()
             .text(Text.from(Line.from(
-                Span.raw(" c").bold().yellow(), Span.raw(" toggle mode  ").dim(),
+                Span.raw(" c").bold().yellow(), Span.raw(" cycle mode  ").dim(),
                 Span.raw("1").bold().yellow(), Span.raw(" Kitty  ").dim(),
                 Span.raw("2").bold().yellow(), Span.raw(" iTerm2  ").dim(),
                 Span.raw("3").bold().yellow(), Span.raw(" Sixel  ").dim(),


### PR DESCRIPTION
Adds a third mode to the image stress test demo for debugging image lifecycle issues.

Pressing `c` now cycles: **SAME → CHANGING → HIDDEN → SAME**.

HIDDEN renders no image widget at all, so `Terminal.cleanupRawOutput()` kicks in and should wipe the image from screen. Useful for verifying:
- Image disappears when hidden
- Image comes back correctly after hiding
- Whether hiding/showing breaks the Ghostty stuck-image issue observed in #363