### PR TITLE
refactor: simplify Builder bindings to use consistent last-write-wins semantics

### DIFF
--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/InlineToolkitRunner.java
@@ -339,7 +339,6 @@ public final class InlineToolkitRunner implements AutoCloseable {
      */
     public static final class Builder {
         private InlineTuiConfig config;
-        private Bindings bindings;
         private StyleEngine styleEngine;
 
         private Builder(int height) {
@@ -350,9 +349,8 @@ public final class InlineToolkitRunner implements AutoCloseable {
          * Sets the inline TUI configuration.
          * <p>
          * Use this to configure terminal settings (tick rate, poll timeout,
-         * clear-on-close, etc.). If {@link #bindings(Bindings)} is also
-         * called, those bindings take precedence over bindings in the
-         * config. Otherwise the config's bindings are used.
+         * clear-on-close, etc.). All builder methods (including
+         * {@link #bindings(Bindings)}) use last-write-wins semantics.
          *
          * @param config the configuration
          * @return this builder
@@ -364,16 +362,12 @@ public final class InlineToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the key bindings.
-         * <p>
-         * When set, these bindings take precedence over any bindings in the
-         * {@link InlineTuiConfig} set via {@link #config(InlineTuiConfig)}.
-         * When not called, the config's bindings are used as-is.
          *
          * @param bindings the bindings to use
          * @return this builder
          */
         public Builder bindings(Bindings bindings) {
-            this.bindings = bindings;
+            this.config = config.toBuilder().bindings(bindings).build();
             return this;
         }
 
@@ -438,14 +432,7 @@ public final class InlineToolkitRunner implements AutoCloseable {
          * @throws Exception if terminal initialization fails
          */
         public InlineToolkitRunner build() throws Exception {
-            // Ensure bindings are propagated to InlineTuiConfig so the
-            // TerminalInputReader stamps KeyEvents with the correct bindings.
-            // This mirrors ToolkitRunner.Builder.build() for consistency.
-            // If bindings were explicitly set, they take precedence over
-            // bindings in the config. Otherwise use the config's bindings.
-            InlineTuiConfig effectiveConfig = bindings != null
-                    ? config.withBindings(bindings) : config;
-            InlineToolkitRunner runner = InlineToolkitRunner.create(effectiveConfig);
+            InlineToolkitRunner runner = InlineToolkitRunner.create(config);
 
             if (styleEngine != null) {
                 runner.styleEngine(styleEngine);

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/app/ToolkitRunner.java
@@ -457,7 +457,6 @@ public final class ToolkitRunner implements AutoCloseable {
      */
     public static final class Builder {
         private TuiConfig config = TuiConfig.defaults();
-        private Bindings bindings;
         private StyleEngine styleEngine;
         private Object app;
         private boolean autoBindingRegistration;
@@ -486,9 +485,8 @@ public final class ToolkitRunner implements AutoCloseable {
          * Sets the TUI configuration.
          * <p>
          * Use this to configure terminal settings (raw mode, alternate screen,
-         * tick rate, mouse capture, etc.). If {@link #bindings(Bindings)} is
-         * also called, those bindings take precedence over bindings in the
-         * config. Otherwise the config's bindings are used.
+         * tick rate, mouse capture, etc.). All builder methods (including
+         * {@link #bindings(Bindings)}) use last-write-wins semantics.
          *
          * @param config the configuration
          * @return this builder
@@ -500,16 +498,12 @@ public final class ToolkitRunner implements AutoCloseable {
 
         /**
          * Sets the bindings to use for action matching.
-         * <p>
-         * When set, these bindings take precedence over any bindings in the
-         * {@link TuiConfig} set via {@link #config(TuiConfig)}. When not
-         * called, the config's bindings are used as-is.
          *
          * @param bindings the bindings
          * @return this builder
          */
         public Builder bindings(Bindings bindings) {
-            this.bindings = bindings;
+            this.config = config.toBuilder().bindings(bindings).build();
             return this;
         }
 
@@ -632,17 +626,8 @@ public final class ToolkitRunner implements AutoCloseable {
          * @throws Exception if terminal initialization fails
          */
         public ToolkitRunner build() throws Exception {
-            // Ensure bindings are propagated to TuiConfig so the TerminalInputReader
-            // stamps KeyEvents with the correct bindings. Without this, custom
-            // bindings (e.g., unbinding focusNext from Tab) would only affect the
-            // render context but not the input reader, causing the EventRouter to
-            // intercept keys that the user intended to handle in their elements.
-            // If bindings were explicitly set, they take precedence over
-            // bindings in the config. Otherwise use the config's bindings.
-            Bindings effectiveBindings = bindings != null ? bindings : config.bindings();
-            TuiConfig effectiveConfig = config.withBindings(effectiveBindings);
-            TuiRunner tuiRunner = TuiRunner.create(effectiveConfig);
-            ToolkitRunner runner = new ToolkitRunner(tuiRunner, effectiveBindings, faultTolerant, errorOutput, toolkitPostRenderProcessors);
+            TuiRunner tuiRunner = TuiRunner.create(config);
+            ToolkitRunner runner = new ToolkitRunner(tuiRunner, config.bindings(), faultTolerant, errorOutput, toolkitPostRenderProcessors);
 
             if (styleEngine != null) {
                 runner.styleEngine(styleEngine);
@@ -650,7 +635,7 @@ public final class ToolkitRunner implements AutoCloseable {
 
             // Register global action handlers from annotated app object
             if (autoBindingRegistration && app != null) {
-                ActionHandler globalHandler = new ActionHandler(effectiveBindings)
+                ActionHandler globalHandler = new ActionHandler(config.bindings())
                         .registerAnnotated(app);
                 runner.eventRouter().addGlobalHandler(globalHandler);
             }

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/InlineTuiConfig.java
@@ -156,25 +156,6 @@ public final class InlineTuiConfig {
     }
 
     /**
-     * Returns a new InlineTuiConfig identical to this one but with different bindings.
-     * <p>
-     * This is useful when the bindings need to be changed after a config has
-     * been created (e.g., when a higher-level builder overrides bindings).
-     *
-     * @param newBindings the bindings to use in the new config
-     * @return a new InlineTuiConfig with the specified bindings
-     */
-    public InlineTuiConfig withBindings(Bindings newBindings) {
-        if (newBindings == null) {
-            newBindings = BindingSets.defaults();
-        }
-        return new InlineTuiConfig(
-                height, tickRate, pollTimeout, clearOnClose, bracketedPaste,
-                newBindings, scheduler
-        );
-    }
-
-    /**
      * Returns the externally-managed scheduler, or null if the runner should create its own.
      * <p>
      * When an external scheduler is provided, the runner will NOT shut it down on close -

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/TuiConfig.java
@@ -267,27 +267,6 @@ public final class TuiConfig {
     }
 
     /**
-     * Returns a new TuiConfig identical to this one but with different bindings.
-     * <p>
-     * This is useful when the bindings need to be changed after a config has
-     * been created (e.g., when a higher-level builder overrides bindings).
-     *
-     * @param newBindings the bindings to use in the new config
-     * @return a new TuiConfig with the specified bindings
-     */
-    public TuiConfig withBindings(Bindings newBindings) {
-        if (newBindings == null) {
-            newBindings = BindingSets.defaults();
-        }
-        return new TuiConfig(
-                rawMode, alternateScreen, hideCursor, mouseCapture, bracketedPaste,
-                pollTimeout, tickRate, resizeGracePeriod, shutdownHook,
-                newBindings, errorHandler, errorOutput, fpsOverlayEnabled,
-                postRenderProcessors, backend, scheduler
-        );
-    }
-
-    /**
      * Returns the error handler for render errors.
      *
      * @return the error handler

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/TuiConfigTest.java
@@ -16,8 +16,6 @@ import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.bindings.Bindings;
 import dev.tamboui.tui.error.ErrorAction;
 import dev.tamboui.tui.error.RenderErrorHandlers;
-import dev.tamboui.tui.event.KeyCode;
-import dev.tamboui.tui.event.KeyEvent;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -195,15 +193,15 @@ class TuiConfigTest {
     }
 
     @Test
-    @DisplayName("withBindings returns new config with different bindings")
-    void withBindingsReturnsNewConfigWithDifferentBindings() {
+    @DisplayName("toBuilder creates copy with different bindings")
+    void toBuilderCreatesConfigWithDifferentBindings() {
         TuiConfig original = TuiConfig.defaults();
         Bindings custom = BindingSets.standard()
                 .toBuilder()
                 .unbind(Actions.FOCUS_NEXT)
                 .build();
 
-        TuiConfig derived = original.withBindings(custom);
+        TuiConfig derived = original.toBuilder().bindings(custom).build();
 
         // Bindings should be different
         assertThat(derived.bindings()).isSameAs(custom);
@@ -220,24 +218,8 @@ class TuiConfigTest {
     }
 
     @Test
-    @DisplayName("withBindings with null falls back to defaults")
-    void withBindingsNullFallsBackToDefaults() {
-        Bindings custom = BindingSets.standard()
-                .toBuilder()
-                .unbind(Actions.FOCUS_NEXT)
-                .build();
-        TuiConfig config = TuiConfig.builder().bindings(custom).build();
-
-        TuiConfig derived = config.withBindings(null);
-
-        // Should use default bindings
-        KeyEvent tab = KeyEvent.ofKey(KeyCode.TAB, derived.bindings());
-        assertThat(tab.isFocusNext()).isTrue();
-    }
-
-    @Test
-    @DisplayName("withBindings preserves custom config settings")
-    void withBindingsPreservesCustomSettings() {
+    @DisplayName("toBuilder preserves custom config settings")
+    void toBuilderPreservesCustomSettings() {
         TuiConfig original = TuiConfig.builder()
                 .mouseCapture(true)
                 .pollTimeout(Duration.ofMillis(50))
@@ -246,7 +228,7 @@ class TuiConfigTest {
                 .build();
 
         Bindings custom = BindingSets.vim();
-        TuiConfig derived = original.withBindings(custom);
+        TuiConfig derived = original.toBuilder().bindings(custom).build();
 
         assertThat(derived.bindings()).isSameAs(custom);
         assertThat(derived.mouseCapture()).isTrue();


### PR DESCRIPTION
Remove the separate `bindings` field from `ToolkitRunner.Builder` and `InlineToolkitRunner.Builder`. The `bindings()` method now applies immediately to the config via `toBuilder()`, consistent with all other convenience methods (`mouseCapture`, `tickRate`, `noTick`, etc.).

This eliminates the `withBindings()` methods on `TuiConfig` and `InlineTuiConfig` which only existed to support the late-merge pattern in `build()`. The `toBuilder()` method already provides the same capability.

Follow-up to #383. Supersedes #384 (which can be closed).