### PR TITLE
fix: clamp MarkdownView scroll to prevent blank viewport

### DIFF
--- a/tamboui-markdown/demos/markdown-demo/src/main/java/dev/tamboui/demo/MarkdownDemo.java
+++ b/tamboui-markdown/demos/markdown-demo/src/main/java/dev/tamboui/demo/MarkdownDemo.java
@@ -41,6 +41,7 @@ public final class MarkdownDemo {
 
     private final String fullSource;
     private int scroll;
+    private int maxScroll;
     private int streamLength;
     private boolean streaming;
     private boolean running = true;
@@ -135,6 +136,9 @@ public final class MarkdownDemo {
             .block(frameBlock)
             .scroll(scroll)
             .build();
+        // Max scroll = total rows minus viewport height; block chrome is included
+        // in both computeHeight and the frame area, so it cancels out.
+        maxScroll = Math.max(0, view.computeHeight(frame.area().width()) - frame.area().height());
         frame.renderWidget(view, frame.area());
     }
 
@@ -147,7 +151,7 @@ public final class MarkdownDemo {
                 break;
             case 'j':
             case 'J':
-                scroll++;
+                scroll = Math.min(scroll + 1, maxScroll);
                 break;
             case 'k':
             case 'K':

--- a/tamboui-markdown/src/main/java/dev/tamboui/markdown/MarkdownView.java
+++ b/tamboui-markdown/src/main/java/dev/tamboui/markdown/MarkdownView.java
@@ -240,7 +240,7 @@ public final class MarkdownView implements Widget {
             return;
         }
 
-        int skip = Math.max(0, Math.min(scroll, totalRows - 1));
+        int skip = Math.max(0, Math.min(scroll, Math.max(0, totalRows - contentArea.height())));
         int y = contentArea.top();
         int rowsRemaining = contentArea.height();
         int rowsSkipped = 0;

--- a/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
+++ b/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
@@ -329,4 +329,34 @@ class MarkdownViewTest {
             renderInto(view, 30, 6);
         }
     }
+
+    @Test
+    @DisplayName("scroll clamp prevents scrolling past content bottom")
+    void scrollClampPreventsBlankScreen() {
+        // Content renders to a few rows. A very large scroll value should show the
+        // last page of content, not a blank viewport.
+        String source = "line one\n\nline two\n\nline three";
+        int viewportHeight = 3;
+
+        // Render with a huge scroll — should show the bottom of the content
+        MarkdownView scrolled = MarkdownView.builder()
+            .source(source)
+            .scroll(Integer.MAX_VALUE)
+            .build();
+        Buffer scrolledBuf = renderInto(scrolled, 30, viewportHeight);
+
+        // At least one row in the viewport must contain non-space content
+        boolean hasContent = false;
+        for (int y = 0; y < viewportHeight && !hasContent; y++) {
+            for (int x = 0; x < 30; x++) {
+                if (!scrolledBuf.get(x, y).symbol().isBlank()) {
+                    hasContent = true;
+                    break;
+                }
+            }
+        }
+        assertThat(hasContent)
+            .as("viewport should show content, not blank space, when scroll is very large")
+            .isTrue();
+    }
 }

--- a/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
+++ b/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
@@ -7,6 +7,7 @@ package dev.tamboui.markdown;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Modifier;
@@ -258,12 +259,13 @@ class MarkdownViewTest {
     @DisplayName("renders bottom of a code block when top is scrolled off-screen")
     void rendersCodeBlockScrolledFromTop() {
         // 1-line code block = 3 rows (top border + content + bottom border).
+        // Viewport must be smaller than content so scrolling is possible.
         // Scroll by 1 so the top border is off-screen — should show content + bottom border.
         MarkdownView view = MarkdownView.builder()
             .source("```\ncode\n```")
             .scroll(1)
             .build();
-        Buffer buffer = renderInto(view, 20, 3);
+        Buffer buffer = renderInto(view, 20, 2);
 
         // Row 0: code content (top border scrolled away)
         assertThat(buffer.get(1, 0).symbol()).isEqualTo("c");
@@ -274,12 +276,13 @@ class MarkdownViewTest {
     @Test
     @DisplayName("renders only bottom border when code block is mostly scrolled off")
     void rendersCodeBlockBottomBorderOnly() {
-        // 1-line code block = 3 rows. Scroll by 2 — only bottom border remains visible.
+        // 1-line code block = 3 rows. Viewport must be smaller than content.
+        // Scroll by 2 — only bottom border remains visible.
         MarkdownView view = MarkdownView.builder()
             .source("```\ncode\n```")
             .scroll(2)
             .build();
-        Buffer buffer = renderInto(view, 20, 3);
+        Buffer buffer = renderInto(view, 20, 1);
 
         // Row 0: bottom border only
         assertThat(buffer.get(0, 0).symbol()).isEqualTo("╰");
@@ -333,30 +336,60 @@ class MarkdownViewTest {
     @Test
     @DisplayName("scroll clamp prevents scrolling past content bottom")
     void scrollClampPreventsBlankScreen() {
-        // Content renders to a few rows. A very large scroll value should show the
-        // last page of content, not a blank viewport.
+        // 5 content rows: "line one" / blank / "line two" / blank / "line three"
+        // Viewport height 3 → clamp = max(0, 5-3) = 2 → shows rows 2-4
         String source = "line one\n\nline two\n\nline three";
-        int viewportHeight = 3;
 
-        // Render with a huge scroll — should show the bottom of the content
         MarkdownView scrolled = MarkdownView.builder()
             .source(source)
             .scroll(Integer.MAX_VALUE)
             .build();
-        Buffer scrolledBuf = renderInto(scrolled, 30, viewportHeight);
+        Buffer scrolledBuf = renderInto(scrolled, 30, 3);
 
-        // At least one row in the viewport must contain non-space content
-        boolean hasContent = false;
-        for (int y = 0; y < viewportHeight && !hasContent; y++) {
-            for (int x = 0; x < 30; x++) {
-                if (!scrolledBuf.get(x, y).symbol().isBlank()) {
-                    hasContent = true;
-                    break;
-                }
-            }
-        }
-        assertThat(hasContent)
-            .as("viewport should show content, not blank space, when scroll is very large")
-            .isTrue();
+        // Row 0: "line two", Row 1: blank, Row 2: "line three"
+        BufferAssertions.assertThat(scrolledBuf)
+            .hasSymbolAt(0, 0, "l")
+            .hasSymbolAt(5, 0, "t")
+            .hasSymbolAt(7, 0, "o")
+            .hasSymbolAt(0, 2, "l")
+            .hasSymbolAt(5, 2, "t")
+            .hasSymbolAt(9, 2, "e");
+    }
+
+    @Test
+    @DisplayName("scroll clamp with content shorter than viewport stays at top")
+    void scrollClampContentShorterThanViewport() {
+        // 1 content row, 5-row viewport → clamp = max(0, 1-5) = 0
+        MarkdownView scrolled = MarkdownView.builder()
+            .source("hello")
+            .scroll(Integer.MAX_VALUE)
+            .build();
+        Buffer buf = renderInto(scrolled, 30, 5);
+
+        BufferAssertions.assertThat(buf)
+            .hasSymbolAt(0, 0, "h")
+            .hasSymbolAt(4, 0, "o");
+    }
+
+    @Test
+    @DisplayName("scroll clamp with content exactly fitting viewport stays at top")
+    void scrollClampContentExactlyFitsViewport() {
+        // 5 content rows, 5-row viewport → clamp = max(0, 5-5) = 0
+        String source = "line one\n\nline two\n\nline three";
+
+        MarkdownView scrolled = MarkdownView.builder()
+            .source(source)
+            .scroll(Integer.MAX_VALUE)
+            .build();
+        Buffer buf = renderInto(scrolled, 30, 5);
+
+        // All content visible from the top
+        BufferAssertions.assertThat(buf)
+            .hasSymbolAt(0, 0, "l")
+            .hasSymbolAt(5, 0, "o")
+            .hasSymbolAt(0, 2, "l")
+            .hasSymbolAt(5, 2, "t")
+            .hasSymbolAt(0, 4, "l")
+            .hasSymbolAt(5, 4, "t");
     }
 }

--- a/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
+++ b/tamboui-markdown/src/test/java/dev/tamboui/markdown/MarkdownViewTest.java
@@ -11,6 +11,7 @@ import dev.tamboui.assertj.BufferAssertions;
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Modifier;
+import dev.tamboui.widgets.block.Block;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -316,7 +317,7 @@ class MarkdownViewTest {
         MarkdownView plain = MarkdownView.builder().source("# Title").build();
         MarkdownView boxed = MarkdownView.builder()
             .source("# Title")
-            .block(dev.tamboui.widgets.block.Block.bordered())
+            .block(Block.bordered())
             .build();
 
         // ALL borders add 2 rows of vertical chrome.
@@ -369,6 +370,22 @@ class MarkdownViewTest {
         BufferAssertions.assertThat(buf)
             .hasSymbolAt(0, 0, "h")
             .hasSymbolAt(4, 0, "o");
+    }
+
+    @Test
+    @DisplayName("computeHeight supports deriving max scroll, with and without block chrome")
+    void computeHeightDerivesMaxScroll() {
+        // 5 content rows: "line one" / blank / "line two" / blank / "line three"
+        String source = "line one\n\nline two\n\nline three";
+        MarkdownView plain = MarkdownView.builder().source(source).build();
+        MarkdownView bordered = MarkdownView.builder().source(source).block(Block.bordered()).build();
+
+        // maxScroll = computeHeight(width) - viewportHeight (chrome cancels out)
+        assertThat(Math.max(0, plain.computeHeight(30) - 3)).isEqualTo(2);
+        assertThat(Math.max(0, plain.computeHeight(30) - 5)).isEqualTo(0);
+        // 5 content rows + 2 border rows = 7 total; viewport 5 -> content area 3 -> max 2
+        assertThat(Math.max(0, bordered.computeHeight(30) - 5)).isEqualTo(2);
+        assertThat(Math.max(0, bordered.computeHeight(30) - 7)).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Fix scroll clamp in `MarkdownView` to prevent scrolling past the content bottom
- Change clamp from `totalRows - 1` to `totalRows - contentArea.height()` so the last page of content stays visible
- Add tests verifying scroll clamp behavior including edge cases

Fixes #392

## Details

The `MarkdownView` scroll was clamped to `totalRows - 1`, which allows the content to scroll entirely above the viewport — leaving a blank screen. The fix clamps to `Math.max(0, totalRows - contentArea.height())` instead, so the furthest scroll position shows the last page of content aligned to the bottom of the viewport.

This is the same behavior as text editors and browsers — you can never scroll past the point where the bottom of content meets the bottom of the viewport.

## Test plan

- [x] Added unit test `scrollClampPreventsBlankScreen` with `BufferAssertions` verifying exact content rows shown
- [x] Added edge-case test `scrollClampContentShorterThanViewport` (content < viewport → no scroll)
- [x] Added edge-case test `scrollClampContentExactlyFitsViewport` (content == viewport → no scroll)
- [x] Fixed pre-existing tests (`rendersCodeBlockScrolledFromTop`, `rendersCodeBlockBottomBorderOnly`) that relied on the old buggy scroll behavior — adjusted viewport heights so scrolling is still possible
- [x] All 27 MarkdownViewTest tests pass