### PR TITLE
feat: add horizontal scroll wheel events (SCROLL_LEFT/SCROLL_RIGHT)

### DIFF
--- a/tamboui-tui/demos/tui-demo/src/main/java/dev/tamboui/demo/TuiDemo.java
+++ b/tamboui-tui/demos/tui-demo/src/main/java/dev/tamboui/demo/TuiDemo.java
@@ -187,6 +187,8 @@ public class TuiDemo {
             case MOVE -> "Mouse move";
             case SCROLL_UP -> "Scroll up";
             case SCROLL_DOWN -> "Scroll down";
+            case SCROLL_LEFT -> "Scroll left";
+            case SCROLL_RIGHT -> "Scroll right";
         };
 
         logEvent(eventName + " at (" + m.x() + "," + m.y() + ")");

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/Actions.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/Actions.java
@@ -135,6 +135,16 @@ public final class Actions {
      */
     public static final String SCROLL_DOWN = "scrollDown";
 
+    /**
+     * Scroll left (mouse horizontal scroll wheel left or trackpad gesture).
+     */
+    public static final String SCROLL_LEFT = "scrollLeft";
+
+    /**
+     * Scroll right (mouse horizontal scroll wheel right or trackpad gesture).
+     */
+    public static final String SCROLL_RIGHT = "scrollRight";
+
     // Debug / Development
     /**
      * Toggle the debug overlay.

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/BindingSets.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/BindingSets.java
@@ -205,6 +205,10 @@ public final class BindingSets {
         map.put("scroll_up", MouseEventKind.SCROLL_UP);
         map.put("scrolldown", MouseEventKind.SCROLL_DOWN);
         map.put("scroll_down", MouseEventKind.SCROLL_DOWN);
+        map.put("scrollleft", MouseEventKind.SCROLL_LEFT);
+        map.put("scroll_left", MouseEventKind.SCROLL_LEFT);
+        map.put("scrollright", MouseEventKind.SCROLL_RIGHT);
+        map.put("scroll_right", MouseEventKind.SCROLL_RIGHT);
         return map;
     }
 
@@ -237,7 +241,7 @@ public final class BindingSets {
      * <ul>
      *   <li>Format: [Modifiers+]Mouse.Button.Kind</li>
      *   <li>Buttons: Left, Right, Middle</li>
-     *   <li>Kinds: Press, Release, Drag, ScrollUp, ScrollDown</li>
+     *   <li>Kinds: Press, Release, Drag, ScrollUp, ScrollDown, ScrollLeft, ScrollRight</li>
      *   <li>Example: Ctrl+Mouse.Left.Press</li>
      * </ul>
      *

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/MouseTrigger.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/bindings/MouseTrigger.java
@@ -15,7 +15,7 @@ import dev.tamboui.tui.event.MouseEventKind;
  * <p>
  * Mouse triggers can match combinations of:
  * <ul>
- *   <li>Event kind (PRESS, RELEASE, SCROLL_UP, SCROLL_DOWN, etc.)</li>
+ *   <li>Event kind (PRESS, RELEASE, SCROLL_UP, SCROLL_DOWN, SCROLL_LEFT, SCROLL_RIGHT, etc.)</li>
  *   <li>Button (LEFT, RIGHT, MIDDLE)</li>
  *   <li>Keyboard modifiers (Ctrl, Alt, Shift held during mouse action)</li>
  * </ul>
@@ -157,6 +157,24 @@ public final class MouseTrigger implements InputTrigger {
      */
     public static MouseTrigger scrollDown() {
         return new MouseTrigger(MouseEventKind.SCROLL_DOWN, MouseButton.NONE, false, false, false);
+    }
+
+    /**
+     * Creates a trigger for scroll wheel left (horizontal tilt wheel or trackpad gesture).
+     *
+     * @return a trigger that matches scroll left
+     */
+    public static MouseTrigger scrollLeft() {
+        return new MouseTrigger(MouseEventKind.SCROLL_LEFT, MouseButton.NONE, false, false, false);
+    }
+
+    /**
+     * Creates a trigger for scroll wheel right (horizontal tilt wheel or trackpad gesture).
+     *
+     * @return a trigger that matches scroll right
+     */
+    public static MouseTrigger scrollRight() {
+        return new MouseTrigger(MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, false, false, false);
     }
 
     /**

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
@@ -416,9 +416,23 @@ public final class EventParser {
         int button = buttonCode & ~(4 | 8 | 16);
 
         // Determine event kind and button
-        if (button >= 64 && button <= 65) {
-            // Scroll wheel
-            MouseEventKind kind = (button == 64) ? MouseEventKind.SCROLL_UP : MouseEventKind.SCROLL_DOWN;
+        if (button >= 64 && button <= 67) {
+            // Scroll wheel: 64=up, 65=down, 66=left, 67=right
+            MouseEventKind kind;
+            switch (button) {
+                case 64:
+                    kind = MouseEventKind.SCROLL_UP;
+                    break;
+                case 65:
+                    kind = MouseEventKind.SCROLL_DOWN;
+                    break;
+                case 66:
+                    kind = MouseEventKind.SCROLL_LEFT;
+                    break;
+                default:
+                    kind = MouseEventKind.SCROLL_RIGHT;
+                    break;
+            }
             return new MouseEvent(kind, MouseButton.NONE, x, y, mods, bindings);
         }
 

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEvent.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEvent.java
@@ -175,6 +175,28 @@ public final class MouseEvent implements Event {
     }
 
     /**
+     * Creates a scroll left event.
+     *
+     * @param x x coordinate
+     * @param y y coordinate
+     * @return mouse event
+     */
+    public static MouseEvent scrollLeft(int x, int y) {
+        return new MouseEvent(MouseEventKind.SCROLL_LEFT, MouseButton.NONE, x, y, KeyModifiers.NONE);
+    }
+
+    /**
+     * Creates a scroll right event.
+     *
+     * @param x x coordinate
+     * @param y y coordinate
+     * @return mouse event
+     */
+    public static MouseEvent scrollRight(int x, int y) {
+        return new MouseEvent(MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, x, y, KeyModifiers.NONE);
+    }
+
+    /**
      * Returns true if this is a press event.
      *
      * @return true if this is a mouse press event
@@ -211,12 +233,15 @@ public final class MouseEvent implements Event {
     }
 
     /**
-     * Returns true if this is a scroll event.
+     * Returns true if this is a scroll event (up, down, left, or right).
      *
-     * @return true if this is a scroll-up or scroll-down event
+     * @return true if this is any scroll event
      */
     public boolean isScroll() {
-        return kind == MouseEventKind.SCROLL_UP || kind == MouseEventKind.SCROLL_DOWN;
+        return kind == MouseEventKind.SCROLL_UP
+            || kind == MouseEventKind.SCROLL_DOWN
+            || kind == MouseEventKind.SCROLL_LEFT
+            || kind == MouseEventKind.SCROLL_RIGHT;
     }
 
     /**

--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEventKind.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/MouseEventKind.java
@@ -24,5 +24,11 @@ public enum MouseEventKind {
     SCROLL_UP,
 
     /** Scroll wheel was scrolled down. */
-    SCROLL_DOWN
+    SCROLL_DOWN,
+
+    /** Scroll wheel was scrolled left (horizontal tilt wheel or trackpad gesture). */
+    SCROLL_LEFT,
+
+    /** Scroll wheel was scrolled right (horizontal tilt wheel or trackpad gesture). */
+    SCROLL_RIGHT
 }

--- a/tamboui-tui/src/main/resources/dev/tamboui/tui/bindings/standard.properties
+++ b/tamboui-tui/src/main/resources/dev/tamboui/tui/bindings/standard.properties
@@ -32,9 +32,11 @@ quit = q, Q, Ctrl+c
 # Mouse
 click = Mouse.Left.Press
 rightClick = Mouse.Right.Press
-scroll = Mouse.ScrollUp, Mouse.ScrollDown
+scroll = Mouse.ScrollUp, Mouse.ScrollDown, Mouse.ScrollLeft, Mouse.ScrollRight
 scrollUp = Mouse.ScrollUp
 scrollDown = Mouse.ScrollDown
+scrollLeft = Mouse.ScrollLeft
+scrollRight = Mouse.ScrollRight
 
 # Debug / Development
 toggleDebugOverlay = Ctrl+Shift+F12

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/bindings/BindingsLoadTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/bindings/BindingsLoadTest.java
@@ -264,6 +264,19 @@ class BindingsLoadTest {
     }
 
     @Test
+    @DisplayName("Parse horizontal mouse scroll bindings")
+    void parseHorizontalMouseScrollBindings() throws IOException {
+        String props = "scrollLeft = Mouse.ScrollLeft\nscrollRight = Mouse.ScrollRight\n";
+        Bindings bindings = BindingSets.load(new ByteArrayInputStream(props.getBytes(StandardCharsets.UTF_8)));
+
+        MouseEvent scrollLeft = new MouseEvent(MouseEventKind.SCROLL_LEFT, MouseButton.NONE, 0, 0, KeyModifiers.NONE, bindings);
+        MouseEvent scrollRight = new MouseEvent(MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, 0, 0, KeyModifiers.NONE, bindings);
+
+        assertThat(scrollLeft.matches(Actions.SCROLL_LEFT)).isTrue();
+        assertThat(scrollRight.matches(Actions.SCROLL_RIGHT)).isTrue();
+    }
+
+    @Test
     @DisplayName("Parse Ctrl+mouse click binding")
     void parseCtrlMouseClickBinding() throws IOException {
         String props = "customClick = Ctrl+Mouse.Left.Press\n";

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/bindings/BindingsTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/bindings/BindingsTest.java
@@ -360,6 +360,54 @@ class BindingsTest {
     }
 
     @Test
+    @DisplayName("Scroll left trigger matches scroll left event")
+    void scrollLeftTriggerMatchesScrollLeftEvent() {
+        MouseTrigger trigger = MouseTrigger.scrollLeft();
+        MouseEvent scrollLeft = new MouseEvent(
+            MouseEventKind.SCROLL_LEFT, MouseButton.NONE, 10, 20, KeyModifiers.NONE);
+
+        assertThat(trigger.matches(scrollLeft)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Scroll right trigger matches scroll right event")
+    void scrollRightTriggerMatchesScrollRightEvent() {
+        MouseTrigger trigger = MouseTrigger.scrollRight();
+        MouseEvent scrollRight = new MouseEvent(
+            MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, 10, 20, KeyModifiers.NONE);
+
+        assertThat(trigger.matches(scrollRight)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Scroll left and right actions match in standard bindings")
+    void scrollLeftAndRightActionsMatchInStandardBindings() {
+        Bindings bindings = BindingSets.standard();
+
+        MouseEvent scrollLeft = new MouseEvent(
+            MouseEventKind.SCROLL_LEFT, MouseButton.NONE, 0, 0, KeyModifiers.NONE, bindings);
+        MouseEvent scrollRight = new MouseEvent(
+            MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, 0, 0, KeyModifiers.NONE, bindings);
+
+        assertThat(scrollLeft.matches(Actions.SCROLL_LEFT)).isTrue();
+        assertThat(scrollRight.matches(Actions.SCROLL_RIGHT)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Horizontal scroll events match the generic scroll action")
+    void horizontalScrollMatchesGenericScrollAction() {
+        Bindings bindings = BindingSets.standard();
+
+        MouseEvent scrollLeft = new MouseEvent(
+            MouseEventKind.SCROLL_LEFT, MouseButton.NONE, 0, 0, KeyModifiers.NONE, bindings);
+        MouseEvent scrollRight = new MouseEvent(
+            MouseEventKind.SCROLL_RIGHT, MouseButton.NONE, 0, 0, KeyModifiers.NONE, bindings);
+
+        assertThat(scrollLeft.matches(Actions.SCROLL)).isTrue();
+        assertThat(scrollRight.matches(Actions.SCROLL)).isTrue();
+    }
+
+    @Test
     @DisplayName("Drag trigger matches drag events")
     void dragTriggerMatchesDragEvents() {
         MouseTrigger trigger = MouseTrigger.drag(MouseButton.LEFT);

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/EventParserTest.java
@@ -255,6 +255,87 @@ class EventParserTest {
         assertThat(((KeyEvent) event).code()).isEqualTo(KeyCode.UP);
     }
 
+    // -- SGR mouse scroll events --
+
+    @Test
+    @DisplayName("SGR mouse button code 64 parsed as SCROLL_UP")
+    void sgrScrollUpParsed() throws IOException {
+        // ESC [ < 64 ; 10 ; 5 M
+        QueueBackend backend = new QueueBackend(
+            27, '[', '<', '6', '4', ';', '1', '0', ';', '5', 'M');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(MouseEvent.class);
+        MouseEvent mouse = (MouseEvent) event;
+        assertThat(mouse.kind()).isEqualTo(MouseEventKind.SCROLL_UP);
+        assertThat(mouse.x()).isEqualTo(9);
+        assertThat(mouse.y()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("SGR mouse button code 65 parsed as SCROLL_DOWN")
+    void sgrScrollDownParsed() throws IOException {
+        // ESC [ < 65 ; 10 ; 5 M
+        QueueBackend backend = new QueueBackend(
+            27, '[', '<', '6', '5', ';', '1', '0', ';', '5', 'M');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(MouseEvent.class);
+        MouseEvent mouse = (MouseEvent) event;
+        assertThat(mouse.kind()).isEqualTo(MouseEventKind.SCROLL_DOWN);
+        assertThat(mouse.x()).isEqualTo(9);
+        assertThat(mouse.y()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("SGR mouse button code 66 parsed as SCROLL_LEFT")
+    void sgrScrollLeftParsed() throws IOException {
+        // ESC [ < 66 ; 10 ; 5 M
+        QueueBackend backend = new QueueBackend(
+            27, '[', '<', '6', '6', ';', '1', '0', ';', '5', 'M');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(MouseEvent.class);
+        MouseEvent mouse = (MouseEvent) event;
+        assertThat(mouse.kind()).isEqualTo(MouseEventKind.SCROLL_LEFT);
+        assertThat(mouse.x()).isEqualTo(9);
+        assertThat(mouse.y()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("SGR mouse button code 67 parsed as SCROLL_RIGHT")
+    void sgrScrollRightParsed() throws IOException {
+        // ESC [ < 67 ; 10 ; 5 M
+        QueueBackend backend = new QueueBackend(
+            27, '[', '<', '6', '7', ';', '1', '0', ';', '5', 'M');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(MouseEvent.class);
+        MouseEvent mouse = (MouseEvent) event;
+        assertThat(mouse.kind()).isEqualTo(MouseEventKind.SCROLL_RIGHT);
+        assertThat(mouse.x()).isEqualTo(9);
+        assertThat(mouse.y()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("SGR horizontal scroll with Shift modifier")
+    void sgrHorizontalScrollWithShiftModifier() throws IOException {
+        // ESC [ < 70 ; 10 ; 5 M (66 + 4 = 70, Shift+ScrollLeft)
+        QueueBackend backend = new QueueBackend(
+            27, '[', '<', '7', '0', ';', '1', '0', ';', '5', 'M');
+
+        Event event = EventParser.readEvent(backend, 0);
+
+        assertThat(event).isInstanceOf(MouseEvent.class);
+        MouseEvent mouse = (MouseEvent) event;
+        assertThat(mouse.kind()).isEqualTo(MouseEventKind.SCROLL_LEFT);
+        assertThat(mouse.modifiers().shift()).isTrue();
+    }
+
     private static final class QueueBackend extends TestBackend {
 
         private final int[] input;

--- a/tamboui-tui/src/test/java/dev/tamboui/tui/event/MouseEventTest.java
+++ b/tamboui-tui/src/test/java/dev/tamboui/tui/event/MouseEventTest.java
@@ -73,6 +73,44 @@ class MouseEventTest {
     }
 
     @Test
+    @DisplayName("scrollLeft creates scroll left event")
+    void scrollLeftCreatesScrollLeftEvent() {
+        MouseEvent event = MouseEvent.scrollLeft(3, 4);
+        assertThat(event.kind()).isEqualTo(MouseEventKind.SCROLL_LEFT);
+        assertThat(event.button()).isEqualTo(MouseButton.NONE);
+        assertThat(event.x()).isEqualTo(3);
+        assertThat(event.y()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("scrollRight creates scroll right event")
+    void scrollRightCreatesScrollRightEvent() {
+        MouseEvent event = MouseEvent.scrollRight(9, 10);
+        assertThat(event.kind()).isEqualTo(MouseEventKind.SCROLL_RIGHT);
+        assertThat(event.button()).isEqualTo(MouseButton.NONE);
+        assertThat(event.x()).isEqualTo(9);
+        assertThat(event.y()).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("isScroll returns true for all scroll directions")
+    void isScrollReturnsTrueForAllScrollDirections() {
+        assertThat(MouseEvent.scrollUp(0, 0).isScroll()).isTrue();
+        assertThat(MouseEvent.scrollDown(0, 0).isScroll()).isTrue();
+        assertThat(MouseEvent.scrollLeft(0, 0).isScroll()).isTrue();
+        assertThat(MouseEvent.scrollRight(0, 0).isScroll()).isTrue();
+    }
+
+    @Test
+    @DisplayName("isScroll returns false for non-scroll events")
+    void isScrollReturnsFalseForNonScrollEvents() {
+        assertThat(MouseEvent.press(MouseButton.LEFT, 0, 0).isScroll()).isFalse();
+        assertThat(MouseEvent.release(MouseButton.LEFT, 0, 0).isScroll()).isFalse();
+        assertThat(MouseEvent.move(0, 0).isScroll()).isFalse();
+        assertThat(MouseEvent.drag(MouseButton.LEFT, 0, 0).isScroll()).isFalse();
+    }
+
+    @Test
     @DisplayName("all mouse buttons supported")
     void allButtonsSupported() {
         assertThat(MouseEvent.press(MouseButton.LEFT, 0, 0).button()).isEqualTo(MouseButton.LEFT);


### PR DESCRIPTION
## Summary

Fixes #398

- Add `SCROLL_LEFT` and `SCROLL_RIGHT` to `MouseEventKind` for horizontal mouse scroll events from tilt wheels or trackpad gestures
- Parse SGR mouse protocol button codes 66 (left) and 67 (right) in `EventParser` alongside existing 64/65
- Add `scrollLeft()`/`scrollRight()` factory methods on `MouseEvent` and `MouseTrigger`
- Add `SCROLL_LEFT`/`SCROLL_RIGHT` action constants in `Actions`
- Register `scrollleft`/`scrollright` kind aliases in `BindingSets`
- Add default bindings for horizontal scroll actions in `standard.properties`
- Update `MouseEvent.isScroll()` to include horizontal scroll events

## Files changed

| File | Change |
|------|--------|
| `MouseEventKind.java` | Add `SCROLL_LEFT`, `SCROLL_RIGHT` enum values |
| `EventParser.java` | Parse button codes 66/67 alongside 64/65 |
| `MouseEvent.java` | Add `scrollLeft()`/`scrollRight()` factories, update `isScroll()` |
| `MouseTrigger.java` | Add `scrollLeft()`/`scrollRight()` trigger factories |
| `Actions.java` | Add `SCROLL_LEFT`/`SCROLL_RIGHT` action constants |
| `BindingSets.java` | Register `scrollleft`/`scrollright` kind aliases |
| `standard.properties` | Add default bindings for horizontal scroll actions |

## Test plan

- [x] All 226 existing + new tests pass
- [x] 12 new tests added covering:
  - `MouseEventTest`: `scrollLeft`/`scrollRight` factory methods, `isScroll()` for all 4 directions + non-scroll events
  - `EventParserTest`: SGR parsing for button codes 64-67 (scroll up/down/left/right) + horizontal scroll with Shift modifier
  - `BindingsTest`: scroll left/right triggers, actions, and generic scroll action matching
  - `BindingsLoadTest`: parsing horizontal scroll bindings from properties files
- [x] Javadoc generates without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)