### PR TITLE
Add mouse interaction support to Scrollbar widget

### DIFF
--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/Scrollbar.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/Scrollbar.java
@@ -336,26 +336,9 @@ public final class Scrollbar implements StatefulWidget<ScrollbarState> {
         }
 
         // Calculate thumb position and size
-        int contentLength = state.contentLength();
-        int viewportLength = state.viewportContentLength() > 0
-            ? state.viewportContentLength()
-            : trackLength;
-
-        // Thumb size proportional to viewport/content ratio
-        int thumbSize = Math.max(1, (int) Math.ceil((double) viewportLength / contentLength * trackLength));
-        thumbSize = Math.min(thumbSize, trackLength);
-
-        // Thumb position
-        int scrollableRange = contentLength - viewportLength;
-        int thumbPosition;
-        if (scrollableRange <= 0) {
-            thumbPosition = 0;
-        } else {
-            double scrollFraction = (double) state.position() / scrollableRange;
-            scrollFraction = Math.max(0.0, Math.min(1.0, scrollFraction));
-            int thumbRange = trackLength - thumbSize;
-            thumbPosition = (int) Math.round(scrollFraction * thumbRange);
-        }
+        ThumbGeometry thumb = computeThumbGeometry(trackLength, state);
+        int thumbSize = thumb.size;
+        int thumbPosition = thumb.position;
 
         // Get effective styles
         Style effectiveStyle = style != null ? style : Style.EMPTY;
@@ -374,6 +357,163 @@ public final class Scrollbar implements StatefulWidget<ScrollbarState> {
                 effectiveBegin, effectiveEnd, effectiveTrackStyle, effectiveThumbStyle,
                 effectiveBeginStyle, effectiveEndStyle, beginOffset, thumbPosition, thumbSize, trackLength);
         }
+    }
+
+    /**
+     * Handles a mouse action on this scrollbar.
+     * <p>
+     * Call this from your own mouse event handler, passing the same {@code area}
+     * used for {@link #render(Rect, Buffer, ScrollbarState) rendering}.
+     * <p>
+     * Supported interactions:
+     * <ul>
+     *   <li><b>Click on track</b>: pages up/left when clicking above/before the thumb,
+     *       pages down/right when clicking below/after</li>
+     *   <li><b>Click on thumb</b>: starts a drag operation</li>
+     *   <li><b>Drag</b>: moves the thumb proportionally to the mouse position</li>
+     *   <li><b>Release</b>: ends any in-progress drag</li>
+     *   <li><b>Scroll up/down</b>: scrolls by one position</li>
+     * </ul>
+     *
+     * <pre>{@code
+     * // In your mouse event handler:
+     * ScrollbarAction action = mapMouseEvent(mouseEvent);
+     * if (action != null) {
+     *     boolean consumed = scrollbar.handleMouseAction(
+     *         mouseEvent.x(), mouseEvent.y(), action, scrollbarArea, scrollbarState);
+     *     if (consumed) {
+     *         return;
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param mouseX the mouse x coordinate (0-based)
+     * @param mouseY the mouse y coordinate (0-based)
+     * @param action the scrollbar action to perform
+     * @param area   the area passed to {@link #render}, used to compute the scrollbar track position
+     * @param state  the scrollbar state to update
+     * @return true if the event was consumed
+     * @see ScrollbarAction
+     */
+    public boolean handleMouseAction(int mouseX, int mouseY, ScrollbarAction action, Rect area, ScrollbarState state) {
+        if (area.isEmpty() || state.contentLength() == 0) {
+            if (action == ScrollbarAction.RELEASE && state.isDragging()) {
+                state.endDrag();
+                return true;
+            }
+            return false;
+        }
+
+        Rect trackArea = calculateTrackArea(area);
+        if (trackArea.isEmpty()) {
+            if (action == ScrollbarAction.RELEASE && state.isDragging()) {
+                state.endDrag();
+                return true;
+            }
+            return false;
+        }
+
+        int beginOffset = beginSymbol != null ? 1 : 0;
+        int endOffset = endSymbol != null ? 1 : 0;
+        int trackLength = (orientation.isVertical() ? trackArea.height() : trackArea.width()) - beginOffset - endOffset;
+        if (trackLength <= 0) {
+            if (action == ScrollbarAction.RELEASE && state.isDragging()) {
+                state.endDrag();
+                return true;
+            }
+            return false;
+        }
+
+        int mouseScrollPos;
+        int trackStart;
+        if (orientation.isVertical()) {
+            mouseScrollPos = mouseY;
+            trackStart = trackArea.y() + beginOffset;
+        } else {
+            mouseScrollPos = mouseX;
+            trackStart = trackArea.x() + beginOffset;
+        }
+
+        boolean inBounds = trackArea.contains(mouseX, mouseY);
+
+        if (action == ScrollbarAction.RELEASE) {
+            boolean wasDragging = state.isDragging();
+            state.endDrag();
+            return wasDragging || inBounds;
+        }
+
+        if (action == ScrollbarAction.DRAG && state.isDragging()) {
+            return handleDrag(mouseScrollPos, trackStart, trackLength, state);
+        }
+
+        if (!inBounds) {
+            return false;
+        }
+
+        if (action == ScrollbarAction.PRESS) {
+            if (beginOffset > 0 && mouseScrollPos < trackStart) {
+                state.prev();
+                return true;
+            }
+            int trackEnd = trackStart + trackLength;
+            if (endOffset > 0 && mouseScrollPos >= trackEnd) {
+                state.next();
+                return true;
+            }
+        }
+
+        switch (action) {
+            case PRESS:
+                return handlePress(mouseScrollPos, trackStart, trackLength, state);
+            case SCROLL_UP:
+                state.prev();
+                return true;
+            case SCROLL_DOWN:
+                state.next();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean handlePress(int mouseScrollPos, int trackStart, int trackLength, ScrollbarState state) {
+        int relativePos = mouseScrollPos - trackStart;
+        if (relativePos < 0 || relativePos >= trackLength) {
+            return false;
+        }
+
+        ThumbGeometry thumb = computeThumbGeometry(trackLength, state);
+
+        if (relativePos >= thumb.position && relativePos < thumb.position + thumb.size) {
+            state.startDrag(relativePos - thumb.position);
+            return true;
+        } else if (relativePos < thumb.position) {
+            state.pageUp();
+            return true;
+        } else {
+            state.pageDown();
+            return true;
+        }
+    }
+
+    private boolean handleDrag(int mouseScrollPos, int trackStart, int trackLength, ScrollbarState state) {
+        ThumbGeometry thumb = computeThumbGeometry(trackLength, state);
+
+        if (thumb.scrollableRange <= 0) {
+            return true;
+        }
+
+        int thumbRange = trackLength - thumb.size;
+        if (thumbRange <= 0) {
+            return true;
+        }
+
+        int relativePos = mouseScrollPos - trackStart;
+        double fraction = (double) (relativePos - state.dragOffset()) / thumbRange;
+        fraction = Math.max(0.0, Math.min(1.0, fraction));
+        int newPosition = (int) Math.round(fraction * thumb.scrollableRange);
+        state.position(newPosition);
+        return true;
     }
 
     private void renderVertical(Buffer buffer, Rect area, String track, String thumb,
@@ -430,6 +570,47 @@ public final class Scrollbar implements StatefulWidget<ScrollbarState> {
         if (end != null) {
             buffer.setString(x + trackLength, y, end, endStyle);
         }
+    }
+
+    /**
+     * Computed thumb geometry for a given track length and scrollbar state.
+     * <p>
+     * This is the single source of truth used by both rendering and mouse hit-testing,
+     * ensuring that clicks always target the visually rendered thumb.
+     */
+    private static final class ThumbGeometry {
+        final int size;
+        final int position;
+        final int scrollableRange;
+
+        ThumbGeometry(int size, int position, int scrollableRange) {
+            this.size = size;
+            this.position = position;
+            this.scrollableRange = scrollableRange;
+        }
+    }
+
+    private ThumbGeometry computeThumbGeometry(int trackLength, ScrollbarState state) {
+        int contentLength = state.contentLength();
+        int viewportLength = state.viewportContentLength() > 0
+            ? state.viewportContentLength()
+            : trackLength;
+
+        int thumbSize = Math.max(1, (int) Math.ceil((double) viewportLength / contentLength * trackLength));
+        thumbSize = Math.min(thumbSize, trackLength);
+
+        int scrollableRange = contentLength - viewportLength;
+        int thumbPosition;
+        if (scrollableRange <= 0) {
+            thumbPosition = 0;
+        } else {
+            double scrollFraction = (double) state.position() / scrollableRange;
+            scrollFraction = Math.max(0.0, Math.min(1.0, scrollFraction));
+            int thumbRange = trackLength - thumbSize;
+            thumbPosition = (int) Math.round(scrollFraction * thumbRange);
+        }
+
+        return new ThumbGeometry(thumbSize, thumbPosition, scrollableRange);
     }
 
     private Rect calculateTrackArea(Rect area) {

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/ScrollbarAction.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/ScrollbarAction.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.widgets.scrollbar;
+
+/**
+ * Mouse actions that a {@link Scrollbar} can handle.
+ * <p>
+ * Consumers map their mouse events to these actions and pass them to
+ * {@link Scrollbar#handleMouseAction(int, int, ScrollbarAction, dev.tamboui.layout.Rect, ScrollbarState)}.
+ *
+ * <pre>{@code
+ * // Example mapping from a MouseEvent:
+ * ScrollbarAction action = null;
+ * switch (mouseEvent.kind()) {
+ *     case PRESS:
+ *         if (mouseEvent.isLeftButton()) action = ScrollbarAction.PRESS;
+ *         break;
+ *     case DRAG:
+ *         if (mouseEvent.isLeftButton()) action = ScrollbarAction.DRAG;
+ *         break;
+ *     case RELEASE:
+ *         action = ScrollbarAction.RELEASE;
+ *         break;
+ *     case SCROLL_UP:
+ *         action = ScrollbarAction.SCROLL_UP;
+ *         break;
+ *     case SCROLL_DOWN:
+ *         action = ScrollbarAction.SCROLL_DOWN;
+ *         break;
+ * }
+ * if (action != null) {
+ *     scrollbar.handleMouseAction(mouseEvent.x(), mouseEvent.y(), action, area, state);
+ * }
+ * }</pre>
+ *
+ * @see Scrollbar#handleMouseAction(int, int, ScrollbarAction, dev.tamboui.layout.Rect, ScrollbarState)
+ */
+public enum ScrollbarAction {
+
+    /**
+     * Left mouse button pressed.
+     * <p>
+     * When pressed on the thumb, initiates a drag. When pressed on the track
+     * above/before the thumb, pages up/left. When pressed below/after, pages down/right.
+     */
+    PRESS,
+
+    /**
+     * Mouse moved while the left button is held (drag).
+     * <p>
+     * Moves the thumb proportionally to the mouse position within the track.
+     * Drag events are consumed even when the mouse moves outside the scrollbar bounds,
+     * as long as a drag is in progress.
+     */
+    DRAG,
+
+    /**
+     * Mouse button released.
+     * <p>
+     * Ends any in-progress drag operation.
+     */
+    RELEASE,
+
+    /**
+     * Scroll wheel moved up (or left for horizontal scrollbars).
+     * <p>
+     * Scrolls the content by one position.
+     */
+    SCROLL_UP,
+
+    /**
+     * Scroll wheel moved down (or right for horizontal scrollbars).
+     * <p>
+     * Scrolls the content by one position.
+     */
+    SCROLL_DOWN
+}

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/ScrollbarState.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/scrollbar/ScrollbarState.java
@@ -33,6 +33,8 @@ public final class ScrollbarState {
     private int contentLength;
     private int position;
     private int viewportContentLength;
+    private boolean dragging;
+    private int dragOffset;
 
     /**
      * Creates a new scrollbar state with default values.
@@ -223,6 +225,29 @@ public final class ScrollbarState {
             return 0.0;
         }
         return (double) position / (contentLength - 1);
+    }
+
+    /**
+     * Returns whether a drag operation is currently in progress.
+     *
+     * @return true if the thumb is being dragged
+     */
+    public boolean isDragging() {
+        return dragging;
+    }
+
+    void startDrag(int offset) {
+        this.dragging = true;
+        this.dragOffset = offset;
+    }
+
+    int dragOffset() {
+        return dragOffset;
+    }
+
+    void endDrag() {
+        this.dragging = false;
+        this.dragOffset = 0;
     }
 
     private int clampPosition(int pos) {

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/scrollbar/ScrollbarMouseTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/scrollbar/ScrollbarMouseTest.java
@@ -1,0 +1,585 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.widgets.scrollbar;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.layout.Rect;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ScrollbarMouseTest {
+
+    @Nested
+    @DisplayName("Click-to-page")
+    class ClickToPage {
+
+        @Test
+        @DisplayName("Click above thumb pages up")
+        void clickAboveThumbPagesUp() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(40);
+        }
+
+        @Test
+        @DisplayName("Click below thumb pages down")
+        void clickBelowThumbPagesDown() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 9, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("Click on thumb starts drag without changing position")
+        void clickOnThumbStartsDrag() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.isDragging()).isTrue();
+            assertThat(state.position()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Click outside scrollbar area is not consumed")
+        void clickOutsideNotConsumed() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(2, 5, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isFalse();
+            assertThat(state.position()).isEqualTo(50);
+        }
+
+        @Test
+        @DisplayName("Click pages up repeatedly toward start")
+        void repeatedPageUp() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(15);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+            assertThat(state.position()).isEqualTo(5);
+            state.endDrag();
+
+            scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+            assertThat(state.position()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Click on thumb at end starts drag instead of page down")
+        void clickOnThumbAtEndStartsDrag() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            // At position >= scrollableRange (100-10=90), the thumb sits at the very
+            // bottom of the track, so a click there starts a drag rather than paging.
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(95);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 9, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.isDragging()).isTrue();
+            assertThat(state.position()).isEqualTo(95);
+        }
+
+        @Test
+        @DisplayName("Page down near end increases position within bounds")
+        void pageDownNearEnd() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            // Use a taller area (20 cells) so the thumb doesn't occupy the last cell.
+            // trackLength=20, thumbSize=ceil(10/100*20)=2, scrollableRange=90,
+            // thumbRange=18, position 85: fraction=85/90≈0.944, thumbPos=round(17.0)=17
+            // thumb at cells 17-18, click at y=19 is below the thumb → pageDown
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(85);
+            Rect area = new Rect(0, 0, 5, 20);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 19, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(95);
+        }
+    }
+
+    @Nested
+    @DisplayName("Drag-to-scroll")
+    class DragToScroll {
+
+        @Test
+        @DisplayName("Drag thumb moves position proportionally")
+        void dragMovesProportionally() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+            assertThat(state.isDragging()).isTrue();
+
+            scrollbar.handleMouseAction(4, 5, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("Drag to top of track scrolls to start")
+        void dragToTopScrollsToStart() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            state.startDrag(0);
+
+            scrollbar.handleMouseAction(4, 0, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Drag to bottom of track scrolls to end")
+        void dragToBottomScrollsToEnd() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            state.startDrag(0);
+
+            scrollbar.handleMouseAction(4, 9, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isEqualTo(90);
+        }
+
+        @Test
+        @DisplayName("Drag beyond track bounds is clamped")
+        void dragBeyondBoundsIsClamped() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            state.startDrag(0);
+
+            scrollbar.handleMouseAction(4, -5, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isEqualTo(0);
+
+            scrollbar.handleMouseAction(4, 20, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isEqualTo(90);
+        }
+
+        @Test
+        @DisplayName("Drag outside cross-axis still works while dragging")
+        void dragOutsideCrossAxisWorks() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            state.startDrag(0);
+
+            boolean consumed = scrollbar.handleMouseAction(0, 5, ScrollbarAction.DRAG, area, state);
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("Release ends drag")
+        void releaseEndsDrag() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+            assertThat(state.isDragging()).isTrue();
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.RELEASE, area, state);
+            assertThat(consumed).isTrue();
+            assertThat(state.isDragging()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Drag without prior press is not consumed")
+        void dragWithoutPressNotConsumed() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.DRAG, area, state);
+            assertThat(consumed).isFalse();
+            assertThat(state.position()).isEqualTo(50);
+        }
+    }
+
+    @Nested
+    @DisplayName("Scroll wheel")
+    class ScrollWheel {
+
+        @Test
+        @DisplayName("Scroll up within scrollbar scrolls up by one")
+        void scrollUpByOne() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.SCROLL_UP, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(49);
+        }
+
+        @Test
+        @DisplayName("Scroll down within scrollbar scrolls down by one")
+        void scrollDownByOne() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.SCROLL_DOWN, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(51);
+        }
+
+        @Test
+        @DisplayName("Scroll outside scrollbar is not consumed")
+        void scrollOutsideNotConsumed() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(2, 5, ScrollbarAction.SCROLL_UP, area, state);
+
+            assertThat(consumed).isFalse();
+            assertThat(state.position()).isEqualTo(50);
+        }
+    }
+
+    @Nested
+    @DisplayName("Horizontal orientation")
+    class HorizontalOrientation {
+
+        @Test
+        @DisplayName("Click before thumb on horizontal scrollbar pages left")
+        void clickBeforeThumbPagesLeft() {
+            Scrollbar scrollbar = Scrollbar.horizontal();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 10, 5);
+
+            boolean consumed = scrollbar.handleMouseAction(0, 4, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(40);
+        }
+
+        @Test
+        @DisplayName("Click after thumb on horizontal scrollbar pages right")
+        void clickAfterThumbPagesRight() {
+            Scrollbar scrollbar = Scrollbar.horizontal();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 10, 5);
+
+            boolean consumed = scrollbar.handleMouseAction(9, 4, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(60);
+        }
+
+        @Test
+        @DisplayName("Drag on horizontal scrollbar uses X axis")
+        void dragUsesXAxis() {
+            Scrollbar scrollbar = Scrollbar.horizontal();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 10, 5);
+
+            state.startDrag(0);
+
+            scrollbar.handleMouseAction(9, 4, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isEqualTo(90);
+        }
+
+        @Test
+        @DisplayName("Horizontal top scrollbar handles mouse on top edge")
+        void horizontalTopOnTopEdge() {
+            Scrollbar scrollbar = Scrollbar.builder()
+                .orientation(ScrollbarOrientation.HORIZONTAL_TOP)
+                .build();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 10, 5);
+
+            boolean consumed = scrollbar.handleMouseAction(5, 0, ScrollbarAction.SCROLL_DOWN, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(51);
+        }
+    }
+
+    @Nested
+    @DisplayName("Begin/end markers")
+    class BeginEndMarkers {
+
+        @Test
+        @DisplayName("Click on begin marker scrolls up by one")
+        void clickOnBeginMarker() {
+            Scrollbar scrollbar = Scrollbar.builder()
+                .orientation(ScrollbarOrientation.VERTICAL_RIGHT)
+                .beginSymbol("↑")
+                .endSymbol("↓")
+                .build();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(49);
+        }
+
+        @Test
+        @DisplayName("Click on end marker scrolls down by one")
+        void clickOnEndMarker() {
+            Scrollbar scrollbar = Scrollbar.builder()
+                .orientation(ScrollbarOrientation.VERTICAL_RIGHT)
+                .beginSymbol("↑")
+                .endSymbol("↓")
+                .build();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 9, ScrollbarAction.PRESS, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(51);
+        }
+
+        @Test
+        @DisplayName("Markers reduce effective track length for thumb calculation")
+        void markersReduceTrackLength() {
+            // Drag to the same absolute y position with and without markers.
+            // With markers (trackLength=8, thumbRange=7): fraction = 4/7 ≈ 0.571
+            // Without markers (trackLength=10, thumbRange=9): fraction = 5/9 ≈ 0.556
+            // The different track lengths produce different scroll positions.
+            Scrollbar withMarkers = Scrollbar.builder()
+                .orientation(ScrollbarOrientation.VERTICAL_RIGHT)
+                .beginSymbol("↑")
+                .endSymbol("↓")
+                .build();
+            Scrollbar noMarkers = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            state.startDrag(0);
+            withMarkers.handleMouseAction(4, 5, ScrollbarAction.DRAG, area, state);
+            int posWithMarkers = state.position();
+            state.endDrag();
+
+            state.position(0);
+            state.startDrag(0);
+            noMarkers.handleMouseAction(4, 5, ScrollbarAction.DRAG, area, state);
+            int posWithout = state.position();
+            state.endDrag();
+
+            assertThat(posWithMarkers).isNotEqualTo(posWithout);
+        }
+    }
+
+    @Nested
+    @DisplayName("Vertical left orientation")
+    class VerticalLeft {
+
+        @Test
+        @DisplayName("Click on left-aligned scrollbar uses left edge")
+        void clickUsesLeftEdge() {
+            Scrollbar scrollbar = Scrollbar.builder()
+                .orientation(ScrollbarOrientation.VERTICAL_LEFT)
+                .build();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 10, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(0, 5, ScrollbarAction.SCROLL_DOWN, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(51);
+        }
+
+        @Test
+        @DisplayName("Click on wrong edge of left-aligned scrollbar is not consumed")
+        void clickOnWrongEdge() {
+            Scrollbar scrollbar = Scrollbar.builder()
+                .orientation(ScrollbarOrientation.VERTICAL_LEFT)
+                .build();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 10, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(9, 5, ScrollbarAction.SCROLL_DOWN, area, state);
+
+            assertThat(consumed).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("Empty area returns false")
+        void emptyArea() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100);
+            Rect area = new Rect(0, 0, 0, 0);
+
+            boolean consumed = scrollbar.handleMouseAction(0, 0, ScrollbarAction.PRESS, area, state);
+            assertThat(consumed).isFalse();
+        }
+
+        @Test
+        @DisplayName("Zero content length returns false")
+        void zeroContent() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.PRESS, area, state);
+            assertThat(consumed).isFalse();
+        }
+
+        @Test
+        @DisplayName("Content fits viewport does not change position on drag")
+        void contentFitsViewport() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(5)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            state.startDrag(0);
+            scrollbar.handleMouseAction(4, 5, ScrollbarAction.DRAG, area, state);
+
+            assertThat(state.position()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Release when not dragging returns false outside bounds")
+        void releaseNotDraggingOutside() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(0, 0, ScrollbarAction.RELEASE, area, state);
+
+            assertThat(consumed).isFalse();
+        }
+
+        @Test
+        @DisplayName("Release when not dragging returns true inside bounds")
+        void releaseNotDraggingInside() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.RELEASE, area, state);
+
+            assertThat(consumed).isTrue();
+        }
+
+        @Test
+        @DisplayName("Release during drag with zero content ends drag")
+        void releaseWithZeroContentEndsDrag() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(0);
+            state.startDrag(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(4, 5, ScrollbarAction.RELEASE, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.isDragging()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Non-zero offset area works correctly")
+        void nonZeroOffsetArea() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100).position(50);
+            Rect area = new Rect(10, 5, 5, 10);
+
+            boolean consumed = scrollbar.handleMouseAction(14, 10, ScrollbarAction.SCROLL_DOWN, area, state);
+
+            assertThat(consumed).isTrue();
+            assertThat(state.position()).isEqualTo(51);
+        }
+
+        @Test
+        @DisplayName("Full drag sequence: press, drag, release")
+        void fullDragSequence() {
+            Scrollbar scrollbar = Scrollbar.vertical();
+            ScrollbarState state = new ScrollbarState(100)
+                .viewportContentLength(10)
+                .position(0);
+            Rect area = new Rect(0, 0, 5, 10);
+
+            scrollbar.handleMouseAction(4, 0, ScrollbarAction.PRESS, area, state);
+            assertThat(state.isDragging()).isTrue();
+            assertThat(state.position()).isEqualTo(0);
+
+            scrollbar.handleMouseAction(4, 4, ScrollbarAction.DRAG, area, state);
+            int midPosition = state.position();
+            assertThat(midPosition).isGreaterThan(0);
+            assertThat(midPosition).isLessThan(90);
+
+            scrollbar.handleMouseAction(4, 9, ScrollbarAction.DRAG, area, state);
+            assertThat(state.position()).isEqualTo(90);
+
+            scrollbar.handleMouseAction(4, 9, ScrollbarAction.RELEASE, area, state);
+            assertThat(state.isDragging()).isFalse();
+            assertThat(state.position()).isEqualTo(90);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds mouse interaction support to the `Scrollbar` widget, enabling click-to-page and drag-to-scroll functionality for both vertical and horizontal scrollbars.

_Claude Code on behalf of Guillaume Nodet_

### New files
- **`ScrollbarAction.java`** — Enum of mouse actions (`PRESS`, `DRAG`, `RELEASE`, `SCROLL_UP`, `SCROLL_DOWN`) that consumers map from their mouse events. Includes a Javadoc example showing `MouseEvent` → `ScrollbarAction` mapping.
- **`ScrollbarMouseTest.java`** — 29 unit tests across 7 groups covering all mouse interaction scenarios.

### Modified files
- **`Scrollbar.java`** — Added `handleMouseAction(int mouseX, int mouseY, ScrollbarAction action, Rect area, ScrollbarState state)` public method with:
  - Click on track before thumb → `pageUp()`
  - Click on track after thumb → `pageDown()`
  - Click on thumb → start drag
  - Drag → proportional thumb movement using inverse mapping from render formula
  - Release → end drag (consumed even outside bounds while dragging)
  - Scroll wheel → `prev()` / `next()`
  - Click on begin/end marker arrows → `prev()` / `next()`
  - Private `computeThumbGeometry()` helper — single source of truth for thumb size/position, shared by `render()`, `handlePress()`, and `handleDrag()`
- **`ScrollbarState.java`** — Added drag state tracking (`isDragging()`, package-private `startDrag()`/`endDrag()`/`dragOffset()`).

### Design decisions
- **No dependency on `tamboui-tui`**: Uses raw coordinates + `ScrollbarAction` enum instead of `MouseEvent` to avoid a circular dependency (`tui` → `widgets` → `tui`). Consumers map `MouseEvent` to `ScrollbarAction` at the call site.
- **Consistent thumb geometry**: `computeThumbGeometry()` is the single source of truth used by both rendering and mouse hit-testing, ensuring clicks always target the visually rendered thumb.
- **Drag outside bounds**: Drag events are consumed even when the mouse moves outside the scrollbar area, matching native scrollbar behavior.
- **RELEASE always ends drag**: RELEASE during an active drag is handled at every early-return point (empty area, zero content, small track), preventing a stuck drag after terminal resize.

## Test plan
- [x] 29 unit tests in `ScrollbarMouseTest` covering:
  - Click-to-page (up, down, multiple pages, near-end behavior, thumb-at-end drag)
  - Drag-to-scroll (proportional movement, drag outside bounds, full drag sequence, release without drag)
  - Scroll wheel (up, down)
  - Horizontal orientation (page left/right, horizontal drag)
  - Begin/end markers (click begin arrow, click end arrow, markers affect effective track length)
  - Vertical left orientation
  - Edge cases (empty area, zero content, content fits viewport, out of bounds, drag without press, release when not dragging, small track, position clamping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)