### PR TITLE
fix(build): resolve two IntelliJ Gradle sync failures

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,6 +17,10 @@ dependencies {
     implementation(libs.spotless.gradle.plugin)
     implementation(libs.test.logger.gradle.plugin)
 
+    // junit-jupiter / junit-platform-launcher are declared without a version in
+    // the catalog; their versions come from the junit BOM. Without this platform
+    // the version is empty ("Could not find org.junit.jupiter:junit-jupiter:").
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/buildSrc/src/main/kotlin/dev.tamboui.demo-aggregator.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.tamboui.demo-aggregator.gradle.kts
@@ -7,6 +7,19 @@ plugins {
     id("dev.tamboui.publishing")
 }
 
+// During an IntelliJ Gradle sync, java-library modules (e.g. tamboui-core) are
+// bumped to `options.release = 11` (see dev.tamboui.java-library) so the IDE can
+// resolve their module-info. That raises their org.gradle.jvm.version variant
+// attribute to 11, which then fails to resolve against this aggregator's Java 8
+// baseline ("looking for a library compatible with JVM runtime version 8, but
+// project :tamboui-core is only compatible with ... 11 or newer"). Mirror the
+// sync-only bump here so the dependency resolves. CLI/CI builds are unaffected.
+if (providers.systemProperty("idea.sync.active").isPresent) {
+    tasks.withType<JavaCompile>().configureEach {
+        options.release = 11
+    }
+}
+
 val aggregatedDemos by configurations.creating {
     isCanBeResolved = false
     isCanBeConsumed = false


### PR DESCRIPTION
Two latent build issues that only surface during an **IntelliJ Gradle sync** (`idea.sync.active` is set). CLI/CI builds are unaffected, which is why they stayed hidden.

## 1. `tamboui-demos` ↔ `java-library` modules — JVM-version variant mismatch

During sync, the `isIDEASync` block in `dev.tamboui.java-library` bumps `tamboui-core`/`widgets`/`tui` to `options.release = 11` (so the IDE can resolve `module-info`). That raises their `org.gradle.jvm.version` variant attribute to 11. `tamboui-demos` uses `dev.tamboui.java-base` (release 8) and depends on those modules, so resolution fails during sync:

> project :tamboui-core is only compatible with JVM runtime version 11 or newer

Fix: mirror the sync-only release bump in `dev.tamboui.demo-aggregator` so the consumer's required JVM version matches.

**Reproduction** (same command, only the fix differs):

```
./gradlew :tamboui-demos:dependencies --configuration compileClasspath -Didea.sync.active=true
```

```
Before                                  After
+--- project :tamboui-core FAILED       +--- project :tamboui-core
+--- project :tamboui-widgets FAILED    +--- project :tamboui-widgets
\--- project :tamboui-tui FAILED        \--- project :tamboui-tui   (resolves)
```

## 2. `buildSrc` test dependencies missing the junit BOM

`junit-jupiter` / `junit-platform-launcher` are declared version-less in the catalog (their version comes from the junit BOM), but `buildSrc/build.gradle.kts` did not add `platform(libs.junit.bom)`, so the version was empty:

> Could not find org.junit.jupiter:junit-jupiter:.

Fix: add the BOM platform. Dormant on CLI because `buildSrc` has no test sources; only an eager IDE sync resolves its test classpath.

## Notes
Both fixes are guarded/additive and have no effect on CLI/CI builds. Happy to adjust the approach (e.g. handle this once in `java-base` rather than per-aggregator) if you'd prefer.
