### PR TITLE
fix: avoid resetting terminal cursor blink timer on unchanged frames

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -17,6 +17,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.DiffResult;
 import dev.tamboui.error.RuntimeIOException;
 import dev.tamboui.jfr.TerminalDrawEvent;
+import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.layout.Size;
 
@@ -39,6 +40,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
     private Buffer currentBuffer;
     private Buffer previousBuffer;
     private boolean hiddenCursor;
+    private Position previousCursorPosition;
     private boolean previousFrameHadRawOutput;
     private List<Rect> previousRawOutputAreas = Collections.emptyList();
 
@@ -149,19 +151,24 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
 
                 // Calculate diff and draw (zero-allocation DoD variant)
                 previousBuffer.diff(currentBuffer, diffResult);
-                if (!diffResult.isEmpty()) {
+                boolean hadDiff = !diffResult.isEmpty();
+                if (hadDiff) {
                     backend.draw(diffResult);
                 }
                 diffResult.clear();  // Clear after use to release Cell refs for GC
 
-                // Handle cursor
+                // Handle cursor — skip redundant setCursorPosition when nothing
+                // on screen changed, so the terminal's blink timer is not reset
                 if (frame.isCursorVisible()) {
                     frame.cursorPosition().ifPresent(pos -> {
                         try {
-                            backend.setCursorPosition(pos);
-                            if (hiddenCursor) {
-                                backend.showCursor();
-                                hiddenCursor = false;
+                            if (hiddenCursor || hadDiff || !pos.equals(previousCursorPosition)) {
+                                backend.setCursorPosition(pos);
+                                if (hiddenCursor) {
+                                    backend.showCursor();
+                                    hiddenCursor = false;
+                                }
+                                previousCursorPosition = pos;
                             }
                         } catch (IOException e) {
                             throw new RuntimeIOException(
@@ -172,6 +179,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                     try {
                         backend.hideCursor();
                         hiddenCursor = true;
+                        previousCursorPosition = null;
                     } catch (IOException e) {
                         throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
                     }

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -153,49 +153,50 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                 previousBuffer.diff(currentBuffer, diffResult);
                 boolean hadDiff = !diffResult.isEmpty();
 
-                // Wrap rendering in synchronized update (Mode 2026) to prevent tearing.
-                // BSU, draw data, cursor ops, and ESU are all written to the output
-                // buffer and flushed together in a single syscall for atomic rendering.
-                backend.beginSynchronizedUpdate();
-                try {
-                    if (hadDiff) {
-                        backend.draw(diffResult);
-                    }
+                // Decide the cursor work before opening the synchronized update, so a
+                // frame that changes nothing writes NOTHING at all: some terminals
+                // (e.g. Ghostty) reset the cursor blink timer on any output, so even
+                // an empty BSU/ESU pair or a redundant cursor reposition keeps the
+                // cursor from ever blinking.
+                Position cursorPos = frame.isCursorVisible()
+                        ? frame.cursorPosition().orElse(null)
+                        : null;
+                boolean repositionCursor = cursorPos != null
+                        && (hiddenCursor || hadDiff || !cursorPos.equals(previousCursorPosition));
+                boolean hideCursorNow = cursorPos == null && !frame.isCursorVisible() && !hiddenCursor;
+                boolean hasRawOutput = previousFrameHadRawOutput || frame.hadRawOutput();
 
-                    // Handle cursor — skip redundant setCursorPosition when nothing
-                    // on screen changed, so the terminal's blink timer is not reset
-                    if (frame.isCursorVisible()) {
-                        frame.cursorPosition().ifPresent(pos -> {
-                            try {
-                                if (hiddenCursor || hadDiff || !pos.equals(previousCursorPosition)) {
-                                    backend.setCursorPosition(pos);
-                                    if (hiddenCursor) {
-                                        backend.showCursor();
-                                        hiddenCursor = false;
-                                    }
-                                    previousCursorPosition = pos;
-                                }
-                            } catch (IOException e) {
-                                throw new RuntimeIOException(
-                                        String.format("Failed to set cursor position to %s: %s", pos, e.getMessage()),
-                                        e);
+                if (hadDiff || repositionCursor || hideCursorNow || hasRawOutput) {
+                    // Wrap rendering in synchronized update (Mode 2026) to prevent tearing.
+                    // BSU, draw data, cursor ops, and ESU are all written to the output
+                    // buffer and flushed together in a single syscall for atomic rendering.
+                    backend.beginSynchronizedUpdate();
+                    try {
+                        if (hadDiff) {
+                            backend.draw(diffResult);
+                        }
+
+                        if (repositionCursor) {
+                            backend.setCursorPosition(cursorPos);
+                            if (hiddenCursor) {
+                                backend.showCursor();
+                                hiddenCursor = false;
                             }
-                        });
-                    } else if (!hiddenCursor) {
-                        try {
+                            previousCursorPosition = cursorPos;
+                        } else if (hideCursorNow) {
                             backend.hideCursor();
                             hiddenCursor = true;
                             previousCursorPosition = null;
-                        } catch (IOException e) {
-                            throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
                         }
+                    } finally {
+                        diffResult.clear();  // Release Cell refs for GC even on error
+                        // Write ESU before flushing so BSU + draw + ESU are sent atomically.
+                        // Done in finally to avoid leaving the terminal in a stuck buffering state.
+                        backend.endSynchronizedUpdate();
+                        backend.flush();
                     }
-                } finally {
-                    diffResult.clear();  // Release Cell refs for GC even on error
-                    // Write ESU before flushing so BSU + draw + ESU are sent atomically.
-                    // Done in finally to avoid leaving the terminal in a stuck buffering state.
-                    backend.endSynchronizedUpdate();
-                    backend.flush();
+                } else {
+                    diffResult.clear();
                 }
 
                 // Swap buffers

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -17,6 +17,7 @@ import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.DiffResult;
 import dev.tamboui.error.RuntimeIOException;
 import dev.tamboui.jfr.TerminalDrawEvent;
+import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.layout.Size;
 
@@ -39,6 +40,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
     private Buffer currentBuffer;
     private Buffer previousBuffer;
     private boolean hiddenCursor;
+    private Position previousCursorPosition;
     private boolean previousFrameHadRawOutput;
     private List<Rect> previousRawOutputAreas = Collections.emptyList();
 
@@ -149,24 +151,29 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
 
                 // Calculate diff and draw (zero-allocation DoD variant)
                 previousBuffer.diff(currentBuffer, diffResult);
+                boolean hadDiff = !diffResult.isEmpty();
 
                 // Wrap rendering in synchronized update (Mode 2026) to prevent tearing.
                 // BSU, draw data, cursor ops, and ESU are all written to the output
                 // buffer and flushed together in a single syscall for atomic rendering.
                 backend.beginSynchronizedUpdate();
                 try {
-                    if (!diffResult.isEmpty()) {
+                    if (hadDiff) {
                         backend.draw(diffResult);
                     }
 
-                    // Handle cursor
+                    // Handle cursor — skip redundant setCursorPosition when nothing
+                    // on screen changed, so the terminal's blink timer is not reset
                     if (frame.isCursorVisible()) {
                         frame.cursorPosition().ifPresent(pos -> {
                             try {
-                                backend.setCursorPosition(pos);
-                                if (hiddenCursor) {
-                                    backend.showCursor();
-                                    hiddenCursor = false;
+                                if (hiddenCursor || hadDiff || !pos.equals(previousCursorPosition)) {
+                                    backend.setCursorPosition(pos);
+                                    if (hiddenCursor) {
+                                        backend.showCursor();
+                                        hiddenCursor = false;
+                                    }
+                                    previousCursorPosition = pos;
                                 }
                             } catch (IOException e) {
                                 throw new RuntimeIOException(
@@ -178,6 +185,7 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
                         try {
                             backend.hideCursor();
                             hiddenCursor = true;
+                            previousCursorPosition = null;
                         } catch (IOException e) {
                             throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
                         }

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/SynchronizedOutputTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/SynchronizedOutputTest.java
@@ -44,13 +44,14 @@ class SynchronizedOutputTest {
         assertThat(calls).containsExactly(
                 "beginSynchronizedUpdate",
                 "draw",
+                "hideCursor", // no cursor set on the frame -> hidden on first draw
                 "endSynchronizedUpdate",
                 "flush");
     }
 
     @Test
-    @DisplayName("draw() sends BSU/ESU even with no diff")
-    void drawSendsSyncUpdateEvenWithNoDiff() {
+    @DisplayName("draw() writes nothing at all when nothing changed")
+    void drawSkipsAllOutputWhenNothingChanged() {
         RecordingBackend backend = new RecordingBackend(10, 5);
         Terminal<RecordingBackend> terminal = new Terminal<>(backend);
 
@@ -58,13 +59,59 @@ class SynchronizedOutputTest {
         terminal.draw(frame -> {});
         backend.clearCalls();
 
-        // Second draw with same content — no diff, but BSU/ESU still sent
+        // Second draw with same content — zero bytes must reach the terminal:
+        // some terminals (e.g. Ghostty) reset the cursor blink timer on ANY
+        // output, so even an empty BSU/ESU pair keeps the cursor from blinking.
         terminal.draw(frame -> {});
 
-        List<String> calls = backend.calls();
-        assertThat(calls).contains("beginSynchronizedUpdate", "endSynchronizedUpdate", "flush");
-        // No "draw" call since there's no diff
-        assertThat(calls).doesNotContain("draw");
+        assertThat(backend.calls()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("unchanged frame with unchanged cursor position writes nothing")
+    void unchangedCursorWritesNothing() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame -> frame.setCursorPosition(new Position(3, 0)));
+        backend.clearCalls();
+
+        terminal.draw(frame -> frame.setCursorPosition(new Position(3, 0)));
+
+        assertThat(backend.calls()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("moved cursor on an unchanged frame is repositioned inside BSU/ESU")
+    void movedCursorIsWritten() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame -> frame.setCursorPosition(new Position(3, 0)));
+        backend.clearCalls();
+
+        terminal.draw(frame -> frame.setCursorPosition(new Position(4, 0)));
+
+        assertThat(backend.calls()).containsExactly(
+                "beginSynchronizedUpdate",
+                "setCursorPosition",
+                "endSynchronizedUpdate",
+                "flush");
+    }
+
+    @Test
+    @DisplayName("hiding the cursor on an unchanged frame still writes")
+    void cursorHideIsWritten() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame -> frame.setCursorPosition(new Position(3, 0)));
+        backend.clearCalls();
+
+        // No cursor set this frame -> cursor must be hidden -> output required
+        terminal.draw(frame -> {});
+
+        assertThat(backend.calls()).contains("hideCursor", "flush");
     }
 
     @Test
@@ -153,10 +200,12 @@ class SynchronizedOutputTest {
 
         @Override
         public void showCursor() throws IOException {
+            calls.add("showCursor");
         }
 
         @Override
         public void hideCursor() throws IOException {
+            calls.add("hideCursor");
         }
 
         @Override
@@ -166,6 +215,7 @@ class SynchronizedOutputTest {
 
         @Override
         public void setCursorPosition(Position position) throws IOException {
+            calls.add("setCursorPosition");
         }
 
         @Override


### PR DESCRIPTION
## Summary

- Track previous cursor position in `Terminal.draw()` and skip redundant `backend.setCursorPosition()` calls when the position hasn't changed and no cells were redrawn
- This lets the terminal's native cursor blink animation run undisturbed between frames
- When cells are redrawn (`hadDiff`), the cursor is always repositioned since `backend.draw()` moves the physical cursor

## Context

Applications with a shell/input panel that call `Frame.setCursorPosition()` every frame were seeing a non-blinking cursor because the cursor position escape sequence was sent every render cycle, resetting the terminal's blink timer before it could complete a cycle.

_Claude Code on behalf of Guillaume Nodet_