### PR TITLE
fix: render emoji presentation sequences (base + VS16) as 2-wide

### DIFF
--- a/demos/unicode-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java
+++ b/demos/unicode-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java
@@ -25,6 +25,9 @@ import dev.tamboui.text.Text;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.list.ListItem;
+import dev.tamboui.widgets.list.ListState;
+import dev.tamboui.widgets.list.ListWidget;
 import dev.tamboui.widgets.paragraph.Paragraph;
 
 /**
@@ -40,7 +43,24 @@ import dev.tamboui.widgets.paragraph.Paragraph;
  */
 public class UnicodeDemo {
 
+    // Items starting with an emoji presentation sequence (1-wide base + VS16):
+    // the terminal renders these 2-wide, so any width miscounting shows up as
+    // stale characters when the selection moves over them (j/k).
+    private static final List<String> VS16_ITEMS = List.of(
+            "\u23FA\uFE0F Record",
+            "\u23F9\uFE0F Stop",
+            "\u23EF\uFE0F Play/Pause",
+            "\u2328\uFE0F Keyboard",
+            "\u260E\uFE0F Phone",
+            "\u2702\uFE0F Scissors",
+            "\u2708\uFE0F Airplane",
+            "\u26A0\uFE0F Warning",
+            "\u2764\uFE0F Heart",
+            "\uD83D\uDD25 Fire (plain wide emoji)",
+            "A Plain ASCII item");
+
     private boolean running = true;
+    private final ListState listState = new ListState();
 
     private UnicodeDemo() {
 
@@ -72,12 +92,17 @@ public class UnicodeDemo {
                 terminal.draw(this::render);
             });
 
+            listState.selectFirst();
+
             while (running) {
                 terminal.draw(this::render);
 
                 int c = backend.read(100);
-                if (c == 'q' || c == 'Q' || c == 3) {
-                    running = false;
+                switch (c) {
+                    case 'q', 'Q', 3 -> running = false;
+                    case 'j', 'J' -> listState.selectNext(VS16_ITEMS.size());
+                    case 'k', 'K' -> listState.selectPrevious();
+                    default -> { }
                 }
             }
         }
@@ -86,6 +111,11 @@ public class UnicodeDemo {
     private void render(Frame frame) {
         Rect area = frame.area();
 
+        List<Rect> columns = Layout.horizontal().constraints(
+                Constraint.fill(),
+                Constraint.length(34)  // VS16 selection list
+        ).split(area);
+
         List<Rect> rows = Layout.vertical().constraints(
                 Constraint.length(7),  // Emoji
                 Constraint.length(6),  // CJK
@@ -93,13 +123,28 @@ public class UnicodeDemo {
                 Constraint.length(5),  // Mixed
                 Constraint.length(1),  // Footer
                 Constraint.fill()
-        ).split(area);
+        ).split(columns.get(0));
 
         renderEmojiSection(frame, rows.get(0));
         renderCjkSection(frame, rows.get(1));
         renderArabicSection(frame, rows.get(2));
         renderMixedSection(frame, rows.get(3));
         renderFooter(frame, rows.get(4));
+        renderVs16List(frame, columns.get(1));
+    }
+
+    private void renderVs16List(Frame frame, Rect area) {
+        ListWidget list = ListWidget.builder()
+                .items(VS16_ITEMS.stream().map(ListItem::from).toArray(ListItem[]::new))
+                .highlightStyle(Style.EMPTY.bg(Color.BLUE).fg(Color.WHITE).bold())
+                .highlightSymbol("\u25B6 ")
+                .block(Block.builder()
+                        .borders(Borders.ALL)
+                        .borderType(BorderType.ROUNDED)
+                        .title("VS16 emoji (j/k)")
+                        .build())
+                .build();
+        frame.renderStatefulWidget(list, area, listState);
     }
 
     private void renderEmojiSection(Frame frame, Rect area) {
@@ -177,6 +222,8 @@ public class UnicodeDemo {
     private void renderFooter(Frame frame, Rect area) {
         Paragraph footer = Paragraph.builder()
                 .text(Text.from(Line.from(
+                        Span.styled("j/k", Style.EMPTY.fg(Color.YELLOW).bold()),
+                        Span.styled(" Select  ", Style.EMPTY.fg(Color.DARK_GRAY)),
                         Span.styled("q", Style.EMPTY.fg(Color.YELLOW).bold()),
                         Span.styled(" Quit", Style.EMPTY.fg(Color.DARK_GRAY))
                 )))

--- a/demos/unicode-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java
+++ b/demos/unicode-demo/src/main/java/dev/tamboui/demo/UnicodeDemo.java
@@ -111,26 +111,32 @@ public class UnicodeDemo {
     private void render(Frame frame) {
         Rect area = frame.area();
 
+        // Main region height = sum of the section heights (7+6+6+5), so the
+        // VS16 list on the right is locked to the same height as the panes.
+        List<Rect> regions = Layout.vertical().constraints(
+                Constraint.length(24), // Sections + VS16 list
+                Constraint.length(1),  // Footer
+                Constraint.fill()
+        ).split(area);
+
         List<Rect> columns = Layout.horizontal().constraints(
                 Constraint.fill(),
                 Constraint.length(34)  // VS16 selection list
-        ).split(area);
+        ).split(regions.get(0));
 
         List<Rect> rows = Layout.vertical().constraints(
                 Constraint.length(7),  // Emoji
                 Constraint.length(6),  // CJK
                 Constraint.length(6),  // Arabic
-                Constraint.length(5),  // Mixed
-                Constraint.length(1),  // Footer
-                Constraint.fill()
+                Constraint.length(5)   // Mixed
         ).split(columns.get(0));
 
         renderEmojiSection(frame, rows.get(0));
         renderCjkSection(frame, rows.get(1));
         renderArabicSection(frame, rows.get(2));
         renderMixedSection(frame, rows.get(3));
-        renderFooter(frame, rows.get(4));
         renderVs16List(frame, columns.get(1));
+        renderFooter(frame, regions.get(1));
     }
 
     private void renderVs16List(Frame frame, Rect area) {

--- a/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
+++ b/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
@@ -202,6 +202,8 @@ public final class Buffer {
      *   <li>ZWJ sequences: characters after ZWJ are appended to the preceding cell</li>
      *   <li>Regional Indicator pairs: combined into a single 2-wide cell</li>
      *   <li>Skin tone modifiers: appended to preceding cell (zero-width)</li>
+     *   <li>Emoji presentation sequences: a 1-wide base glyph followed by VS16 is
+     *       promoted to a 2-wide cell with a continuation</li>
      * </ul>
      *
      * @param x the x coordinate
@@ -232,6 +234,20 @@ public final class Buffer {
                     Cell baseCell = get(baseCol, y);
                     String combined = baseCell.symbol() + new String(Character.toChars(codePoint));
                     set(baseCol, y, baseCell.symbol(combined));
+
+                    // Variation Selector-16 forces emoji (2-wide) presentation. When the base
+                    // glyph was placed as 1-wide (a text-default symbol such as U+2328 keyboard,
+                    // U+23F9 stop or U+23FA record), promote it to occupy two cells so the
+                    // terminal's 2-wide rendering stays in sync with the buffer. Without this the
+                    // following cell is left untracked and stale glyphs remain on screen.
+                    // At the extreme right edge (base on the last column) the loop breaks before
+                    // VS16 is reached, so the glyph degrades to its 1-wide text presentation,
+                    // matching how wide characters truncate at the right edge.
+                    if (codePoint == 0xFE0F && baseCol == col - 1
+                            && col < area.right() && !get(col, y).isContinuation()) {
+                        set(col, y, Cell.CONTINUATION);
+                        col++;
+                    }
                 }
                 // Check if this is ZWJ - next char should join
                 if (codePoint == 0x200D) {

--- a/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
+++ b/tamboui-core/src/main/java/dev/tamboui/buffer/Buffer.java
@@ -235,16 +235,17 @@ public final class Buffer {
                     String combined = baseCell.symbol() + new String(Character.toChars(codePoint));
                     set(baseCol, y, baseCell.symbol(combined));
 
-                    // Variation Selector-16 forces emoji (2-wide) presentation. When the base
-                    // glyph was placed as 1-wide (a text-default symbol such as U+2328 keyboard,
-                    // U+23F9 stop or U+23FA record), promote it to occupy two cells so the
-                    // terminal's 2-wide rendering stays in sync with the buffer. Without this the
-                    // following cell is left untracked and stale glyphs remain on screen.
-                    // At the extreme right edge (base on the last column) the loop breaks before
-                    // VS16 is reached, so the glyph degrades to its 1-wide text presentation,
-                    // matching how wide characters truncate at the right edge.
-                    if (codePoint == 0xFE0F && baseCol == col - 1
-                            && col < area.right() && !get(col, y).isContinuation()) {
+                    // Variation Selector-16 forces emoji (2-wide) presentation, but only for
+                    // recognized emoji-variation bases (the same set CharWidth.of(String) uses) -
+                    // e.g. "A" + VS16 stays 1-wide, unlike U+2328 keyboard or U+23F9 stop. When the
+                    // base glyph qualifies, promote it to occupy two cells so the terminal's 2-wide
+                    // rendering stays in sync with the buffer. The next cell is claimed even if it
+                    // already held an unrelated (e.g. stale) continuation, so it isn't left for the
+                    // following character to clobber. At the extreme right edge (base on the last
+                    // column) the loop breaks before VS16 is reached, so the glyph degrades to its
+                    // 1-wide text presentation, matching how wide characters truncate at the right edge.
+                    if (codePoint == 0xFE0F && baseCol == col - 1 && col < area.right()
+                            && CharWidth.isEmojiVariationBase(baseCell.symbol().codePointAt(0))) {
                         set(col, y, Cell.CONTINUATION);
                         col++;
                     }

--- a/tamboui-core/src/main/java/dev/tamboui/text/CharWidth.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/CharWidth.java
@@ -211,6 +211,7 @@ public final class CharWidth {
      *   <li>ZWJ sequences (e.g., 👨‍👦): width 2 for the combined glyph</li>
      *   <li>Regional Indicator pairs (flags, e.g., 🇫🇷): width 2</li>
      *   <li>Skin tone modifiers: zero-width (added to base emoji)</li>
+     *   <li>Emoji presentation sequences (1-wide base + VS16, e.g. ⌨️): width 2</li>
      * </ul>
      *
      * @param s the string to measure
@@ -247,6 +248,18 @@ public final class CharWidth {
                         i = nextIdx + Character.charCount(next);
                         continue;
                     }
+                }
+            }
+
+            // Emoji presentation sequence: a text-default glyph (1-wide on its own,
+            // e.g. U+2328 keyboard, U+23F9 stop, U+23FA record) followed by
+            // Variation Selector-16 (U+FE0F) is rendered as a 2-wide emoji.
+            if (cpWidth == 1) {
+                int vsIdx = i + charCount;
+                if (vsIdx < s.length() && s.codePointAt(vsIdx) == 0xFE0F) {
+                    width += 2;
+                    i = vsIdx + 1; // consume base glyph + VS16 (VS16 is in the BMP)
+                    continue;
                 }
             }
 

--- a/tamboui-core/src/main/java/dev/tamboui/text/CharWidth.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/CharWidth.java
@@ -337,6 +337,9 @@ public final class CharWidth {
      * Returns true if the code point is a recognized emoji-variation base: a
      * character for which Unicode defines both a text-style and emoji-style
      * variation sequence (see {@link #EMOJI_VARIATION_BASES}).
+     *
+     * @param codePoint the Unicode code point to check
+     * @return true if the code point is a recognized emoji-variation base
      */
     public static boolean isEmojiVariationBase(int codePoint) {
         return Arrays.binarySearch(EMOJI_VARIATION_BASES, codePoint) >= 0;

--- a/tamboui-core/src/main/java/dev/tamboui/text/CharWidth.java
+++ b/tamboui-core/src/main/java/dev/tamboui/text/CharWidth.java
@@ -253,8 +253,9 @@ public final class CharWidth {
 
             // Emoji presentation sequence: a text-default glyph (1-wide on its own,
             // e.g. U+2328 keyboard, U+23F9 stop, U+23FA record) followed by
-            // Variation Selector-16 (U+FE0F) is rendered as a 2-wide emoji.
-            if (cpWidth == 1) {
+            // Variation Selector-16 (U+FE0F) is rendered as a 2-wide emoji. Only
+            // recognized emoji-variation bases qualify; e.g. "A" + VS16 stays 1-wide.
+            if (cpWidth == 1 && isEmojiVariationBase(codePoint)) {
                 int vsIdx = i + charCount;
                 if (vsIdx < s.length() && s.codePointAt(vsIdx) == 0xFE0F) {
                     width += 2;
@@ -275,6 +276,70 @@ public final class CharWidth {
      */
     private static boolean isRegionalIndicator(int codePoint) {
         return codePoint >= 0x1F1E6 && codePoint <= 0x1F1FF;
+    }
+
+    // Sorted code points for which Unicode defines both a text-style (U+FE0E) and
+    // emoji-style (U+FE0F) variation sequence. Source: emoji-variation-sequences.txt
+    // (UTS #51, Unicode 17.0). Combined with a base width of 1, this identifies
+    // text-default glyphs (e.g. U+2328 keyboard) that render 2-wide when followed
+    // by VS16 - as opposed to arbitrary code points, which VS16 does not widen.
+    private static final int[] EMOJI_VARIATION_BASES = {
+        0x0023, 0x002A, 0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035,
+        0x0036, 0x0037, 0x0038, 0x0039, 0x00A9, 0x00AE, 0x203C, 0x2049,
+        0x2122, 0x2139, 0x2194, 0x2195, 0x2196, 0x2197, 0x2198, 0x2199,
+        0x21A9, 0x21AA, 0x231A, 0x231B, 0x2328, 0x23CF, 0x23E9, 0x23EA,
+        0x23EB, 0x23EC, 0x23ED, 0x23EE, 0x23EF, 0x23F0, 0x23F1, 0x23F2,
+        0x23F3, 0x23F8, 0x23F9, 0x23FA, 0x24C2, 0x25AA, 0x25AB, 0x25B6,
+        0x25C0, 0x25FB, 0x25FC, 0x25FD, 0x25FE, 0x2600, 0x2601, 0x2602,
+        0x2603, 0x2604, 0x260E, 0x2611, 0x2614, 0x2615, 0x2618, 0x261D,
+        0x2620, 0x2622, 0x2623, 0x2626, 0x262A, 0x262E, 0x262F, 0x2638,
+        0x2639, 0x263A, 0x2640, 0x2642, 0x2648, 0x2649, 0x264A, 0x264B,
+        0x264C, 0x264D, 0x264E, 0x264F, 0x2650, 0x2651, 0x2652, 0x2653,
+        0x265F, 0x2660, 0x2663, 0x2665, 0x2666, 0x2668, 0x267B, 0x267E,
+        0x267F, 0x2692, 0x2693, 0x2694, 0x2695, 0x2696, 0x2697, 0x2699,
+        0x269B, 0x269C, 0x26A0, 0x26A1, 0x26A7, 0x26AA, 0x26AB, 0x26B0,
+        0x26B1, 0x26BD, 0x26BE, 0x26C4, 0x26C5, 0x26C8, 0x26CE, 0x26CF,
+        0x26D1, 0x26D3, 0x26D4, 0x26E9, 0x26EA, 0x26F0, 0x26F1, 0x26F2,
+        0x26F3, 0x26F4, 0x26F5, 0x26F7, 0x26F8, 0x26F9, 0x26FA, 0x26FD,
+        0x2702, 0x2705, 0x2708, 0x2709, 0x270A, 0x270B, 0x270C, 0x270D,
+        0x270F, 0x2712, 0x2714, 0x2716, 0x271D, 0x2721, 0x2728, 0x2733,
+        0x2734, 0x2744, 0x2747, 0x274C, 0x274E, 0x2753, 0x2754, 0x2755,
+        0x2757, 0x2763, 0x2764, 0x2795, 0x2796, 0x2797, 0x27A1, 0x27B0,
+        0x27BF, 0x2934, 0x2935, 0x2B05, 0x2B06, 0x2B07, 0x2B1B, 0x2B1C,
+        0x2B50, 0x2B55, 0x3030, 0x303D, 0x3297, 0x3299, 0x1F004, 0x1F170,
+        0x1F171, 0x1F17E, 0x1F17F, 0x1F202, 0x1F21A, 0x1F22F, 0x1F237, 0x1F30D,
+        0x1F30E, 0x1F30F, 0x1F315, 0x1F31C, 0x1F321, 0x1F324, 0x1F325, 0x1F326,
+        0x1F327, 0x1F328, 0x1F329, 0x1F32A, 0x1F32B, 0x1F32C, 0x1F336, 0x1F378,
+        0x1F37D, 0x1F393, 0x1F396, 0x1F397, 0x1F399, 0x1F39A, 0x1F39B, 0x1F39E,
+        0x1F39F, 0x1F3A7, 0x1F3AC, 0x1F3AD, 0x1F3AE, 0x1F3C2, 0x1F3C4, 0x1F3C6,
+        0x1F3CA, 0x1F3CB, 0x1F3CC, 0x1F3CD, 0x1F3CE, 0x1F3D4, 0x1F3D5, 0x1F3D6,
+        0x1F3D7, 0x1F3D8, 0x1F3D9, 0x1F3DA, 0x1F3DB, 0x1F3DC, 0x1F3DD, 0x1F3DE,
+        0x1F3DF, 0x1F3E0, 0x1F3ED, 0x1F3F3, 0x1F3F5, 0x1F3F7, 0x1F408, 0x1F415,
+        0x1F41F, 0x1F426, 0x1F43F, 0x1F441, 0x1F442, 0x1F446, 0x1F447, 0x1F448,
+        0x1F449, 0x1F44D, 0x1F44E, 0x1F453, 0x1F46A, 0x1F47D, 0x1F4A3, 0x1F4B0,
+        0x1F4B3, 0x1F4BB, 0x1F4BF, 0x1F4CB, 0x1F4DA, 0x1F4DF, 0x1F4E4, 0x1F4E5,
+        0x1F4E6, 0x1F4EA, 0x1F4EB, 0x1F4EC, 0x1F4ED, 0x1F4F7, 0x1F4F9, 0x1F4FA,
+        0x1F4FB, 0x1F4FD, 0x1F508, 0x1F50D, 0x1F512, 0x1F513, 0x1F549, 0x1F54A,
+        0x1F550, 0x1F551, 0x1F552, 0x1F553, 0x1F554, 0x1F555, 0x1F556, 0x1F557,
+        0x1F558, 0x1F559, 0x1F55A, 0x1F55B, 0x1F55C, 0x1F55D, 0x1F55E, 0x1F55F,
+        0x1F560, 0x1F561, 0x1F562, 0x1F563, 0x1F564, 0x1F565, 0x1F566, 0x1F567,
+        0x1F56F, 0x1F570, 0x1F573, 0x1F574, 0x1F575, 0x1F576, 0x1F577, 0x1F578,
+        0x1F579, 0x1F587, 0x1F58A, 0x1F58B, 0x1F58C, 0x1F58D, 0x1F590, 0x1F5A5,
+        0x1F5A8, 0x1F5B1, 0x1F5B2, 0x1F5BC, 0x1F5C2, 0x1F5C3, 0x1F5C4, 0x1F5D1,
+        0x1F5D2, 0x1F5D3, 0x1F5DC, 0x1F5DD, 0x1F5DE, 0x1F5E1, 0x1F5E3, 0x1F5E8,
+        0x1F5EF, 0x1F5F3, 0x1F5FA, 0x1F610, 0x1F687, 0x1F68D, 0x1F691, 0x1F694,
+        0x1F698, 0x1F6AD, 0x1F6B2, 0x1F6B9, 0x1F6BA, 0x1F6BC, 0x1F6CB, 0x1F6CD,
+        0x1F6CE, 0x1F6CF, 0x1F6E0, 0x1F6E1, 0x1F6E2, 0x1F6E3, 0x1F6E4, 0x1F6E5,
+        0x1F6E9, 0x1F6F0, 0x1F6F3,
+    };
+
+    /**
+     * Returns true if the code point is a recognized emoji-variation base: a
+     * character for which Unicode defines both a text-style and emoji-style
+     * variation sequence (see {@link #EMOJI_VARIATION_BASES}).
+     */
+    public static boolean isEmojiVariationBase(int codePoint) {
+        return Arrays.binarySearch(EMOJI_VARIATION_BASES, codePoint) >= 0;
     }
 
     /**
@@ -326,6 +391,23 @@ public final class CharWidth {
                     lastSafeWidth = width;
                 }
                 continue;
+            }
+
+            // Emoji presentation sequence: treat base + VS16 as an atomic 2-wide
+            // unit (mirrors CharWidth.of(String)) so truncation never splits the
+            // base off from its VS16, or under-counts the pair's width.
+            if (cpWidth == 1 && isEmojiVariationBase(codePoint)) {
+                int vsIdx = i + charCount;
+                if (vsIdx < s.length() && s.codePointAt(vsIdx) == 0xFE0F) {
+                    if (width + 2 > maxWidth) {
+                        break;
+                    }
+                    width += 2;
+                    i = vsIdx + 1;
+                    lastSafeBreak = i;
+                    lastSafeWidth = width;
+                    continue;
+                }
             }
 
             // Check if adding this character would exceed max width
@@ -418,12 +500,30 @@ public final class CharWidth {
         int width = 0;
         while (i > 0) {
             int codePoint = s.codePointBefore(i);
+            int charCount = Character.charCount(codePoint);
+
+            // Emoji presentation sequence, scanned backward: VS16 immediately
+            // preceded by an emoji-variation base is an atomic 2-wide unit
+            // (mirrors CharWidth.of(String)/substringByWidth).
+            if (codePoint == 0xFE0F && i - charCount > 0) {
+                int baseIdx = i - charCount;
+                int baseCodePoint = s.codePointBefore(baseIdx);
+                if (of(baseCodePoint) == 1 && isEmojiVariationBase(baseCodePoint)) {
+                    if (width + 2 > maxWidth) {
+                        break;
+                    }
+                    width += 2;
+                    i = baseIdx - Character.charCount(baseCodePoint);
+                    continue;
+                }
+            }
+
             int charWidth = of(codePoint);
             if (width + charWidth > maxWidth) {
                 break;
             }
             width += charWidth;
-            i -= Character.charCount(codePoint);
+            i -= charCount;
         }
         return s.substring(i);
     }

--- a/tamboui-core/src/test/java/dev/tamboui/buffer/BufferWideCharTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/buffer/BufferWideCharTest.java
@@ -201,6 +201,70 @@ class BufferWideCharTest {
     }
 
     @Test
+    @DisplayName("Emoji presentation sequence (base + VS16) occupies two cells")
+    void emojiPresentationSequenceOccupiesTwoCells() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+        // \u2328\uFE0F = keyboard (U+2328) + Variation Selector-16 (U+FE0F).
+        // The base glyph is 1-wide on its own but renders as a 2-wide emoji with VS16.
+        String keyboard = "\u2328\uFE0F";
+        int endCol = buffer.setString(0, 0, keyboard, Style.EMPTY);
+
+        assertThat(endCol).isEqualTo(2);
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo(keyboard);
+        assertThat(buffer.get(1, 0).isContinuation()).isTrue();
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("Emoji presentation sequence does not leave stale cells when text follows")
+    void emojiPresentationSequenceWithTrailingText() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 20, 1));
+        // "\u23FA\uFE0F Rec" : record (U+23FA) + VS16, space, then text.
+        String label = "\u23FA\uFE0F Rec";
+        buffer.setString(0, 0, label, Style.EMPTY);
+
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("\u23FA\uFE0F");
+        assertThat(buffer.get(1, 0).isContinuation()).isTrue();
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(3, 0).symbol()).isEqualTo("R");
+        assertThat(buffer.get(4, 0).symbol()).isEqualTo("e");
+        assertThat(buffer.get(5, 0).symbol()).isEqualTo("c");
+    }
+
+    @Test
+    @DisplayName("Already-wide emoji with VS16 stays two cells")
+    void alreadyWideEmojiWithVariationSelectorStaysTwoCells() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+        // \uD83D\uDDA5\uFE0F = desktop computer (U+1F5A5, already 2-wide) + VS16 must stay 2-wide
+        String desktop = "\uD83D\uDDA5\uFE0F";
+        int endCol = buffer.setString(0, 0, desktop, Style.EMPTY);
+
+        assertThat(endCol).isEqualTo(2);
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo(desktop);
+        assertThat(buffer.get(1, 0).isContinuation()).isTrue();
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("Emoji presentation sequence at the right edge degrades to its 1-wide base")
+    void emojiPresentationSequenceAtRightEdgeTruncates() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 2, 1));
+        // The base glyph (U+2328) lands on the last column, so the loop breaks before
+        // VS16 is reached. Rather than overflowing or leaving a stale continuation, the
+        // glyph degrades to its 1-wide text presentation, matching how wide characters
+        // truncate at the right edge. This documents the one boundary where setString's
+        // return value (1 column consumed) intentionally differs from CharWidth.of (2).
+        int endCol = buffer.setString(1, 0, "⌨️", Style.EMPTY);
+
+        assertThat(endCol).isEqualTo(2);
+        // Only the base glyph (U+2328) is placed; VS16 is never appended.
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("⌨");
+        assertThat(buffer.get(1, 0).isContinuation()).isFalse();
+        // The cell to the left is untouched (still empty).
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo(" ");
+    }
+
+    @Test
     @DisplayName("Multiple flag emoji render correctly")
     void multipleFlagEmojiRenderCorrectly() {
         Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));

--- a/tamboui-core/src/test/java/dev/tamboui/buffer/BufferWideCharTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/buffer/BufferWideCharTest.java
@@ -280,6 +280,22 @@ class BufferWideCharTest {
     }
 
     @Test
+    @DisplayName("ZWJ sequence embedding a variation base stays a single 2-wide cell")
+    void zwjSequenceWithVariationBaseStaysSingleCell() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+        // U+26F9 U+FE0F U+200D U+2640 U+FE0F = person bouncing ball, female.
+        // The leading base+VS16 is promoted to 2 cells; the ZWJ tail (U+2640 U+FE0F)
+        // must append to the base cell without a second promotion or drift.
+        String sequence = "\u26F9\uFE0F\u200D\u2640\uFE0F";
+        int endCol = buffer.setString(0, 0, sequence + "X", Style.EMPTY);
+
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo(sequence);
+        assertThat(buffer.get(1, 0).isContinuation()).isTrue();
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo("X");
+        assertThat(endCol).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("Emoji presentation sequence reuses a stale continuation cell and still advances")
     void emojiPresentationSequenceReusesStaleContinuation() {
         Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));

--- a/tamboui-core/src/test/java/dev/tamboui/buffer/BufferWideCharTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/buffer/BufferWideCharTest.java
@@ -265,6 +265,41 @@ class BufferWideCharTest {
     }
 
     @Test
+    @DisplayName("VS16 after a non-emoji base does not promote to two cells")
+    void vs16AfterNonEmojiBaseStaysOneCell() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+        // 'A' is not a recognized emoji-variation base, so VS16 must not reserve
+        // a continuation cell for it (unlike the real keyboard/stop/record cases above).
+        int endCol = buffer.setString(0, 0, "A️B", Style.EMPTY);
+
+        assertThat(endCol).isEqualTo(2);
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("A️");
+        assertThat(buffer.get(0, 0).isContinuation()).isFalse();
+        assertThat(buffer.get(1, 0).isContinuation()).isFalse();
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("B");
+    }
+
+    @Test
+    @DisplayName("Emoji presentation sequence reuses a stale continuation cell and still advances")
+    void emojiPresentationSequenceReusesStaleContinuation() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));
+        // Column 1 starts out as a continuation cell belonging to a previously
+        // rendered wide char ("世").
+        buffer.setString(0, 0, "世", Style.EMPTY);
+
+        // Overwrite column 0 with a promoted emoji presentation sequence followed
+        // by more text. The stale continuation at column 1 must be reclaimed for
+        // the new sequence, and the cursor must still advance past it so "X"
+        // doesn't overwrite the just-combined base cell.
+        int endCol = buffer.setString(0, 0, "⌨️X", Style.EMPTY);
+
+        assertThat(buffer.get(0, 0).symbol()).isEqualTo("⌨️");
+        assertThat(buffer.get(1, 0).isContinuation()).isTrue();
+        assertThat(buffer.get(2, 0).symbol()).isEqualTo("X");
+        assertThat(endCol).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("Multiple flag emoji render correctly")
     void multipleFlagEmojiRenderCorrectly() {
         Buffer buffer = Buffer.empty(new Rect(0, 0, 10, 1));

--- a/tamboui-core/src/test/java/dev/tamboui/text/CharWidthTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/text/CharWidthTest.java
@@ -135,6 +135,30 @@ class CharWidthTest {
     }
 
     @Test
+    @DisplayName("Emoji presentation sequence (base + VS16) has width 2")
+    void emojiPresentationSequenceWidth() {
+        // Base glyphs that are 1-wide on their own but render as 2-wide emoji
+        // when followed by Variation Selector-16 (U+FE0F).
+        // U+2328 keyboard alone is 1-wide
+        assertThat(CharWidth.of(0x2328)).isEqualTo(1);
+        // ⌨️ = U+2328 + U+FE0F (keyboard)
+        assertThat(CharWidth.of("⌨️")).isEqualTo(2);
+        // ⏹️ = U+23F9 + U+FE0F (stop)
+        assertThat(CharWidth.of("⏹️")).isEqualTo(2);
+        // ⏺️ = U+23FA + U+FE0F (record)
+        assertThat(CharWidth.of("⏺️")).isEqualTo(2);
+        // Surrounding text keeps its own width: "A⌨️B" = 1 + 2 + 1 = 4
+        assertThat(CharWidth.of("A⌨️B")).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("Already-wide emoji with VS16 stays width 2")
+    void alreadyWideEmojiWithVariationSelectorWidth() {
+        // 🖥️ = U+1F5A5 (already 2-wide) + U+FE0F must not become 4-wide
+        assertThat(CharWidth.of("🖥️")).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("Null and empty string have width 0")
     void nullAndEmptyWidth() {
         assertThat(CharWidth.of((String) null)).isEqualTo(0);

--- a/tamboui-core/src/test/java/dev/tamboui/text/CharWidthTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/text/CharWidthTest.java
@@ -152,6 +152,19 @@ class CharWidthTest {
     }
 
     @Test
+    @DisplayName("ZWJ sequences embedding variation bases stay width 2")
+    void zwjSequencesWithVariationBasesStayWidth2() {
+        // U+2695 (staff of aesculapius) and U+2640 (female sign) are emoji-variation
+        // bases, but inside a ZWJ sequence they join the preceding glyph instead of
+        // forming their own 2-wide unit.
+        // \uD83D\uDC69 U+200D U+2695 U+FE0F = woman health worker (VS16 after ZWJ'd base)
+        assertThat(CharWidth.of("\uD83D\uDC69\u200D\u2695\uFE0F")).isEqualTo(2);
+        // U+26F9 U+FE0F U+200D U+2640 U+FE0F = person bouncing ball, female
+        // (VS16 before AND after the ZWJ)
+        assertThat(CharWidth.of("\u26F9\uFE0F\u200D\u2640\uFE0F")).isEqualTo(2);
+    }
+
+    @Test
     @DisplayName("VS16 after a non-emoji base stays width 1")
     void vs16AfterNonEmojiBaseStaysWidth1() {
         // 'A' is not a recognized emoji-variation base, so VS16 does not widen it.

--- a/tamboui-core/src/test/java/dev/tamboui/text/CharWidthTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/text/CharWidthTest.java
@@ -152,6 +152,24 @@ class CharWidthTest {
     }
 
     @Test
+    @DisplayName("VS16 after a non-emoji base stays width 1")
+    void vs16AfterNonEmojiBaseStaysWidth1() {
+        // 'A' is not a recognized emoji-variation base, so VS16 does not widen it.
+        assertThat(CharWidth.of("A️")).isEqualTo(1);
+        assertThat(CharWidth.of("A️B")).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("substringByWidth and substringByWidthFromEnd keep an emoji presentation sequence intact")
+    void substringByWidthKeepsEmojiPresentationSequenceAtomic() {
+        // "A⌨️B" = widths [1, 2, 1], total 4
+        assertThat(CharWidth.substringByWidth("A⌨️B", 2)).isEqualTo("A");
+        assertThat(CharWidth.substringByWidth("A⌨️B", 3)).isEqualTo("A⌨️");
+        assertThat(CharWidth.substringByWidthFromEnd("A⌨️B", 2)).isEqualTo("B");
+        assertThat(CharWidth.substringByWidthFromEnd("A⌨️B", 3)).isEqualTo("⌨️B");
+    }
+
+    @Test
     @DisplayName("Already-wide emoji with VS16 stays width 2")
     void alreadyWideEmojiWithVariationSelectorWidth() {
         // 🖥️ = U+1F5A5 (already 2-wide) + U+FE0F must not become 4-wide


### PR DESCRIPTION
## Problem

Text-default glyphs such as `U+2328` (⌨ keyboard), `U+23F9` (⏹ stop) and `U+23FA` (⏺ record) are 1-wide on their own but render as **2-wide emoji** when followed by Variation Selector-16 (`U+FE0F`), i.e. as an emoji presentation sequence (`⌨️`, `⏹️`, `⏺️`).

Two places treated these as width 1:

- `CharWidth.of(String)` summed `width(base=1) + width(VS16=0) = 1`.
- `Buffer.setString` placed the base glyph in a single cell and appended VS16 to it, never reserving a continuation cell.

Because the terminal actually advances 2 columns for the glyph while the buffer tracked only 1, everything after the emoji drifted one column out of sync. On redraw, the diff stopped one cell short and left **stale characters on screen**. This is visible, for example, when arrow-key scrolling over list popup items that begin with such an emoji: the row appears to shift left and leftover letters remain after the selection moves away.

## Fix

- `CharWidth.of(String)`: a 1-wide base glyph immediately followed by `U+FE0F` now counts as width **2**.
- `Buffer.setString`: when `U+FE0F` is appended to a base that was placed as 1-wide, promote it to occupy two cells by reserving a continuation cell.

Already-wide emoji that also carry VS16 (e.g. `U+1F5A5` 🖥️ desktop) are unaffected: their base is already width 2, so no extra promotion happens.

## Tests

- `CharWidthTest`: emoji presentation sequences (`⌨️`, `⏹️`, `⏺️`, and mixed `A⌨️B`) measure width 2; already-wide `🖥️` stays width 2.
- `BufferWideCharTest`: `⌨️` occupies two cells with a continuation; `⏺️ Rec` keeps following text correctly positioned; `🖥️` stays two cells; an emoji presentation sequence placed on the last column degrades to its 1-wide base (right-edge truncation, matching wide-char behavior).

The `of(String)` / `setString` Javadoc grapheme-handling lists were also updated to document the new emoji-presentation-sequence case.

Full `:tamboui-core:test` and `:tamboui-widgets:test` suites pass; `spotlessApply` is a no-op on the change.

## Follow-up

Review surfaced a pre-existing, unrelated no-op block in `Buffer.setString` (wide-char overwrite handling). Tracked separately in #389 to keep this PR focused.

---
_Submitted by Claude Code on behalf of Adriano Machado (@ammachado), who has reviewed and takes responsibility for this change._

🤖 Generated with [Claude Code](https://claude.com/claude-code)