### PR TITLE
fix: Parse Shift+F1-F4 key events correctly

### DIFF
--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
@@ -301,6 +301,18 @@ public final class EventParser {
             case 'F':
                 code = KeyCode.END;
                 break;
+            case 'P':
+                code = KeyCode.F1;
+                break;
+            case 'Q':
+                code = KeyCode.F2;
+                break;
+            case 'R':
+                code = KeyCode.F3;
+                break;
+            case 'S':
+                code = KeyCode.F4;
+                break;
             default:
                 code = KeyCode.UNKNOWN;
                 break;

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
@@ -103,6 +103,71 @@ class EventParserTest {
         assertThat(keyEvent.hasShift()).isTrue();
     }
 
+    @Test
+    @DisplayName("SS3 F4 (ESC O S) is parsed as F4")
+    void ss3F4ParsedCorrectly() throws IOException {
+        QueueBackend backend = new QueueBackend(27, 'O', 'S');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.F4);
+        assertThat(keyEvent.hasShift()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Shift+F1 (ESC[1;2P) is parsed as F1 with Shift")
+    void shiftF1ParsedCorrectly() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', '1', ';', '2', 'P');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.F1);
+        assertThat(keyEvent.hasShift()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Shift+F4 (ESC[1;2S) is parsed as F4 with Shift")
+    void shiftF4ParsedCorrectly() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', '1', ';', '2', 'S');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.F4);
+        assertThat(keyEvent.hasShift()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Ctrl+F2 (ESC[1;5Q) is parsed as F2 with Ctrl")
+    void ctrlF2ParsedCorrectly() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', '1', ';', '5', 'Q');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.F2);
+        assertThat(keyEvent.hasCtrl()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Alt+F3 (ESC[1;3R) is parsed as F3 with Alt")
+    void altF3ParsedCorrectly() throws IOException {
+        QueueBackend backend = new QueueBackend(27, '[', '1', ';', '3', 'R');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(KeyEvent.class);
+        KeyEvent keyEvent = (KeyEvent) event;
+        assertThat(keyEvent.code()).isEqualTo(KeyCode.F3);
+        assertThat(keyEvent.hasAlt()).isTrue();
+    }
+
     private static final class QueueBackend extends TestBackend {
 
         private final int[] input;


### PR DESCRIPTION
## Problem

`parseModifiedArrow()` in `EventParser` handles CSI sequences with modifiers for arrows (`A`-`D`) and Home/End (`H`/`F`), but not for F1-F4 (`P`-`S`).

When terminals send modified F1-F4 keys as CSI sequences (e.g., Shift+F4 as `\033[1;2S`), they are parsed as `KeyCode.UNKNOWN` instead of `KeyCode.F4` with the Shift modifier.

This affects F1-F4 because they normally use SS3 sequences (`\033OP` through `\033OS`), but when combined with modifiers (Shift, Ctrl, Alt), terminals switch to CSI format (`\033[1;2P` through `\033[1;2S`).

F5+ are unaffected because they always use CSI format (`\033[15~` etc.) and modifiers are handled via `parseVT()`.

## Fix

Add cases for `P` (F1), `Q` (F2), `R` (F3), `S` (F4) to `parseModifiedArrow()`.

## Testing

Verified with Apache Camel's TUI where Shift+F4 is used to cycle shell panel height. Before the fix, Shift+F4 produced no effect. After the fix, it correctly triggers `KeyCode.F4` with `hasShift() == true`.

_Claude Code on behalf of Guillaume Nodet_