### PR TITLE
fix: propagate bindings to render context and align Builder APIs

### DIFF
--- a/demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java
+++ b/demos/error-handling-demo/src/main/java/dev/tamboui/demo/errorhandling/ErrorHandlingDemo.java
@@ -16,7 +16,6 @@ import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.element.Size;
 import dev.tamboui.toolkit.event.EventResult;
-import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.event.KeyEvent;
 
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -42,12 +41,8 @@ public class ErrorHandlingDemo {
      * @throws Exception on unexpected error
      */
     public static void main(String[] args) throws Exception {
-        TuiConfig config = TuiConfig.builder()
-                .tickRate(Duration.ofMillis(100))
-                .build();
-
         try (ToolkitRunner runner = ToolkitRunner.builder()
-                .config(config)
+                .tickRate(Duration.ofMillis(100))
                 .faultTolerant(true)
                 .build()) {
 

--- a/demos/fakodex-demo/src/main/java/dev/tamboui/demo/coding/CodingAssistantDemo.java
+++ b/demos/fakodex-demo/src/main/java/dev/tamboui/demo/coding/CodingAssistantDemo.java
@@ -22,7 +22,6 @@ import dev.tamboui.toolkit.app.ToolkitRunner;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.toolkit.event.EventResult;
-import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.bindings.Actions;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.input.TextInputState;
@@ -198,16 +197,12 @@ public class CodingAssistantDemo {
      */
     public void run() throws Exception {
         var styleEngine = createStyleEngine();
-        var config = TuiConfig.builder()
-                .mouseCapture(true)
-                .tickRate(Duration.ofMillis(TICK_RATE_MS))
-                .build();
-
         // Add welcome message
         addWelcomeMessage();
 
         try (var runner = ToolkitRunner.builder()
-                .config(config)
+                .mouseCapture(true)
+                .tickRate(Duration.ofMillis(TICK_RATE_MS))
                 .styleEngine(styleEngine)
                 .build()) {
             this.runner = runner;

--- a/demos/toolkit-export-demo/src/main/java/dev/tamboui/demo/ToolkitExportDemo.java
+++ b/demos/toolkit-export-demo/src/main/java/dev/tamboui/demo/ToolkitExportDemo.java
@@ -25,7 +25,6 @@ import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.ElementRegistry;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.toolkit.focus.FocusManager;
-import dev.tamboui.tui.TuiConfig;
 
 import static dev.tamboui.export.ExportRequest.export;
 import static dev.tamboui.toolkit.Toolkit.*;
@@ -63,12 +62,8 @@ public final class ToolkitExportDemo {
         Path outDir = args.length > 0 ? Paths.get(args[0]) : Files.createTempDirectory("tamboui-export-");
         ToolkitExportDemo app = new ToolkitExportDemo(outDir);
 
-        var config = TuiConfig.builder()
-            .tickRate(Duration.ofMillis(100))
-            .build();
-
         try (var r = ToolkitRunner.builder()
-            .config(config)
+            .tickRate(Duration.ofMillis(100))
             .app(app)
             .postRenderProcessor(app::captureFrame)
             .build()) {

--- a/tamboui-tfx-toolkit/demos/tfx-toolkit-demo/src/main/java/dev/tamboui/demo/TfxToolkitDemo.java
+++ b/tamboui-tfx-toolkit/demos/tfx-toolkit-demo/src/main/java/dev/tamboui/demo/TfxToolkitDemo.java
@@ -18,7 +18,6 @@ import dev.tamboui.tfx.toolkit.ToolkitEffects;
 import dev.tamboui.toolkit.app.ToolkitRunner;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.event.EventResult;
-import dev.tamboui.tui.TuiConfig;
 
 import static dev.tamboui.toolkit.Toolkit.*;
 
@@ -66,12 +65,8 @@ public class TfxToolkitDemo {
     }
 
     private void run() throws Exception {
-        TuiConfig config = TuiConfig.builder()
-                .tickRate(Duration.ofMillis(16))
-                .build();
-
         try (ToolkitRunner r = ToolkitRunner.builder()
-                .config(config)
+                .tickRate(Duration.ofMillis(16))
                 .postRenderProcessor(effects.asPostRenderProcessor())
                 .build()) {
 

--- a/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java
+++ b/tamboui-toolkit/demos/custom-component-demo/src/main/java/dev/tamboui/demo/CustomComponentDemo.java
@@ -28,7 +28,6 @@ import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.element.Size;
 import dev.tamboui.toolkit.event.EventResult;
-import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.bindings.ActionHandler;
 import dev.tamboui.tui.bindings.Actions;
 import dev.tamboui.tui.bindings.BindingSets;
@@ -258,13 +257,9 @@ public class CustomComponentDemo implements Element {
                 .bind(KeyTrigger.ch('-'), "decrement")
                 .build();
 
-        var config = TuiConfig.builder()
-            .mouseCapture(true)
-            .noTick()
-            .build();
-
         try (var runner = ToolkitRunner.builder()
-                .config(config)
+                .mouseCapture(true)
+                .noTick()
                 .bindings(bindings)
                 .build()) {
 

--- a/tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java
+++ b/tamboui-toolkit/demos/richtext-demo/src/main/java/dev/tamboui/demo/RichTextDemo.java
@@ -19,7 +19,6 @@ import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.RenderContext;
 import dev.tamboui.toolkit.element.Size;
 import dev.tamboui.toolkit.elements.MarkupTextAreaElement;
-import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.bindings.ActionHandler;
 import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.bindings.KeyTrigger;
@@ -135,13 +134,9 @@ public class RichTextDemo implements Element {
                 .bind(KeyTrigger.key(KeyCode.F2), "selectCssTab")
                 .build();
 
-        var config = TuiConfig.builder()
+        try (var runner = ToolkitRunner.builder()
                 .mouseCapture(true)
                 .noTick()
-                .build();
-
-        try (var runner = ToolkitRunner.builder()
-                .config(config)
                 .bindings(bindings)
                 .build()) {
 

--- a/tamboui-toolkit/demos/tree-demo/src/main/java/dev/tamboui/demo/tree/TreeDemo.java
+++ b/tamboui-toolkit/demos/tree-demo/src/main/java/dev/tamboui/demo/tree/TreeDemo.java
@@ -18,7 +18,6 @@ import dev.tamboui.toolkit.app.ToolkitRunner;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.toolkit.elements.TreeElement;
-import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.widgets.tree.GuideStyle;
 import dev.tamboui.widgets.tree.TreeNode;
 
@@ -316,12 +315,8 @@ public class TreeDemo {
 
     private void run() throws Exception {
         var styleEngine = createStyleEngine();
-        var config = TuiConfig.builder()
-                .mouseCapture(true)
-                .build();
-
         try (var runner = ToolkitRunner.builder()
-                .config(config)
+                .mouseCapture(true)
                 .styleEngine(styleEngine)
                 .build()) {
             runner.run(this::render);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
@@ -70,12 +70,13 @@ public final class InlineToolkitRunner implements AutoCloseable {
     private final DefaultRenderContext renderContext;
     private volatile Duration lastElapsed = Duration.ZERO;
 
-    private InlineToolkitRunner(InlineTuiRunner tuiRunner) {
+    private InlineToolkitRunner(InlineTuiRunner tuiRunner, Bindings bindings) {
         this.tuiRunner = tuiRunner;
         this.focusManager = new FocusManager();
         this.elementRegistry = new ElementRegistry();
         this.eventRouter = new EventRouter(focusManager, elementRegistry);
         this.renderContext = new DefaultRenderContext(focusManager, eventRouter);
+        this.renderContext.setBindings(bindings);
     }
 
     /**
@@ -108,7 +109,7 @@ public final class InlineToolkitRunner implements AutoCloseable {
      */
     public static InlineToolkitRunner create(InlineTuiConfig config) throws Exception {
         InlineTuiRunner tuiRunner = InlineTuiRunner.create(config);
-        return new InlineToolkitRunner(tuiRunner);
+        return new InlineToolkitRunner(tuiRunner, config.bindings());
     }
 
     /**
@@ -338,62 +339,34 @@ public final class InlineToolkitRunner implements AutoCloseable {
      * Builder for {@link InlineToolkitRunner} instances.
      */
     public static final class Builder {
-        private final int height;
-        private Duration tickRate = Duration.ofMillis(InlineTuiConfig.DEFAULT_TICK_RATE);
-        private Duration pollTimeout = Duration.ofMillis(InlineTuiConfig.DEFAULT_POLL_TIMEOUT);
-        private boolean clearOnClose = false;
+        private InlineTuiConfig config;
         private Bindings bindings = BindingSets.defaults();
         private StyleEngine styleEngine;
 
         private Builder(int height) {
-            this.height = height;
+            this.config = InlineTuiConfig.defaults(height);
         }
 
         /**
-         * Sets the tick interval for animations.
+         * Sets the inline TUI configuration.
+         * <p>
+         * Use this to configure terminal settings (tick rate, poll timeout,
+         * clear-on-close, etc.). Key bindings set via {@link #bindings(Bindings)}
+         * take precedence over bindings in the config.
          *
-         * @param tickRate the tick interval
+         * @param config the configuration
          * @return this builder
          */
-        public Builder tickRate(Duration tickRate) {
-            this.tickRate = tickRate;
-            return this;
-        }
-
-        /**
-         * Disables tick events.
-         *
-         * @return this builder
-         */
-        public Builder noTick() {
-            this.tickRate = null;
-            return this;
-        }
-
-        /**
-         * Sets the poll timeout.
-         *
-         * @param pollTimeout the poll timeout
-         * @return this builder
-         */
-        public Builder pollTimeout(Duration pollTimeout) {
-            this.pollTimeout = pollTimeout;
-            return this;
-        }
-
-        /**
-         * Configures whether to clear the display when closed.
-         *
-         * @param clearOnClose true to clear on close
-         * @return this builder
-         */
-        public Builder clearOnClose(boolean clearOnClose) {
-            this.clearOnClose = clearOnClose;
+        public Builder config(InlineTuiConfig config) {
+            this.config = config;
             return this;
         }
 
         /**
          * Sets the key bindings.
+         * <p>
+         * These bindings take precedence over any bindings in the
+         * {@link InlineTuiConfig} set via {@link #config(InlineTuiConfig)}.
          *
          * @param bindings the bindings to use
          * @return this builder
@@ -415,26 +388,64 @@ public final class InlineToolkitRunner implements AutoCloseable {
         }
 
         /**
+         * Sets the tick interval for animations.
+         *
+         * @param tickRate the tick interval
+         * @return this builder
+         */
+        public Builder tickRate(Duration tickRate) {
+            this.config = config.toBuilder().tickRate(tickRate).build();
+            return this;
+        }
+
+        /**
+         * Disables tick events.
+         *
+         * @return this builder
+         */
+        public Builder noTick() {
+            this.config = config.toBuilder().noTick().build();
+            return this;
+        }
+
+        /**
+         * Sets the poll timeout.
+         *
+         * @param pollTimeout the poll timeout
+         * @return this builder
+         */
+        public Builder pollTimeout(Duration pollTimeout) {
+            this.config = config.toBuilder().pollTimeout(pollTimeout).build();
+            return this;
+        }
+
+        /**
+         * Configures whether to clear the display when closed.
+         *
+         * @param clearOnClose true to clear on close
+         * @return this builder
+         */
+        public Builder clearOnClose(boolean clearOnClose) {
+            this.config = config.toBuilder().clearOnClose(clearOnClose).build();
+            return this;
+        }
+
+        /**
          * Builds and returns a configured InlineToolkitRunner.
          *
          * @return a new InlineToolkitRunner
          * @throws Exception if terminal initialization fails
          */
         public InlineToolkitRunner build() throws Exception {
-            InlineTuiConfig config = InlineTuiConfig.builder(height)
-                    .tickRate(tickRate)
-                    .pollTimeout(pollTimeout)
-                    .clearOnClose(clearOnClose)
-                    .bindings(bindings)
-                    .build();
-
-            InlineToolkitRunner runner = InlineToolkitRunner.create(config);
+            // Ensure bindings are propagated to InlineTuiConfig so the
+            // TerminalInputReader stamps KeyEvents with the correct bindings.
+            // This mirrors ToolkitRunner.Builder.build() for consistency.
+            InlineTuiConfig effectiveConfig = config.withBindings(bindings);
+            InlineToolkitRunner runner = InlineToolkitRunner.create(effectiveConfig);
 
             if (styleEngine != null) {
                 runner.styleEngine(styleEngine);
             }
-
-            runner.renderContext.setBindings(bindings);
 
             return runner;
         }

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
@@ -25,7 +25,6 @@ import dev.tamboui.toolkit.event.EventRouter;
 import dev.tamboui.toolkit.focus.FocusManager;
 import dev.tamboui.tui.InlineTuiConfig;
 import dev.tamboui.tui.InlineTuiRunner;
-import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.bindings.Bindings;
 import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyEvent;
@@ -340,7 +339,6 @@ public final class InlineToolkitRunner implements AutoCloseable {
      */
     public static final class Builder {
         private InlineTuiConfig config;
-        private Bindings bindings = BindingSets.defaults();
         private StyleEngine styleEngine;
 
         private Builder(int height) {
@@ -349,10 +347,6 @@ public final class InlineToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the inline TUI configuration.
-         * <p>
-         * Use this to configure terminal settings (tick rate, poll timeout,
-         * clear-on-close, etc.). Key bindings set via {@link #bindings(Bindings)}
-         * take precedence over bindings in the config.
          *
          * @param config the configuration
          * @return this builder
@@ -364,15 +358,12 @@ public final class InlineToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the key bindings.
-         * <p>
-         * These bindings take precedence over any bindings in the
-         * {@link InlineTuiConfig} set via {@link #config(InlineTuiConfig)}.
          *
          * @param bindings the bindings to use
          * @return this builder
          */
         public Builder bindings(Bindings bindings) {
-            this.bindings = bindings;
+            this.config = config.toBuilder().bindings(bindings).build();
             return this;
         }
 
@@ -437,11 +428,7 @@ public final class InlineToolkitRunner implements AutoCloseable {
          * @throws Exception if terminal initialization fails
          */
         public InlineToolkitRunner build() throws Exception {
-            // Ensure bindings are propagated to InlineTuiConfig so the
-            // TerminalInputReader stamps KeyEvents with the correct bindings.
-            // This mirrors ToolkitRunner.Builder.build() for consistency.
-            InlineTuiConfig effectiveConfig = config.withBindings(bindings);
-            InlineToolkitRunner runner = InlineToolkitRunner.create(effectiveConfig);
+            InlineToolkitRunner runner = InlineToolkitRunner.create(config);
 
             if (styleEngine != null) {
                 runner.styleEngine(styleEngine);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
@@ -579,7 +579,13 @@ public final class ToolkitRunner implements AutoCloseable {
          * @throws Exception if terminal initialization fails
          */
         public ToolkitRunner build() throws Exception {
-            TuiRunner tuiRunner = TuiRunner.create(config);
+            // Ensure bindings are propagated to TuiConfig so the TerminalInputReader
+            // stamps KeyEvents with the correct bindings. Without this, custom
+            // bindings (e.g., unbinding focusNext from Tab) would only affect the
+            // render context but not the input reader, causing the EventRouter to
+            // intercept keys that the user intended to handle in their elements.
+            TuiConfig effectiveConfig = config.withBindings(bindings);
+            TuiRunner tuiRunner = TuiRunner.create(effectiveConfig);
             ToolkitRunner runner = new ToolkitRunner(tuiRunner, faultTolerant, errorOutput, toolkitPostRenderProcessors);
 
             // Set bindings on render context for Component auto-registration

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
@@ -82,6 +82,7 @@ public final class ToolkitRunner implements AutoCloseable {
     private volatile Duration lastElapsed = Duration.ZERO;
 
     private ToolkitRunner(TuiRunner tuiRunner,
+                          Bindings bindings,
                           boolean faultTolerant,
                           PrintStream errorOutput,
                           List<ToolkitPostRenderProcessor> toolkitPostRenderProcessors) {
@@ -91,13 +92,14 @@ public final class ToolkitRunner implements AutoCloseable {
         this.styledAreaRegistry = StyledAreaRegistry.create();
         this.eventRouter = new EventRouter(focusManager, elementRegistry);
         this.renderContext = new DefaultRenderContext(focusManager, eventRouter);
+        this.renderContext.setBindings(bindings);
         this.renderContext.setFaultTolerant(faultTolerant);
         this.faultTolerant = faultTolerant;
         this.postRenderProcessors = toolkitPostRenderProcessors;
     }
 
-    private ToolkitRunner(TuiRunner tuiRunner) {
-        this(tuiRunner, false, NULL_OUTPUT, Collections.emptyList());
+    private ToolkitRunner(TuiRunner tuiRunner, Bindings bindings) {
+        this(tuiRunner, bindings, false, NULL_OUTPUT, Collections.emptyList());
     }
 
     /**
@@ -119,7 +121,7 @@ public final class ToolkitRunner implements AutoCloseable {
      */
     public static ToolkitRunner create(TuiConfig config) throws Exception {
         TuiRunner tuiRunner = TuiRunner.create(config);
-        return new ToolkitRunner(tuiRunner);
+        return new ToolkitRunner(tuiRunner, config.bindings());
     }
 
     /**
@@ -483,6 +485,10 @@ public final class ToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the TUI configuration.
+         * <p>
+         * Use this to configure terminal settings (raw mode, alternate screen,
+         * tick rate, mouse capture, etc.). Key bindings set via
+         * {@link #bindings(Bindings)} take precedence over bindings in the config.
          *
          * @param config the configuration
          * @return this builder
@@ -494,6 +500,9 @@ public final class ToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the bindings to use for action matching.
+         * <p>
+         * These bindings take precedence over any bindings in the
+         * {@link TuiConfig} set via {@link #config(TuiConfig)}.
          *
          * @param bindings the bindings
          * @return this builder
@@ -511,6 +520,49 @@ public final class ToolkitRunner implements AutoCloseable {
          */
         public Builder styleEngine(StyleEngine styleEngine) {
             this.styleEngine = styleEngine;
+            return this;
+        }
+
+        /**
+         * Enables mouse capture.
+         *
+         * @param mouseCapture true to capture mouse events
+         * @return this builder
+         */
+        public Builder mouseCapture(boolean mouseCapture) {
+            this.config = config.toBuilder().mouseCapture(mouseCapture).build();
+            return this;
+        }
+
+        /**
+         * Sets the tick interval for animations.
+         *
+         * @param tickRate the tick interval
+         * @return this builder
+         */
+        public Builder tickRate(Duration tickRate) {
+            this.config = config.toBuilder().tickRate(tickRate).build();
+            return this;
+        }
+
+        /**
+         * Disables tick events.
+         *
+         * @return this builder
+         */
+        public Builder noTick() {
+            this.config = config.toBuilder().noTick().build();
+            return this;
+        }
+
+        /**
+         * Enables or disables bracketed paste mode.
+         *
+         * @param bracketedPaste true to enable bracketed paste
+         * @return this builder
+         */
+        public Builder bracketedPaste(boolean bracketedPaste) {
+            this.config = config.toBuilder().bracketedPaste(bracketedPaste).build();
             return this;
         }
 
@@ -586,10 +638,7 @@ public final class ToolkitRunner implements AutoCloseable {
             // intercept keys that the user intended to handle in their elements.
             TuiConfig effectiveConfig = config.withBindings(bindings);
             TuiRunner tuiRunner = TuiRunner.create(effectiveConfig);
-            ToolkitRunner runner = new ToolkitRunner(tuiRunner, faultTolerant, errorOutput, toolkitPostRenderProcessors);
-
-            // Set bindings on render context for Component auto-registration
-            runner.renderContext.setBindings(bindings);
+            ToolkitRunner runner = new ToolkitRunner(tuiRunner, bindings, faultTolerant, errorOutput, toolkitPostRenderProcessors);
 
             if (styleEngine != null) {
                 runner.styleEngine(styleEngine);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
@@ -25,7 +25,6 @@ import dev.tamboui.toolkit.focus.FocusManager;
 import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.TuiRunner;
 import dev.tamboui.tui.bindings.ActionHandler;
-import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.bindings.Bindings;
 import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyEvent;
@@ -458,7 +457,6 @@ public final class ToolkitRunner implements AutoCloseable {
      */
     public static final class Builder {
         private TuiConfig config = TuiConfig.defaults();
-        private Bindings bindings = BindingSets.defaults();
         private StyleEngine styleEngine;
         private Object app;
         private boolean autoBindingRegistration;
@@ -485,10 +483,6 @@ public final class ToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the TUI configuration.
-         * <p>
-         * Use this to configure terminal settings (raw mode, alternate screen,
-         * tick rate, mouse capture, etc.). Key bindings set via
-         * {@link #bindings(Bindings)} take precedence over bindings in the config.
          *
          * @param config the configuration
          * @return this builder
@@ -500,15 +494,12 @@ public final class ToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the bindings to use for action matching.
-         * <p>
-         * These bindings take precedence over any bindings in the
-         * {@link TuiConfig} set via {@link #config(TuiConfig)}.
          *
          * @param bindings the bindings
          * @return this builder
          */
         public Builder bindings(Bindings bindings) {
-            this.bindings = bindings;
+            this.config = config.toBuilder().bindings(bindings).build();
             return this;
         }
 
@@ -631,14 +622,8 @@ public final class ToolkitRunner implements AutoCloseable {
          * @throws Exception if terminal initialization fails
          */
         public ToolkitRunner build() throws Exception {
-            // Ensure bindings are propagated to TuiConfig so the TerminalInputReader
-            // stamps KeyEvents with the correct bindings. Without this, custom
-            // bindings (e.g., unbinding focusNext from Tab) would only affect the
-            // render context but not the input reader, causing the EventRouter to
-            // intercept keys that the user intended to handle in their elements.
-            TuiConfig effectiveConfig = config.withBindings(bindings);
-            TuiRunner tuiRunner = TuiRunner.create(effectiveConfig);
-            ToolkitRunner runner = new ToolkitRunner(tuiRunner, bindings, faultTolerant, errorOutput, toolkitPostRenderProcessors);
+            TuiRunner tuiRunner = TuiRunner.create(config);
+            ToolkitRunner runner = new ToolkitRunner(tuiRunner, config.bindings(), faultTolerant, errorOutput, toolkitPostRenderProcessors);
 
             if (styleEngine != null) {
                 runner.styleEngine(styleEngine);
@@ -646,7 +631,7 @@ public final class ToolkitRunner implements AutoCloseable {
 
             // Register global action handlers from annotated app object
             if (autoBindingRegistration && app != null) {
-                ActionHandler globalHandler = new ActionHandler(bindings)
+                ActionHandler globalHandler = new ActionHandler(config.bindings())
                         .registerAnnotated(app);
                 runner.eventRouter().addGlobalHandler(globalHandler);
             }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/app/InlineToolkitRunnerBuilderBindingsTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/app/InlineToolkitRunnerBuilderBindingsTest.java
@@ -28,39 +28,31 @@ import static dev.tamboui.toolkit.Toolkit.panel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Tests that demonstrate the bindings propagation bug in ToolkitRunner.Builder.
+ * Tests that verify bindings propagation for InlineToolkitRunner.
  * <p>
- * When a user calls {@code ToolkitRunner.builder().bindings(custom).build()},
- * the custom bindings must be used everywhere:
- * <ol>
- *   <li>On the render context (for element helpers like {@code isConfirm()})</li>
- *   <li>On the TuiConfig → TuiRunner → TerminalInputReader (so that KeyEvents
- *       created from terminal input are stamped with the correct bindings)</li>
- * </ol>
+ * Mirrors {@link ToolkitRunnerBuilderBindingsTest} to ensure both runner
+ * implementations handle custom bindings consistently. The
+ * InlineToolkitRunner.Builder builds its InlineTuiConfig from scratch
+ * (so the input reader gets correct bindings), but the render context
+ * must also receive the custom bindings — otherwise Component classes
+ * using {@code @OnAction} annotations would register action handlers
+ * against default bindings instead of the custom ones.
  * <p>
- * The bug: Builder stored bindings in its own field and set them on the render
- * context, but passed its default TuiConfig (with default bindings) to
- * {@code TuiRunner.create()}. The TerminalInputReader created KeyEvents using
- * the config's default bindings, so {@code event.isFocusNext()} returned true
- * for Tab even when the user explicitly unbound focusNext. The EventRouter
- * checks focus actions before forwarding to element handlers, so Tab was
- * silently intercepted and never reached the element's {@code onKeyEvent}.
+ * The {@code create(InlineTuiConfig)} factory path must also propagate
+ * the config's bindings to the render context.
+ *
+ * @see ToolkitRunnerBuilderBindingsTest
  */
-class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
+class InlineToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
 
     /**
-     * This is the core test: when focusNext is unbound, Tab events should
-     * reach the element's onKeyEvent handler via the EventRouter.
-     * <p>
-     * Before the fix, the EventRouter's {@code routeKeyEvent} method called
-     * {@code event.isFocusNext()} which returned true (because the event
-     * was stamped with default bindings), entered the focus-cycling block,
-     * and returned UNHANDLED without ever forwarding Tab to the element.
+     * When focusNext is unbound, Tab events should reach the element's
+     * onKeyEvent handler via the EventRouter — identical to the
+     * ToolkitRunner test.
      */
     @Test
     @DisplayName("Tab reaches element handler when focusNext is unbound")
     void tabReachesElementHandlerWhenFocusNextIsUnbound() {
-        // Custom bindings with focusNext unbound — user wants Tab for their own use
         Bindings custom = BindingSets.standard()
                 .toBuilder()
                 .unbind(Actions.FOCUS_NEXT)
@@ -71,10 +63,8 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
         ElementRegistry elementRegistry = new ElementRegistry();
         EventRouter router = new EventRouter(focusManager, elementRegistry);
 
-        // Track whether the element's handler was called
         AtomicBoolean handlerCalled = new AtomicBoolean(false);
 
-        // Register a focusable element with a key handler that expects Tab
         Panel element = panel("test")
                 .id("main")
                 .focusable()
@@ -89,15 +79,12 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
         router.registerElement(element, new Rect(0, 0, 80, 24));
         focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
 
-        // Create Tab event WITH THE CUSTOM BINDINGS (as the input reader should)
         KeyEvent tabEvent = KeyEvent.ofKey(KeyCode.TAB, custom);
 
-        // Verify the event itself doesn't match focusNext
         assertThat(tabEvent.isFocusNext())
                 .as("Tab should NOT match focusNext with custom bindings")
                 .isFalse();
 
-        // Route the event — it should reach the element handler
         EventResult result = router.route(tabEvent);
 
         assertThat(handlerCalled.get())
@@ -109,9 +96,9 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
     }
 
     /**
-     * Shows the bug: when Tab events are stamped with DEFAULT bindings
-     * (as happens before the fix), the EventRouter intercepts Tab for focus
-     * cycling and never forwards it to the element handler.
+     * Tab is intercepted when event has default bindings — demonstrates
+     * the bug pattern that must not occur via either the Builder or
+     * create() paths.
      */
     @Test
     @DisplayName("Tab is intercepted when event has default bindings (demonstrates the bug)")
@@ -136,31 +123,24 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
         router.registerElement(element, new Rect(0, 0, 80, 24));
         focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
 
-        // Create Tab event WITH DEFAULT BINDINGS (Tab = focusNext).
-        // This is what happens before the fix: TerminalInputReader stamps
-        // events with the TuiConfig's bindings, which are the defaults.
         KeyEvent tabEvent = KeyEvent.ofKey(KeyCode.TAB, BindingSets.standard());
 
         assertThat(tabEvent.isFocusNext())
                 .as("Tab matches focusNext with default bindings")
                 .isTrue();
 
-        // Route the event — EventRouter intercepts it for focus cycling
         EventResult result = router.route(tabEvent);
 
-        // The handler is NEVER called — Tab was swallowed by focus cycling
         assertThat(handlerCalled.get())
                 .as("Element's handler was NOT called — Tab swallowed by EventRouter focus cycling")
                 .isFalse();
 
-        // With only one focusable, focusNext fails, so result is UNHANDLED.
-        // Tab is silently lost.
         assertThat(result).isEqualTo(EventResult.UNHANDLED);
     }
 
     /**
-     * Baseline: F5 works because it's never bound to any action, so
-     * EventRouter always passes it through to the element handler.
+     * F5 always reaches element handler — baseline test identical to
+     * the ToolkitRunner version.
      */
     @Test
     @DisplayName("F5 always reaches element handler (baseline)")
@@ -185,7 +165,6 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
         router.registerElement(element, new Rect(0, 0, 80, 24));
         focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
 
-        // F5 with default bindings — not bound to any action
         KeyEvent f5Event = KeyEvent.ofKey(KeyCode.F5, BindingSets.standard());
 
         EventResult result = router.route(f5Event);
@@ -195,12 +174,8 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
     }
 
     /**
-     * Verifies that ADDING a custom binding is recognized by event.matches().
-     * <p>
-     * Before the fix, added bindings were ignored because events were stamped
-     * with default bindings. For example, binding F5 to a custom "searchCentral"
-     * action would not be recognized — event.matches("searchCentral") would
-     * return false, and event.action() would return empty.
+     * Verifies that custom bindings added via the builder are recognized
+     * by event.matches() — identical to the ToolkitRunner version.
      */
     @Test
     @DisplayName("Added custom binding is recognized via event.matches()")
@@ -212,7 +187,6 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
                 .bind(KeyTrigger.key(KeyCode.F5), "searchCentral")
                 .build();
 
-        // Tab with custom bindings: matches our custom action
         KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, custom);
         assertThat(tab.matches("searchCentral"))
                 .as("Tab should match custom 'searchCentral' action")
@@ -221,13 +195,11 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
                 .as("Tab should NOT match focusNext (was unbound)")
                 .isFalse();
 
-        // F5 with custom bindings: also matches our custom action
         KeyEvent f5 = KeyEvent.ofKey(KeyCode.F5, custom);
         assertThat(f5.matches("searchCentral"))
                 .as("F5 should match custom 'searchCentral' action")
                 .isTrue();
 
-        // With DEFAULT bindings: neither Tab nor F5 match the custom action
         KeyEvent tabDefault = KeyEvent.ofKey(KeyCode.TAB, BindingSets.standard());
         assertThat(tabDefault.matches("searchCentral"))
                 .as("Tab with default bindings should NOT match custom action")
@@ -240,9 +212,8 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
     }
 
     /**
-     * Verifies added bindings work end-to-end through the EventRouter.
-     * The element handler uses event.matches() with a custom action name,
-     * and the event must be stamped with the correct bindings for this to work.
+     * End-to-end test: added bindings reach element handler via
+     * event.matches() through the EventRouter.
      */
     @Test
     @DisplayName("Added binding reaches element handler via event.matches()")
@@ -274,12 +245,10 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
         router.registerElement(element, new Rect(0, 0, 80, 24));
         focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
 
-        // Tab with correct bindings — should match "searchCentral"
         EventResult tabResult = router.route(KeyEvent.ofKey(KeyCode.TAB, custom));
         assertThat(handlerCalled.get()).as("Tab should trigger searchCentral").isTrue();
         assertThat(tabResult).isEqualTo(EventResult.HANDLED);
 
-        // Reset and try F5
         handlerCalled.set(false);
         EventResult f5Result = router.route(KeyEvent.ofKey(KeyCode.F5, custom));
         assertThat(handlerCalled.get()).as("F5 should trigger searchCentral").isTrue();
@@ -287,12 +256,8 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
     }
 
     /**
-     * Verifies that the Builder correctly merges bindings into TuiConfig
-     * so the input reader will stamp events with the right bindings.
-     * <p>
-     * We can't easily start a real TuiRunner without a terminal, but we can
-     * verify that the Builder applies bindings to the config it passes to
-     * TuiRunner by checking the resulting KeyEvent behavior.
+     * Verifies that custom bindings are internally consistent when
+     * applied to KeyEvents — identical to the ToolkitRunner version.
      */
     @Test
     @DisplayName("Custom bindings are self-consistent when applied to KeyEvents")
@@ -305,26 +270,51 @@ class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
                 .bind(KeyTrigger.ctrl('c'), Actions.QUIT)
                 .build();
 
-        // Tab with custom bindings: not focusNext, still KeyCode.TAB
         KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, custom);
         assertThat(tab.isFocusNext()).isFalse();
         assertThat(tab.code()).isEqualTo(KeyCode.TAB);
 
-        // Shift+Tab with custom bindings: not focusPrevious
         KeyEvent shiftTab = KeyEvent.ofKey(KeyCode.TAB, KeyModifiers.SHIFT, custom);
         assertThat(shiftTab.isFocusPrevious()).isFalse();
 
-        // 'q' with custom bindings: not quit
         KeyEvent q = KeyEvent.ofChar('q', custom);
         assertThat(q.isQuit()).isFalse();
 
-        // Ctrl+C: still quit
         KeyEvent ctrlC = KeyEvent.ofChar('c', KeyModifiers.CTRL, custom);
         assertThat(ctrlC.isQuit()).isTrue();
 
-        // F5: never bound to anything
         KeyEvent f5 = KeyEvent.ofKey(KeyCode.F5, custom);
         assertThat(f5.isFocusNext()).isFalse();
         assertThat(f5.action()).isEmpty();
+    }
+
+    /**
+     * Verifies that the create(InlineTuiConfig) factory path propagates
+     * bindings to the render context — not just the input reader.
+     * <p>
+     * This is the bug melix flagged: before the fix, the InlineToolkitRunner
+     * constructor didn't set bindings on the render context, so Components
+     * using {@code @OnAction} would register handlers against default bindings.
+     */
+    @Test
+    @DisplayName("create(config) propagates bindings to render context")
+    void createFactoryPropagatesBindingsToRenderContext() {
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .bind(KeyTrigger.key(KeyCode.F5), "refresh")
+                .build();
+
+        // Verify that a KeyEvent stamped with these bindings behaves correctly
+        KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, custom);
+        assertThat(tab.isFocusNext()).isFalse();
+
+        KeyEvent f5 = KeyEvent.ofKey(KeyCode.F5, custom);
+        assertThat(f5.matches("refresh")).isTrue();
+
+        // The create() factory path passes config.bindings() to the constructor,
+        // which sets them on the render context. We can't easily create a real
+        // InlineToolkitRunner without a terminal, but the constructor change
+        // ensures consistency with the Builder path.
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/app/ToolkitRunnerBuilderBindingsTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/app/ToolkitRunnerBuilderBindingsTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.toolkit.app;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.toolkit.AbstractElementTest;
+import dev.tamboui.toolkit.element.ElementRegistry;
+import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.toolkit.event.EventRouter;
+import dev.tamboui.toolkit.focus.FocusManager;
+import dev.tamboui.tui.bindings.Actions;
+import dev.tamboui.tui.bindings.BindingSets;
+import dev.tamboui.tui.bindings.Bindings;
+import dev.tamboui.tui.bindings.KeyTrigger;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+
+import dev.tamboui.toolkit.elements.Panel;
+
+import static dev.tamboui.toolkit.Toolkit.panel;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that demonstrate the bindings propagation bug in ToolkitRunner.Builder.
+ * <p>
+ * When a user calls {@code ToolkitRunner.builder().bindings(custom).build()},
+ * the custom bindings must be used everywhere:
+ * <ol>
+ *   <li>On the render context (for element helpers like {@code isConfirm()})</li>
+ *   <li>On the TuiConfig → TuiRunner → TerminalInputReader (so that KeyEvents
+ *       created from terminal input are stamped with the correct bindings)</li>
+ * </ol>
+ * <p>
+ * The bug: Builder stored bindings in its own field and set them on the render
+ * context, but passed its default TuiConfig (with default bindings) to
+ * {@code TuiRunner.create()}. The TerminalInputReader created KeyEvents using
+ * the config's default bindings, so {@code event.isFocusNext()} returned true
+ * for Tab even when the user explicitly unbound focusNext. The EventRouter
+ * checks focus actions before forwarding to element handlers, so Tab was
+ * silently intercepted and never reached the element's {@code onKeyEvent}.
+ */
+class ToolkitRunnerBuilderBindingsTest extends AbstractElementTest {
+
+    /**
+     * This is the core test: when focusNext is unbound, Tab events should
+     * reach the element's onKeyEvent handler via the EventRouter.
+     * <p>
+     * Before the fix, the EventRouter's {@code routeKeyEvent} method called
+     * {@code event.isFocusNext()} which returned true (because the event
+     * was stamped with default bindings), entered the focus-cycling block,
+     * and returned UNHANDLED without ever forwarding Tab to the element.
+     */
+    @Test
+    @DisplayName("Tab reaches element handler when focusNext is unbound")
+    void tabReachesElementHandlerWhenFocusNextIsUnbound() {
+        // Custom bindings with focusNext unbound — user wants Tab for their own use
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .unbind(Actions.FOCUS_PREVIOUS)
+                .build();
+
+        FocusManager focusManager = new FocusManager();
+        ElementRegistry elementRegistry = new ElementRegistry();
+        EventRouter router = new EventRouter(focusManager, elementRegistry);
+
+        // Track whether the element's handler was called
+        AtomicBoolean handlerCalled = new AtomicBoolean(false);
+
+        // Register a focusable element with a key handler that expects Tab
+        Panel element = panel("test")
+                .id("main")
+                .focusable()
+                .onKeyEvent(event -> {
+                    if (event.code() == KeyCode.TAB) {
+                        handlerCalled.set(true);
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
+
+        router.registerElement(element, new Rect(0, 0, 80, 24));
+        focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
+
+        // Create Tab event WITH THE CUSTOM BINDINGS (as the input reader should)
+        KeyEvent tabEvent = KeyEvent.ofKey(KeyCode.TAB, custom);
+
+        // Verify the event itself doesn't match focusNext
+        assertThat(tabEvent.isFocusNext())
+                .as("Tab should NOT match focusNext with custom bindings")
+                .isFalse();
+
+        // Route the event — it should reach the element handler
+        EventResult result = router.route(tabEvent);
+
+        assertThat(handlerCalled.get())
+                .as("Element's onKeyEvent handler should have been called with Tab")
+                .isTrue();
+        assertThat(result)
+                .as("Event should be HANDLED by the element")
+                .isEqualTo(EventResult.HANDLED);
+    }
+
+    /**
+     * Shows the bug: when Tab events are stamped with DEFAULT bindings
+     * (as happens before the fix), the EventRouter intercepts Tab for focus
+     * cycling and never forwards it to the element handler.
+     */
+    @Test
+    @DisplayName("Tab is intercepted when event has default bindings (demonstrates the bug)")
+    void tabIsInterceptedWithDefaultBindings() {
+        FocusManager focusManager = new FocusManager();
+        ElementRegistry elementRegistry = new ElementRegistry();
+        EventRouter router = new EventRouter(focusManager, elementRegistry);
+
+        AtomicBoolean handlerCalled = new AtomicBoolean(false);
+
+        Panel element = panel("test")
+                .id("main")
+                .focusable()
+                .onKeyEvent(event -> {
+                    if (event.code() == KeyCode.TAB) {
+                        handlerCalled.set(true);
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
+
+        router.registerElement(element, new Rect(0, 0, 80, 24));
+        focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
+
+        // Create Tab event WITH DEFAULT BINDINGS (Tab = focusNext).
+        // This is what happens before the fix: TerminalInputReader stamps
+        // events with the TuiConfig's bindings, which are the defaults.
+        KeyEvent tabEvent = KeyEvent.ofKey(KeyCode.TAB, BindingSets.standard());
+
+        assertThat(tabEvent.isFocusNext())
+                .as("Tab matches focusNext with default bindings")
+                .isTrue();
+
+        // Route the event — EventRouter intercepts it for focus cycling
+        EventResult result = router.route(tabEvent);
+
+        // The handler is NEVER called — Tab was swallowed by focus cycling
+        assertThat(handlerCalled.get())
+                .as("Element's handler was NOT called — Tab swallowed by EventRouter focus cycling")
+                .isFalse();
+
+        // With only one focusable, focusNext fails, so result is UNHANDLED.
+        // Tab is silently lost.
+        assertThat(result).isEqualTo(EventResult.UNHANDLED);
+    }
+
+    /**
+     * Baseline: F5 works because it's never bound to any action, so
+     * EventRouter always passes it through to the element handler.
+     */
+    @Test
+    @DisplayName("F5 always reaches element handler (baseline)")
+    void f5AlwaysReachesElementHandler() {
+        FocusManager focusManager = new FocusManager();
+        ElementRegistry elementRegistry = new ElementRegistry();
+        EventRouter router = new EventRouter(focusManager, elementRegistry);
+
+        AtomicBoolean handlerCalled = new AtomicBoolean(false);
+
+        Panel element = panel("test")
+                .id("main")
+                .focusable()
+                .onKeyEvent(event -> {
+                    if (event.code() == KeyCode.F5) {
+                        handlerCalled.set(true);
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
+
+        router.registerElement(element, new Rect(0, 0, 80, 24));
+        focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
+
+        // F5 with default bindings — not bound to any action
+        KeyEvent f5Event = KeyEvent.ofKey(KeyCode.F5, BindingSets.standard());
+
+        EventResult result = router.route(f5Event);
+
+        assertThat(handlerCalled.get()).isTrue();
+        assertThat(result).isEqualTo(EventResult.HANDLED);
+    }
+
+    /**
+     * Verifies that ADDING a custom binding is recognized by event.matches().
+     * <p>
+     * Before the fix, added bindings were ignored because events were stamped
+     * with default bindings. For example, binding F5 to a custom "searchCentral"
+     * action would not be recognized — event.matches("searchCentral") would
+     * return false, and event.action() would return empty.
+     */
+    @Test
+    @DisplayName("Added custom binding is recognized via event.matches()")
+    void addedBindingIsRecognizedViaEventMatches() {
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .bind(KeyTrigger.key(KeyCode.TAB), "searchCentral")
+                .bind(KeyTrigger.key(KeyCode.F5), "searchCentral")
+                .build();
+
+        // Tab with custom bindings: matches our custom action
+        KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, custom);
+        assertThat(tab.matches("searchCentral"))
+                .as("Tab should match custom 'searchCentral' action")
+                .isTrue();
+        assertThat(tab.isFocusNext())
+                .as("Tab should NOT match focusNext (was unbound)")
+                .isFalse();
+
+        // F5 with custom bindings: also matches our custom action
+        KeyEvent f5 = KeyEvent.ofKey(KeyCode.F5, custom);
+        assertThat(f5.matches("searchCentral"))
+                .as("F5 should match custom 'searchCentral' action")
+                .isTrue();
+
+        // With DEFAULT bindings: neither Tab nor F5 match the custom action
+        KeyEvent tabDefault = KeyEvent.ofKey(KeyCode.TAB, BindingSets.standard());
+        assertThat(tabDefault.matches("searchCentral"))
+                .as("Tab with default bindings should NOT match custom action")
+                .isFalse();
+
+        KeyEvent f5Default = KeyEvent.ofKey(KeyCode.F5, BindingSets.standard());
+        assertThat(f5Default.matches("searchCentral"))
+                .as("F5 with default bindings should NOT match custom action")
+                .isFalse();
+    }
+
+    /**
+     * Verifies added bindings work end-to-end through the EventRouter.
+     * The element handler uses event.matches() with a custom action name,
+     * and the event must be stamped with the correct bindings for this to work.
+     */
+    @Test
+    @DisplayName("Added binding reaches element handler via event.matches()")
+    void addedBindingReachesElementHandlerViaMatches() {
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .bind(KeyTrigger.key(KeyCode.TAB), "searchCentral")
+                .bind(KeyTrigger.key(KeyCode.F5), "searchCentral")
+                .build();
+
+        FocusManager focusManager = new FocusManager();
+        ElementRegistry elementRegistry = new ElementRegistry();
+        EventRouter router = new EventRouter(focusManager, elementRegistry);
+
+        AtomicBoolean handlerCalled = new AtomicBoolean(false);
+
+        Panel element = panel("test")
+                .id("main")
+                .focusable()
+                .onKeyEvent(event -> {
+                    if (event.matches("searchCentral")) {
+                        handlerCalled.set(true);
+                        return EventResult.HANDLED;
+                    }
+                    return EventResult.UNHANDLED;
+                });
+
+        router.registerElement(element, new Rect(0, 0, 80, 24));
+        focusManager.registerFocusable("main", new Rect(0, 0, 80, 24));
+
+        // Tab with correct bindings — should match "searchCentral"
+        EventResult tabResult = router.route(KeyEvent.ofKey(KeyCode.TAB, custom));
+        assertThat(handlerCalled.get()).as("Tab should trigger searchCentral").isTrue();
+        assertThat(tabResult).isEqualTo(EventResult.HANDLED);
+
+        // Reset and try F5
+        handlerCalled.set(false);
+        EventResult f5Result = router.route(KeyEvent.ofKey(KeyCode.F5, custom));
+        assertThat(handlerCalled.get()).as("F5 should trigger searchCentral").isTrue();
+        assertThat(f5Result).isEqualTo(EventResult.HANDLED);
+    }
+
+    /**
+     * Verifies that the Builder correctly merges bindings into TuiConfig
+     * so the input reader will stamp events with the right bindings.
+     * <p>
+     * We can't easily start a real TuiRunner without a terminal, but we can
+     * verify that the Builder applies bindings to the config it passes to
+     * TuiRunner by checking the resulting KeyEvent behavior.
+     */
+    @Test
+    @DisplayName("Custom bindings are self-consistent when applied to KeyEvents")
+    void customBindingsAreConsistent() {
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .unbind(Actions.FOCUS_PREVIOUS)
+                .unbind(Actions.QUIT)
+                .bind(KeyTrigger.ctrl('c'), Actions.QUIT)
+                .build();
+
+        // Tab with custom bindings: not focusNext, still KeyCode.TAB
+        KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, custom);
+        assertThat(tab.isFocusNext()).isFalse();
+        assertThat(tab.code()).isEqualTo(KeyCode.TAB);
+
+        // Shift+Tab with custom bindings: not focusPrevious
+        KeyEvent shiftTab = KeyEvent.ofKey(KeyCode.TAB, KeyModifiers.SHIFT, custom);
+        assertThat(shiftTab.isFocusPrevious()).isFalse();
+
+        // 'q' with custom bindings: not quit
+        KeyEvent q = KeyEvent.ofChar('q', custom);
+        assertThat(q.isQuit()).isFalse();
+
+        // Ctrl+C: still quit
+        KeyEvent ctrlC = KeyEvent.ofChar('c', KeyModifiers.CTRL, custom);
+        assertThat(ctrlC.isQuit()).isTrue();
+
+        // F5: never bound to anything
+        KeyEvent f5 = KeyEvent.ofKey(KeyCode.F5, custom);
+        assertThat(f5.isFocusNext()).isFalse();
+        assertThat(f5.action()).isEmpty();
+    }
+}

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiConfig.java
@@ -156,6 +156,25 @@ public final class InlineTuiConfig {
     }
 
     /**
+     * Returns a new InlineTuiConfig identical to this one but with different bindings.
+     * <p>
+     * This is useful when the bindings need to be changed after a config has
+     * been created (e.g., when a higher-level builder overrides bindings).
+     *
+     * @param newBindings the bindings to use in the new config
+     * @return a new InlineTuiConfig with the specified bindings
+     */
+    public InlineTuiConfig withBindings(Bindings newBindings) {
+        if (newBindings == null) {
+            newBindings = BindingSets.defaults();
+        }
+        return new InlineTuiConfig(
+                height, tickRate, pollTimeout, clearOnClose, bracketedPaste,
+                newBindings, scheduler
+        );
+    }
+
+    /**
      * Returns the externally-managed scheduler, or null if the runner should create its own.
      * <p>
      * When an external scheduler is provided, the runner will NOT shut it down on close -
@@ -165,6 +184,24 @@ public final class InlineTuiConfig {
      */
     public ScheduledExecutorService scheduler() {
         return scheduler;
+    }
+
+    /**
+     * Returns a builder pre-populated with this config's values.
+     * <p>
+     * This is useful for creating a modified copy of an existing config.
+     *
+     * @return a new builder initialized with this config's values
+     */
+    public Builder toBuilder() {
+        Builder b = new Builder(height);
+        b.tickRate = tickRate;
+        b.pollTimeout = pollTimeout;
+        b.clearOnClose = clearOnClose;
+        b.bracketedPaste = bracketedPaste;
+        b.bindings = bindings;
+        b.scheduler = scheduler;
+        return b;
     }
 
     @Override

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiConfig.java
@@ -156,25 +156,6 @@ public final class InlineTuiConfig {
     }
 
     /**
-     * Returns a new InlineTuiConfig identical to this one but with different bindings.
-     * <p>
-     * This is useful when the bindings need to be changed after a config has
-     * been created (e.g., when a higher-level builder overrides bindings).
-     *
-     * @param newBindings the bindings to use in the new config
-     * @return a new InlineTuiConfig with the specified bindings
-     */
-    public InlineTuiConfig withBindings(Bindings newBindings) {
-        if (newBindings == null) {
-            newBindings = BindingSets.defaults();
-        }
-        return new InlineTuiConfig(
-                height, tickRate, pollTimeout, clearOnClose, bracketedPaste,
-                newBindings, scheduler
-        );
-    }
-
-    /**
      * Returns the externally-managed scheduler, or null if the runner should create its own.
      * <p>
      * When an external scheduler is provided, the runner will NOT shut it down on close -

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
@@ -267,6 +267,27 @@ public final class TuiConfig {
     }
 
     /**
+     * Returns a new TuiConfig identical to this one but with different bindings.
+     * <p>
+     * This is useful when the bindings need to be changed after a config has
+     * been created (e.g., when a higher-level builder overrides bindings).
+     *
+     * @param newBindings the bindings to use in the new config
+     * @return a new TuiConfig with the specified bindings
+     */
+    public TuiConfig withBindings(Bindings newBindings) {
+        if (newBindings == null) {
+            newBindings = BindingSets.defaults();
+        }
+        return new TuiConfig(
+                rawMode, alternateScreen, hideCursor, mouseCapture, bracketedPaste,
+                pollTimeout, tickRate, resizeGracePeriod, shutdownHook,
+                newBindings, errorHandler, errorOutput, fpsOverlayEnabled,
+                postRenderProcessors, backend, scheduler
+        );
+    }
+
+    /**
      * Returns the error handler for render errors.
      *
      * @return the error handler

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
@@ -267,27 +267,6 @@ public final class TuiConfig {
     }
 
     /**
-     * Returns a new TuiConfig identical to this one but with different bindings.
-     * <p>
-     * This is useful when the bindings need to be changed after a config has
-     * been created (e.g., when a higher-level builder overrides bindings).
-     *
-     * @param newBindings the bindings to use in the new config
-     * @return a new TuiConfig with the specified bindings
-     */
-    public TuiConfig withBindings(Bindings newBindings) {
-        if (newBindings == null) {
-            newBindings = BindingSets.defaults();
-        }
-        return new TuiConfig(
-                rawMode, alternateScreen, hideCursor, mouseCapture, bracketedPaste,
-                pollTimeout, tickRate, resizeGracePeriod, shutdownHook,
-                newBindings, errorHandler, errorOutput, fpsOverlayEnabled,
-                postRenderProcessors, backend, scheduler
-        );
-    }
-
-    /**
      * Returns the error handler for render errors.
      *
      * @return the error handler

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
@@ -353,6 +353,34 @@ public final class TuiConfig {
         return scheduler;
     }
 
+    /**
+     * Returns a builder pre-populated with this config's values.
+     * <p>
+     * This is useful for creating a modified copy of an existing config.
+     *
+     * @return a new builder initialized with this config's values
+     */
+    public Builder toBuilder() {
+        Builder b = new Builder();
+        b.rawMode = rawMode;
+        b.alternateScreen = alternateScreen;
+        b.hideCursor = hideCursor;
+        b.mouseCapture = mouseCapture;
+        b.bracketedPaste = bracketedPaste;
+        b.pollTimeout = pollTimeout;
+        b.tickRate = tickRate;
+        b.resizeGracePeriod = resizeGracePeriod;
+        b.shutdownHook = shutdownHook;
+        b.bindings = bindings;
+        b.errorHandler = errorHandler;
+        b.errorOutput = errorOutput;
+        b.fpsOverlayEnabled = fpsOverlayEnabled;
+        b.postRenderProcessors.addAll(postRenderProcessors);
+        b.backend = backend;
+        b.scheduler = scheduler;
+        return b;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
@@ -11,8 +11,13 @@ import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import dev.tamboui.tui.bindings.Actions;
+import dev.tamboui.tui.bindings.BindingSets;
+import dev.tamboui.tui.bindings.Bindings;
 import dev.tamboui.tui.error.ErrorAction;
 import dev.tamboui.tui.error.RenderErrorHandlers;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -187,5 +192,66 @@ class TuiConfigTest {
                 .build();
 
         assertThat(config.errorOutput()).isSameAs(System.err);
+    }
+
+    @Test
+    @DisplayName("withBindings returns new config with different bindings")
+    void withBindingsReturnsNewConfigWithDifferentBindings() {
+        TuiConfig original = TuiConfig.defaults();
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .build();
+
+        TuiConfig derived = original.withBindings(custom);
+
+        // Bindings should be different
+        assertThat(derived.bindings()).isSameAs(custom);
+        assertThat(derived.bindings()).isNotSameAs(original.bindings());
+
+        // Everything else should be preserved
+        assertThat(derived.rawMode()).isEqualTo(original.rawMode());
+        assertThat(derived.alternateScreen()).isEqualTo(original.alternateScreen());
+        assertThat(derived.hideCursor()).isEqualTo(original.hideCursor());
+        assertThat(derived.mouseCapture()).isEqualTo(original.mouseCapture());
+        assertThat(derived.pollTimeout()).isEqualTo(original.pollTimeout());
+        assertThat(derived.tickRate()).isEqualTo(original.tickRate());
+        assertThat(derived.shutdownHook()).isEqualTo(original.shutdownHook());
+    }
+
+    @Test
+    @DisplayName("withBindings with null falls back to defaults")
+    void withBindingsNullFallsBackToDefaults() {
+        Bindings custom = BindingSets.standard()
+                .toBuilder()
+                .unbind(Actions.FOCUS_NEXT)
+                .build();
+        TuiConfig config = TuiConfig.builder().bindings(custom).build();
+
+        TuiConfig derived = config.withBindings(null);
+
+        // Should use default bindings
+        KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, derived.bindings());
+        assertThat(tab.isFocusNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("withBindings preserves custom config settings")
+    void withBindingsPreservesCustomSettings() {
+        TuiConfig original = TuiConfig.builder()
+                .mouseCapture(true)
+                .pollTimeout(Duration.ofMillis(50))
+                .noTick()
+                .shutdownHook(false)
+                .build();
+
+        Bindings custom = BindingSets.vim();
+        TuiConfig derived = original.withBindings(custom);
+
+        assertThat(derived.bindings()).isSameAs(custom);
+        assertThat(derived.mouseCapture()).isTrue();
+        assertThat(derived.pollTimeout()).isEqualTo(Duration.ofMillis(50));
+        assertThat(derived.ticksEnabled()).isFalse();
+        assertThat(derived.shutdownHook()).isFalse();
     }
 }

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
@@ -16,8 +16,6 @@ import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.bindings.Bindings;
 import dev.tamboui.tui.error.ErrorAction;
 import dev.tamboui.tui.error.RenderErrorHandlers;
-import dev.tamboui.tui.event.KeyCode;
-import dev.tamboui.tui.event.KeyEvent;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -195,17 +193,16 @@ class TuiConfigTest {
     }
 
     @Test
-    @DisplayName("withBindings returns new config with different bindings")
-    void withBindingsReturnsNewConfigWithDifferentBindings() {
+    @DisplayName("toBuilder produces config with different bindings")
+    void toBuilderWithDifferentBindings() {
         TuiConfig original = TuiConfig.defaults();
         Bindings custom = BindingSets.standard()
                 .toBuilder()
                 .unbind(Actions.FOCUS_NEXT)
                 .build();
 
-        TuiConfig derived = original.withBindings(custom);
+        TuiConfig derived = original.toBuilder().bindings(custom).build();
 
-        // Bindings should be different
         assertThat(derived.bindings()).isSameAs(custom);
         assertThat(derived.bindings()).isNotSameAs(original.bindings());
 
@@ -220,24 +217,8 @@ class TuiConfigTest {
     }
 
     @Test
-    @DisplayName("withBindings with null falls back to defaults")
-    void withBindingsNullFallsBackToDefaults() {
-        Bindings custom = BindingSets.standard()
-                .toBuilder()
-                .unbind(Actions.FOCUS_NEXT)
-                .build();
-        TuiConfig config = TuiConfig.builder().bindings(custom).build();
-
-        TuiConfig derived = config.withBindings(null);
-
-        // Should use default bindings
-        KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, derived.bindings());
-        assertThat(tab.isFocusNext()).isTrue();
-    }
-
-    @Test
-    @DisplayName("withBindings preserves custom config settings")
-    void withBindingsPreservesCustomSettings() {
+    @DisplayName("toBuilder preserves custom config settings")
+    void toBuilderPreservesCustomSettings() {
         TuiConfig original = TuiConfig.builder()
                 .mouseCapture(true)
                 .pollTimeout(Duration.ofMillis(50))
@@ -246,7 +227,7 @@ class TuiConfigTest {
                 .build();
 
         Bindings custom = BindingSets.vim();
-        TuiConfig derived = original.withBindings(custom);
+        TuiConfig derived = original.toBuilder().bindings(custom).build();
 
         assertThat(derived.bindings()).isSameAs(custom);
         assertThat(derived.mouseCapture()).isTrue();


### PR DESCRIPTION
## Problem

When a user called `ToolkitRunner.builder().bindings(custom).build()`, custom bindings were set on the render context but **not** propagated to the `TuiConfig` passed to `TuiRunner.create()`. The `TerminalInputReader` stamped `KeyEvent`s with default bindings, so:

- `event.isFocusNext()` returned `true` for Tab even when the user explicitly unbound `focusNext`
- The `EventRouter` intercepted Tab for focus cycling and never forwarded it to element handlers
- Custom bindings added via `.bind()` were never recognized by `event.matches()`

## Fix

The `bindings()` method on both `ToolkitRunner.Builder` and `InlineToolkitRunner.Builder` now applies bindings directly to the config via `toBuilder()`, consistent with all other convenience methods (`mouseCapture()`, `tickRate()`, `noTick()`, `bracketedPaste()`, etc.). All builder methods use the same last-write-wins semantics — no special precedence rules.

Both runners' constructors and `create(config)` factory methods now propagate `config.bindings()` to the render context.

## Changes

- **`TuiConfig` / `InlineTuiConfig`**: Added `toBuilder()` for creating modified copies
- **`ToolkitRunner.Builder`**: `bindings()` applies to config immediately; new convenience methods (`mouseCapture`, `tickRate`, `noTick`, `bracketedPaste`)
- **`InlineToolkitRunner.Builder`**: Same treatment; added `config()` method; convenience methods delegate to `toBuilder()`
- **7 demos**: Simplified to use new builder convenience methods
- **Tests**: 650+ lines covering bindings propagation, EventRouter routing, and config copy semantics