### PR TITLE
fix(deps): update aesh-terminal to 3.14.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jline = "3.25.1"
-aesh-terminal = "3.12"
+aesh-terminal = "3.14.1"
 junit = "5.14.3"
 assertj = "3.27.7"
 native-build-tools = "0.11.4"


### PR DESCRIPTION
Upgrade aesh-terminal from 3.12 to 3.14.1 (latest release).

Affects `terminal-tty`, `terminal-ssh`, and `terminal-http` modules.

Build and all tests pass.