### PR TITLE
feat: add horizontal scroll wheel events (SCROLL_LEFT/SCROLL_RIGHT)

### DIFF
--- a/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/Actions.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/Actions.java
@@ -135,6 +135,16 @@ public final class Actions {
      */
     public static final String SCROLL_DOWN = "scrollDown";
 
+    /**
+     * Scroll left (horizontal/tilt scroll wheel left).
+     */
+    public static final String SCROLL_LEFT = "scrollLeft";
+
+    /**
+     * Scroll right (horizontal/tilt scroll wheel right).
+     */
+    public static final String SCROLL_RIGHT = "scrollRight";
+
     // Debug / Development
     /**
      * Toggle the debug overlay.

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/BindingSets.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/BindingSets.java
@@ -205,6 +205,10 @@ public final class BindingSets {
         map.put("scroll_up", MouseEventKind.SCROLL_UP);
         map.put("scrolldown", MouseEventKind.SCROLL_DOWN);
         map.put("scroll_down", MouseEventKind.SCROLL_DOWN);
+        map.put("scrollleft", MouseEventKind.SCROLL_LEFT);
+        map.put("scroll_left", MouseEventKind.SCROLL_LEFT);
+        map.put("scrollright", MouseEventKind.SCROLL_RIGHT);
+        map.put("scroll_right", MouseEventKind.SCROLL_RIGHT);
         return map;
     }
 

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/MouseTrigger.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/MouseTrigger.java
@@ -160,6 +160,24 @@ public final class MouseTrigger implements InputTrigger {
     }
 
     /**
+     * Creates a trigger for scroll wheel left (horizontal/tilt wheel).
+     *
+     * @return a trigger that matches scroll left
+     */
+    public static MouseTrigger scrollLeft() {
+        return new MouseTrigger(MouseEventKind.SCROLL_LEFT, MouseButton.NONE, false, false, false);
+    }
+
+    /**
+     * Creates a trigger for scroll wheel right (horizontal/tilt wheel).
+     *
+     * @return a trigger that matches scroll right
+     */
+    public static MouseTrigger scrollRight() {
+        return new MouseTrigger(MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, false, false, false);
+    }
+
+    /**
      * Creates a trigger for a drag event.
      *
      * @param button the button held during drag

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
@@ -416,9 +416,17 @@ public final class EventParser {
         int button = buttonCode & ~(4 | 8 | 16);
 
         // Determine event kind and button
-        if (button >= 64 && button <= 65) {
-            // Scroll wheel
-            MouseEventKind kind = (button == 64) ? MouseEventKind.SCROLL_UP : MouseEventKind.SCROLL_DOWN;
+        if (button >= 64 && button <= 67) {
+            MouseEventKind kind;
+            if (button == 65) {
+                kind = MouseEventKind.SCROLL_DOWN;
+            } else if (button == 66) {
+                kind = MouseEventKind.SCROLL_LEFT;
+            } else if (button == 67) {
+                kind = MouseEventKind.SCROLL_RIGHT;
+            } else {
+                kind = MouseEventKind.SCROLL_UP;
+            }
             return new MouseEvent(kind, MouseButton.NONE, x, y, mods, bindings);
         }
 

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEvent.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEvent.java
@@ -175,6 +175,28 @@ public final class MouseEvent implements Event {
     }
 
     /**
+     * Creates a scroll left event (horizontal/tilt wheel).
+     *
+     * @param x x coordinate
+     * @param y y coordinate
+     * @return mouse event
+     */
+    public static MouseEvent scrollLeft(int x, int y) {
+        return new MouseEvent(MouseEventKind.SCROLL_LEFT, MouseButton.NONE, x, y, KeyModifiers.NONE);
+    }
+
+    /**
+     * Creates a scroll right event (horizontal/tilt wheel).
+     *
+     * @param x x coordinate
+     * @param y y coordinate
+     * @return mouse event
+     */
+    public static MouseEvent scrollRight(int x, int y) {
+        return new MouseEvent(MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, x, y, KeyModifiers.NONE);
+    }
+
+    /**
      * Returns true if this is a press event.
      *
      * @return true if this is a mouse press event
@@ -211,12 +233,13 @@ public final class MouseEvent implements Event {
     }
 
     /**
-     * Returns true if this is a scroll event.
+     * Returns true if this is a scroll event (vertical or horizontal).
      *
-     * @return true if this is a scroll-up or scroll-down event
+     * @return true if this is a scroll event
      */
     public boolean isScroll() {
-        return kind == MouseEventKind.SCROLL_UP || kind == MouseEventKind.SCROLL_DOWN;
+        return kind == MouseEventKind.SCROLL_UP || kind == MouseEventKind.SCROLL_DOWN
+                || kind == MouseEventKind.SCROLL_LEFT || kind == MouseEventKind.SCROLL_RIGHT;
     }
 
     /**

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEventKind.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEventKind.java
@@ -24,5 +24,11 @@ public enum MouseEventKind {
     SCROLL_UP,
 
     /** Scroll wheel was scrolled down. */
-    SCROLL_DOWN
+    SCROLL_DOWN,
+
+    /** Scroll wheel was scrolled left (horizontal/tilt wheel). */
+    SCROLL_LEFT,
+
+    /** Scroll wheel was scrolled right (horizontal/tilt wheel). */
+    SCROLL_RIGHT
 }

--- a/tamboui-tui/src/main/resources/dev/tamboui/tui/bindings/standard.properties
+++ b/tamboui-tui/src/main/resources/dev/tamboui/tui/bindings/standard.properties
@@ -32,9 +32,11 @@ quit = q, Q, Ctrl+c
 # Mouse
 click = Mouse.Left.Press
 rightClick = Mouse.Right.Press
-scroll = Mouse.ScrollUp, Mouse.ScrollDown
+scroll = Mouse.ScrollUp, Mouse.ScrollDown, Mouse.ScrollLeft, Mouse.ScrollRight
 scrollUp = Mouse.ScrollUp
 scrollDown = Mouse.ScrollDown
+scrollLeft = Mouse.ScrollLeft
+scrollRight = Mouse.ScrollRight
 
 # Debug / Development
 toggleDebugOverlay = Ctrl+Shift+F12


### PR DESCRIPTION
## Summary

- Add `SCROLL_LEFT` and `SCROLL_RIGHT` to `MouseEventKind` for horizontal mouse scroll events
- Parse SGR mouse protocol button codes 66 (left) and 67 (right) in `EventParser`
- Add factory methods, triggers, actions, and default bindings for the new scroll directions
- Update `MouseEvent.isScroll()` to include horizontal events

This enables terminals with tilt wheels or trackpads (e.g., macOS) to send horizontal scroll events, which is useful for horizontally scrollable content like diagrams.

## Files changed

| File | Change |
|------|--------|
| `MouseEventKind.java` | Add `SCROLL_LEFT`, `SCROLL_RIGHT` enum values |
| `EventParser.java` | Parse button codes 66/67 alongside 64/65 |
| `MouseEvent.java` | Add `scrollLeft()`/`scrollRight()` factories, update `isScroll()` |
| `MouseTrigger.java` | Add `scrollLeft()`/`scrollRight()` trigger factories |
| `Actions.java` | Add `SCROLL_LEFT`/`SCROLL_RIGHT` action constants |
| `BindingSets.java` | Register `scrollleft`/`scrollright` kind aliases |
| `standard.properties` | Add default bindings for horizontal scroll actions |

## Test plan

- [x] All 212 existing tests pass
- [ ] Manual test with a tilt-wheel mouse or trackpad horizontal scroll gesture

_Claude Code on behalf of Guillaume Nodet_