### PR TITLE
feat(toolkit): add title alignment to Panel

### DIFF
--- a/demos/flex-demo/src/main/java/dev/tamboui/demo/flex/FlexDemo.java
+++ b/demos/flex-demo/src/main/java/dev/tamboui/demo/flex/FlexDemo.java
@@ -9,6 +9,7 @@ package dev.tamboui.demo.flex;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.style.Color;
 import dev.tamboui.toolkit.app.ToolkitRunner;
@@ -298,11 +299,11 @@ public class FlexDemo {
     }
 
     /**
-     * Example 4: Practical toolbar examples.
+     * Example 4: Practical toolbar examples with title alignment.
      */
     private static Element renderToolbar(Flex flex) {
         return column(
-                // Simple toolbar
+                // Simple toolbar - left-aligned title (default)
                 panel(() -> row(
                         button("New", Color.GREEN),
                         button("Open", Color.BLUE),
@@ -315,18 +316,19 @@ public class FlexDemo {
                 .borderColor(Color.BLUE)
                 .length(5),
 
-                // Status bar style
+                // Status bar style - centered title
                 panel(() -> row(
                         text(" Ready").bold().green(),
                         text(" | Line 42, Col 15").dim(),
                         text(" | UTF-8").dim()
                 ).flex(flex))
                 .title("Status bar")
+                .titleCenter()
                 .rounded()
                 .borderColor(Color.GREEN)
                 .length(3),
 
-                // Menu bar style
+                // Menu bar style - right-aligned title, centered bottom title
                 panel(() -> row(
                         menuItem("File"),
                         menuItem("Edit"),
@@ -334,6 +336,9 @@ public class FlexDemo {
                         menuItem("Help")
                 ).flex(flex).spacing(2))
                 .title("Menu bar")
+                .titleRight()
+                .bottomTitle("ESC to close")
+                .bottomTitleAlignment(Alignment.CENTER)
                 .rounded()
                 .borderColor(Color.YELLOW)
                 .length(3),

--- a/docs/src/docs/asciidoc/api-levels.adoc
+++ b/docs/src/docs/asciidoc/api-levels.adoc
@@ -377,6 +377,13 @@ Panels support border styling:
 include::{snippets-dir}/dev/tamboui/docs/snippets/ApiLevelsSnippets.java[tags=panel-border-styling]
 ----
 
+Titles can be aligned within the border. An explicit alignment overrides the CSS `text-align` property; when neither is set the title is left-aligned:
+
+[source,java]
+----
+include::{snippets-dir}/dev/tamboui/docs/snippets/ApiLevelsSnippets.java[tags=panel-title-alignment]
+----
+
 === Sizing
 
 Control how elements fill space:

--- a/docs/src/snippets/java/dev/tamboui/docs/snippets/ApiLevelsSnippets.java
+++ b/docs/src/snippets/java/dev/tamboui/docs/snippets/ApiLevelsSnippets.java
@@ -6,6 +6,7 @@ import dev.tamboui.backend.jline3.JLineBackend;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.inline.InlineDisplay;
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Flex;
 import dev.tamboui.layout.Layout;
@@ -541,6 +542,17 @@ public class ApiLevelsSnippets {
             .borderColor(Color.CYAN)
             .focusedBorderColor(Color.YELLOW);
         // end::panel-border-styling[]
+    }
+
+    void panelTitleAlignment() {
+        // tag::panel-title-alignment[]
+        panel("Centered", text("content"))
+            .titleCenter();          // also titleLeft(), titleRight(), titleAlignment(...)
+
+        panel("Status", text("content"))
+            .bottomTitle("v1.0")
+            .bottomTitleAlignment(Alignment.RIGHT);
+        // end::panel-title-alignment[]
     }
 
     void sizingOptions() {

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import dev.tamboui.css.Styleable;
 import dev.tamboui.css.cascade.CssStyleResolver;
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Direction;
 import dev.tamboui.layout.Flex;
@@ -49,6 +50,7 @@ import dev.tamboui.widgets.block.Title;
  *   <li>{@code flex} - Flex positioning mode: "start", "center", "end", "space-between", "space-around", "space-evenly"</li>
  *   <li>{@code margin} - Margin around the panel: single value or CSS-style shorthand</li>
  *   <li>{@code spacing} - Gap between children in cells</li>
+ *   <li>{@code text-align} - Title alignment: "left", "center", or "right"</li>
  * </ul>
  * <p>
  * Programmatic values override CSS values when both are set.
@@ -58,6 +60,8 @@ public final class Panel extends ContainerElement<Panel> {
     private Line title;
     private Line bottomTitle;
     private Overflow titleOverflow = Overflow.CLIP;
+    private Alignment titleAlignment;
+    private Alignment bottomTitleAlignment;
     private BorderType borderType;
     private Color borderColor;
     private Color focusedBorderColor;
@@ -174,6 +178,64 @@ public final class Panel extends ContainerElement<Panel> {
      */
     public Panel titleEllipsisStart() {
         this.titleOverflow = Overflow.ELLIPSIS_START;
+        return this;
+    }
+
+    /**
+     * Sets the title alignment within the top border.
+     * <p>
+     * Overrides the CSS {@code text-align} property. When neither is set, the
+     * title is left-aligned.
+     *
+     * @param alignment the title alignment
+     * @return this panel for chaining
+     */
+    public Panel titleAlignment(Alignment alignment) {
+        this.titleAlignment = alignment;
+        return this;
+    }
+
+    /**
+     * Left-aligns the title (the default).
+     *
+     * @return this panel for chaining
+     */
+    public Panel titleLeft() {
+        this.titleAlignment = Alignment.LEFT;
+        return this;
+    }
+
+    /**
+     * Center-aligns the title within the top border.
+     *
+     * @return this panel for chaining
+     */
+    public Panel titleCenter() {
+        this.titleAlignment = Alignment.CENTER;
+        return this;
+    }
+
+    /**
+     * Right-aligns the title within the top border.
+     *
+     * @return this panel for chaining
+     */
+    public Panel titleRight() {
+        this.titleAlignment = Alignment.RIGHT;
+        return this;
+    }
+
+    /**
+     * Sets the bottom title alignment within the bottom border.
+     * <p>
+     * Overrides the CSS {@code text-align} property. When neither is set, the
+     * bottom title is left-aligned.
+     *
+     * @param alignment the bottom title alignment
+     * @return this panel for chaining
+     */
+    public Panel bottomTitleAlignment(Alignment alignment) {
+        this.bottomTitleAlignment = alignment;
         return this;
     }
 
@@ -566,11 +628,14 @@ public final class Panel extends ContainerElement<Panel> {
         }
 
         if (title != null) {
-            blockBuilder.title(Title.from(title).overflow(titleOverflow));
+            blockBuilder.title(Title.from(title)
+                    .alignment(resolveTitleAlignment(titleAlignment, cssResolver))
+                    .overflow(titleOverflow));
         }
 
         if (bottomTitle != null) {
-            blockBuilder.titleBottom(Title.from(bottomTitle));
+            blockBuilder.titleBottom(Title.from(bottomTitle)
+                    .alignment(resolveTitleAlignment(bottomTitleAlignment, cssResolver)));
         }
 
         Block block = blockBuilder.build();
@@ -646,6 +711,25 @@ public final class Panel extends ContainerElement<Panel> {
             Rect childArea = areas.get(i);
             context.renderChild(child, frame, childArea);
         }
+    }
+
+    /**
+     * Resolves the effective title alignment using the priority: explicit
+     * value set on this panel, then the CSS {@code text-align} property, then
+     * {@link Alignment#LEFT}.
+     *
+     * @param explicit the explicitly set alignment, or {@code null}
+     * @param cssResolver the CSS resolver for this element, or {@code null}
+     * @return the effective alignment, never {@code null}
+     */
+    private Alignment resolveTitleAlignment(Alignment explicit, CssStyleResolver cssResolver) {
+        if (explicit != null) {
+            return explicit;
+        }
+        if (cssResolver != null) {
+            return cssResolver.alignment().orElse(Alignment.LEFT);
+        }
+        return Alignment.LEFT;
     }
 
     /**

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/Panel.java
@@ -635,7 +635,8 @@ public final class Panel extends ContainerElement<Panel> {
 
         if (bottomTitle != null) {
             blockBuilder.titleBottom(Title.from(bottomTitle)
-                    .alignment(resolveTitleAlignment(bottomTitleAlignment, cssResolver)));
+                    .alignment(resolveTitleAlignment(bottomTitleAlignment, cssResolver))
+                    .overflow(titleOverflow));
         }
 
         Block block = blockBuilder.build();

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.css.engine.StyleEngine;
+import dev.tamboui.layout.Alignment;
 import dev.tamboui.layout.Direction;
 import dev.tamboui.layout.Margin;
 import dev.tamboui.layout.Padding;
@@ -69,6 +70,65 @@ class PanelTest extends AbstractElementTest {
         panel("Test").render(frame, area, context);
 
         assertThat(buffer.get(0, 0).style().fg()).contains(Color.CYAN);
+    }
+
+    // ============ title alignment tests ============
+
+    @Test
+    @DisplayName("Title is left-aligned by default")
+    void titleAlignment_defaultsToLeft() {
+        Buffer buffer = renderPanel(panel("Hi"), new Rect(0, 0, 20, 3));
+        // startX = left border + 1 = 1
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo("i");
+    }
+
+    @Test
+    @DisplayName("titleCenter() centers the title in the top border")
+    void titleCenter_centersTitle() {
+        Buffer buffer = renderPanel(panel("Hi").titleCenter(), new Rect(0, 0, 20, 3));
+        // availableWidth = 20 - 2 = 18, startX = 1, x = 1 + (18 - 2) / 2 = 9
+        assertThat(buffer.get(9, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(10, 0).symbol()).isEqualTo("i");
+    }
+
+    @Test
+    @DisplayName("titleRight() right-aligns the title in the top border")
+    void titleRight_rightAlignsTitle() {
+        Buffer buffer = renderPanel(panel("Hi").titleRight(), new Rect(0, 0, 20, 3));
+        // x = startX + availableWidth - titleWidth = 1 + 18 - 2 = 17
+        assertThat(buffer.get(17, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(18, 0).symbol()).isEqualTo("i");
+    }
+
+    @Test
+    @DisplayName("bottomTitleAlignment() aligns the bottom title")
+    void bottomTitleAlignment_centersBottomTitle() {
+        Buffer buffer = renderPanel(
+            panel().bottomTitle("Hi").bottomTitleAlignment(Alignment.CENTER),
+            new Rect(0, 0, 20, 3));
+        // bottom border row = height - 1 = 2; centered x = 9
+        assertThat(buffer.get(9, 2).symbol()).isEqualTo("H");
+        assertThat(buffer.get(10, 2).symbol()).isEqualTo("i");
+    }
+
+    @Test
+    @DisplayName("CSS text-align centers the title")
+    void titleAlignment_fromCssTextAlign() {
+        Buffer buffer = renderPanelStyled(panel("Hi"), new Rect(0, 0, 20, 3),
+            "Panel { text-align: center; }");
+        assertThat(buffer.get(9, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(10, 0).symbol()).isEqualTo("i");
+    }
+
+    @Test
+    @DisplayName("Explicit title alignment overrides CSS text-align")
+    void titleAlignment_explicitOverridesCss() {
+        Buffer buffer = renderPanelStyled(panel("Hi").titleRight(), new Rect(0, 0, 20, 3),
+            "Panel { text-align: center; }");
+        // explicit right wins over CSS center
+        assertThat(buffer.get(17, 0).symbol()).isEqualTo("H");
+        assertThat(buffer.get(18, 0).symbol()).isEqualTo("i");
     }
 
     // ============ preferredWidth tests ============
@@ -187,5 +247,26 @@ class PanelTest extends AbstractElementTest {
 
         assertThat(vertical.preferredSize(-1, -1, null).widthOr(0)).isEqualTo(3); // max(1,1) + 2 borders
         assertThat(horizontal.preferredSize(-1, -1, null).widthOr(0)).isEqualTo(4); // 1+1 + 2 borders
+    }
+
+    private static Buffer renderPanel(Panel panel, Rect area) {
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        panel.render(frame, area, DefaultRenderContext.createEmpty());
+        return buffer;
+    }
+
+    private static Buffer renderPanelStyled(Panel panel, Rect area, String css) {
+        StyleEngine styleEngine = StyleEngine.create();
+        styleEngine.addStylesheet("test", css);
+        styleEngine.setActiveStylesheet("test");
+
+        DefaultRenderContext context = DefaultRenderContext.createEmpty();
+        context.setStyleEngine(styleEngine);
+
+        Buffer buffer = Buffer.empty(area);
+        Frame frame = Frame.forTesting(buffer);
+        panel.render(frame, area, context);
+        return buffer;
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/PanelTest.java
@@ -131,6 +131,23 @@ class PanelTest extends AbstractElementTest {
         assertThat(buffer.get(18, 0).symbol()).isEqualTo("i");
     }
 
+    // ============ titleOverflow on bottom title ============
+
+    @Test
+    @DisplayName("titleOverflow applies to bottom title")
+    void titleOverflow_appliesToBottomTitle() {
+        // "Hello World" (11 chars) in a 10-wide panel: inner border width = 8
+        Buffer buffer = renderPanel(
+            panel().bottomTitle("Hello World").titleEllipsis(),
+            new Rect(0, 0, 10, 3));
+        // Bottom border is row 2; chars start at x=1
+        // 8 available, 11 needed -> ellipsis: "Hello..." (8 chars)
+        // Last 3 chars should be "..."
+        assertThat(buffer.get(6, 2).symbol()).isEqualTo(".");
+        assertThat(buffer.get(7, 2).symbol()).isEqualTo(".");
+        assertThat(buffer.get(8, 2).symbol()).isEqualTo(".");
+    }
+
     // ============ preferredWidth tests ============
 
     @Test


### PR DESCRIPTION
## What
`Panel` always rendered its title left-aligned, even though the underlying
`Block`/`Title` widget already supports left/center/right alignment. This
exposes title alignment on the toolkit `Panel` element.

## Changes
- `titleAlignment(Alignment)` + `titleLeft()` / `titleCenter()` / `titleRight()`
- `bottomTitleAlignment(Alignment)` for the bottom title
- Alignment resolves as **explicit > CSS `text-align` > LEFT**, matching the
  element's other CSS-backed properties (the "explicit > CSS > default" pattern
  documented in AGENTS.md)

## Tests
`PanelTest` asserts the rendered title position for each alignment, the CSS
`text-align` path, and explicit-overrides-CSS.

## Docs
Added a snippet + section to `api-levels.adoc`.

## Notes for reviewers
The CSS path reuses the Panel's own `text-align` (via `CssStyleResolver.alignment()`).
Happy to switch to a dedicated child selector (e.g. `Panel-title`) or a new
property instead if you'd prefer to keep `text-align` free for other uses.
