### PR TITLE
Add mise tasks for common development workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,22 @@ cd tamboui
 ./gradlew build
 ```
 
+### mise (optional, recommended)
+
+If you have [mise](https://mise.jdx.dev) installed, it will automatically set up the correct Java and JBang versions and give you shorthand tasks for common operations:
+
+```bash
+mise install        # install Java + JBang
+mise tasks          # list available tasks
+mise run build      # compile + format, no tests
+mise run test       # run all tests
+mise run check      # full build + tests + javadoc
+mise run format     # apply Spotless formatting
+mise run demo <name>  # run a demo
+```
+
+Run `mise tasks` for the full list.
+
 ## IDE's 
 
 Intellij, Visual Code Studio and Cursor is known to work with TamboUI project.
@@ -45,6 +61,16 @@ You need to set both `java.jdt.ls.java.home` and `gradle.java.home` for it to wo
 ```
 
 ## Build and test
+
+Using mise (if installed):
+
+- Build: `mise run build`
+- Test: `mise run test`
+- Full check: `mise run check`
+- Javadoc: `mise run javadoc`
+- Format: `mise run format`
+
+Or directly with Gradle:
 
 - Build: `./gradlew -q build`
 - Test: `./gradlew -q test`

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,69 @@
+[tools]
+java = "latest"
+jbang = "latest"
+
+# ── Build ──────────────────────────────────────────────────────────────────────
+
+[tasks.build]
+description = "Build without tests or javadoc"
+run = "./gradlew -q spotlessApply assemble -x test -x javadoc"
+
+[tasks.test]
+description = "Run all tests"
+run = "./gradlew -q test"
+
+[tasks.check]
+description = "Full build: compile + test + javadoc"
+run = "./gradlew -q build javadoc"
+
+# ── Code Quality ───────────────────────────────────────────────────────────────
+
+[tasks.format]
+description = "Apply code formatting (Spotless)"
+run = "./gradlew -q spotlessApply"
+
+[tasks.format-check]
+description = "Check code formatting without applying"
+run = "./gradlew -q spotlessCheck"
+
+# ── Documentation ──────────────────────────────────────────────────────────────
+
+[tasks.javadoc]
+description = "Generate javadoc (checks for warnings)"
+run = "./gradlew -q javadoc"
+
+[tasks.docs]
+description = "Build Asciidoc documentation"
+run = "./gradlew -q :docs:asciidoctor"
+
+# ── Publishing ─────────────────────────────────────────────────────────────────
+
+[tasks.publish-local]
+description = "Publish to local Maven repository"
+run = "./gradlew -q publishToMavenLocal"
+
+[tasks.publish-build]
+description = "Publish to build/ directory for inspection"
+run = "./gradlew -q publishAllPublicationsToBuildRepository"
+
+# ── Demos ──────────────────────────────────────────────────────────────────────
+
+[tasks.demo]
+description = "Run a demo (pass demo name as argument)"
+run = "./run-demo.sh {{arg(name=\"demo\", required=true)}}"
+
+[tasks.demo-native]
+description = "Run a demo as native image"
+run = "./run-demo.sh {{arg(name=\"demo\", required=true)}} --native"
+
+# ── JBang ──────────────────────────────────────────────────────────────────────
+
+[tasks.update-jbang]
+description = "Update the JBang demo catalog"
+run = "./gradlew -q updateJBangCatalog"
+
+# ── Housekeeping ───────────────────────────────────────────────────────────────
+
+[tasks.clean]
+description = "Delete all build directories"
+run = "./gradlew -q clean"


### PR DESCRIPTION
Adds a `mise.toml` with tasks for the most common operations:

| Task | What it does |
|------|-------------|
| `mise run build` | Compile + format, no tests/javadoc |
| `mise run test` | Run all tests |
| `mise run check` | Full build + tests + javadoc |
| `mise run format` | Apply Spotless formatting |
| `mise run format-check` | Check formatting without applying |
| `mise run javadoc` | Generate javadoc |
| `mise run docs` | Build Asciidoc docs |
| `mise run demo <name>` | Run a demo |
| `mise run demo-native <name>` | Run a demo as native image |
| `mise run publish-local` | Publish to local Maven repo |
| `mise run publish-build` | Publish to build/ for inspection |
| `mise run update-jbang` | Update JBang demo catalog |
| `mise run clean` | Wipe build dirs |

Inspired by [jbangdev/jbang's justfile](https://github.com/jbangdev/jbang/blob/main/.justfile).