### PR TITLE
fix: exclude .settings directory from gradle demo module scanning

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ val modules = listOf(
 include(*modules.toTypedArray())
 
 fun includeDemosFrom(demosDir: File, projectPathPrefix: String) {
-    demosDir.listFiles()?.filter { it.isDirectory }?.forEach { demo ->
+    demosDir.listFiles()?.filter { it.isDirectory && !it.name.startsWith(".settings") }?.forEach { demo ->
         val projectPath = "$projectPathPrefix${demo.name}"
         include(projectPath)
         project(":$projectPath").projectDir = demo


### PR DESCRIPTION
VSCode Java Language Server generates a .settings directory under the project root, which was incorrectly picked up by includeDemosFrom() and treated as a Gradle subproject, causing a naming convention error.

Fix #373 