### PR TITLE
feat(demos): add gourman maze game demo

### DIFF
--- a/demos/gourman-demo/build.gradle.kts
+++ b/demos/gourman-demo/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("dev.tamboui.demo-project")
+}
+
+description = "Gourman - a Pac-Man style maze game rendered on a canvas, with pluggable game-event listeners"
+
+demo {
+    displayName = "Gourman Maze Game"
+    tags = setOf("canvas", "game", "animation", "events")
+}
+
+dependencies {
+    implementation(projects.tambouiTui)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.bundles.testing)
+}
+
+application {
+    mainClass.set("dev.tamboui.demo.gourman.Gourman")
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Direction.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Direction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+/** The four movement directions on the maze grid. Rows grow downward, so UP is dy = -1. */
+public enum Direction {
+
+    /** Toward the top of the maze. */
+    UP(0, -1),
+    /** Toward the bottom of the maze. */
+    DOWN(0, 1),
+    /** Toward the left edge of the maze. */
+    LEFT(-1, 0),
+    /** Toward the right edge of the maze. */
+    RIGHT(1, 0);
+
+    private final int dx;
+    private final int dy;
+
+    Direction(int dx, int dy) {
+        this.dx = dx;
+        this.dy = dy;
+    }
+
+    /**
+     * The column delta of one step in this direction.
+     *
+     * @return -1, 0 or 1
+     */
+    public int dx() {
+        return dx;
+    }
+
+    /**
+     * The row delta of one step in this direction.
+     *
+     * @return -1, 0 or 1
+     */
+    public int dy() {
+        return dy;
+    }
+
+    /**
+     * The reverse of this direction.
+     *
+     * @return the opposite direction
+     */
+    public Direction opposite() {
+        switch (this) {
+        case UP:
+            return DOWN;
+        case DOWN:
+            return UP;
+        case LEFT:
+            return RIGHT;
+        default:
+            return LEFT;
+        }
+    }
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GameEvent.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GameEvent.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+/**
+ * An event emitted by {@link GourmanGame}. Every state change in a game publishes one: lifecycle
+ * (start, level, pause, game over), every actor move, every pellet, every score change. Consumers
+ * subscribe with {@link GourmanGame#addListener(GameListener)} and can forward the stream anywhere
+ * — a metrics sink, a replay log, or a message broker such as Kafka.
+ *
+ * <p>
+ * The hierarchy is sealed so consumers can switch over events exhaustively with pattern matching.
+ * Events are immutable records carrying tile coordinates ({@code column}/{@code row} on the 28x31
+ * maze grid) and are not timestamped: they are emitted synchronously as the change happens, so
+ * listeners stamp them with whatever clock their transport needs.
+ * </p>
+ */
+public sealed interface GameEvent {
+
+    /**
+     * A new game began (initial start or restart), with its starting level and lives.
+     *
+     * @param level the starting level
+     * @param lives the starting number of lives
+     */
+    record GameStarted(int level, int lives) implements GameEvent {
+    }
+
+    /**
+     * The READY pause ended and play began for the given level (also after each lost life).
+     *
+     * @param level the level now being played
+     */
+    record LevelStarted(int level) implements GameEvent {
+    }
+
+    /**
+     * Every pellet was eaten; the level is complete.
+     *
+     * @param level the level that was cleared
+     * @param score the score at clear time
+     */
+    record LevelCleared(int level, int score) implements GameEvent {
+    }
+
+    /**
+     * Gourman moved one tile.
+     *
+     * @param column the tile column moved to
+     * @param row the tile row moved to
+     * @param direction the direction of the step
+     */
+    record GourmanMoved(int column, int row, Direction direction) implements GameEvent {
+    }
+
+    /**
+     * Gourman ate a pellet; {@code remaining} counts pellets (of both kinds) left on the maze.
+     *
+     * @param column the tile column of the pellet
+     * @param row the tile row of the pellet
+     * @param remaining pellets (of both kinds) left on the maze
+     */
+    record PelletEaten(int column, int row, int remaining) implements GameEvent {
+    }
+
+    /**
+     * Gourman ate a power pellet; a {@link GhostsFrightened} event follows.
+     *
+     * @param column the tile column of the power pellet
+     * @param row the tile row of the power pellet
+     */
+    record PowerPelletEaten(int column, int row) implements GameEvent {
+    }
+
+    /**
+     * All roaming ghosts turned frightened for the given duration.
+     *
+     * @param durationSeconds how long the frightened period lasts
+     */
+    record GhostsFrightened(long durationSeconds) implements GameEvent {
+    }
+
+    /** The frightened period expired with ghosts still uneaten. */
+    record FrightenedEnded() implements GameEvent {
+    }
+
+    /**
+     * A ghost moved one tile.
+     *
+     * @param ghost the ghost that moved
+     * @param column the tile column moved to
+     * @param row the tile row moved to
+     * @param state the ghost state after the move
+     * @param frightened whether the ghost is currently frightened
+     */
+    record GhostMoved(Ghost.Kind ghost, int column, int row, Ghost.State state, boolean frightened)
+            implements GameEvent {
+    }
+
+    /**
+     * A ghost left the ghost house and started roaming.
+     *
+     * @param ghost the ghost that left the house
+     */
+    record GhostReleased(Ghost.Kind ghost) implements GameEvent {
+    }
+
+    /**
+     * Gourman ate a frightened ghost; {@code chain} counts ghosts eaten on this power pellet.
+     *
+     * @param ghost the ghost that was eaten
+     * @param points the points awarded
+     * @param chain how many ghosts this power pellet has claimed so far
+     */
+    record GhostEaten(Ghost.Kind ghost, int points, int chain) implements GameEvent {
+    }
+
+    /**
+     * An eaten ghost's eyes reached the ghost house and it will respawn.
+     *
+     * @param ghost the ghost whose eyes reached the house
+     */
+    record GhostReturned(Ghost.Kind ghost) implements GameEvent {
+    }
+
+    /**
+     * A ghost caught Gourman.
+     *
+     * @param livesRemaining lives left after this death
+     */
+    record GourmanDied(int livesRemaining) implements GameEvent {
+    }
+
+    /**
+     * The score changed by {@code points}, to {@code score}. Accompanies every scoring event.
+     *
+     * @param points the points just added
+     * @param score the new total score
+     */
+    record ScoreChanged(int points, int score) implements GameEvent {
+    }
+
+    /**
+     * The bonus life threshold was crossed.
+     *
+     * @param score the score that crossed the threshold
+     * @param lives the new number of lives
+     */
+    record ExtraLifeAwarded(int score, int lives) implements GameEvent {
+    }
+
+    /** The player paused the game. */
+    record GamePaused() implements GameEvent {
+    }
+
+    /** The player resumed the game. */
+    record GameResumed() implements GameEvent {
+    }
+
+    /**
+     * The last life was lost.
+     *
+     * @param score the final score
+     * @param level the level reached
+     */
+    record GameOver(int score, int level) implements GameEvent {
+    }
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GameListener.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GameListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+/**
+ * Receives every {@link GameEvent} a {@link GourmanGame} emits.
+ *
+ * <p>
+ * Register programmatically with {@link GourmanGame#addListener(GameListener)}, or ship an
+ * implementation on the classpath with a {@code META-INF/services/dev.tamboui.demo.gourman.GameListener}
+ * entry and the launcher discovers it via {@link java.util.ServiceLoader} — that is how an
+ * external publisher (e.g. one that forwards events to Kafka) plugs in without code changes.
+ * </p>
+ *
+ * <p>
+ * Listeners are invoked synchronously on the game loop thread, between frames. They must return
+ * quickly and never block: hand events to an async transport (a Kafka producer's send, a queue)
+ * instead of doing I/O inline. A listener that throws is skipped for that event; the game and the
+ * other listeners are unaffected.
+ * </p>
+ */
+@FunctionalInterface
+public interface GameListener {
+
+    /**
+     * Called for every event the game emits, in emission order.
+     *
+     * @param event the event that just happened
+     */
+    void onEvent(GameEvent event);
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Ghost.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Ghost.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import dev.tamboui.style.Color;
+
+/** One ghost: its identity (color, scatter corner, release delay) and its mutable position/state. */
+public final class Ghost {
+
+    /** The four ghosts. Scatter corners are just outside the maze, as in the arcade original. */
+    public enum Kind {
+
+        /** The red ghost: chases Gourman directly and is released immediately. */
+        BLINKY(Color.RED, Maze.COLUMNS - 3, -1, 0),
+        /** The pink ghost: ambushes four tiles ahead of Gourman. */
+        PINKY(Color.rgb(255, 184, 255), 2, -1, 2),
+        /** The cyan ghost: doubles Blinky's pincer vector. */
+        INKY(Color.CYAN, Maze.COLUMNS - 1, Maze.ROWS, 4),
+        /** The orange ghost: chases only while more than eight tiles away. */
+        CLYDE(Color.rgb(255, 184, 82), 0, Maze.ROWS, 6);
+
+        private final Color color;
+        private final int scatterColumn;
+        private final int scatterRow;
+        private final int releaseSeconds;
+
+        Kind(Color color, int scatterColumn, int scatterRow, int releaseSeconds) {
+            this.color = color;
+            this.scatterColumn = scatterColumn;
+            this.scatterRow = scatterRow;
+            this.releaseSeconds = releaseSeconds;
+        }
+
+        Color color() {
+            return color;
+        }
+
+        int scatterColumn() {
+            return scatterColumn;
+        }
+
+        int scatterRow() {
+            return scatterRow;
+        }
+
+        int releaseSeconds() {
+            return releaseSeconds;
+        }
+
+    }
+
+    /** Where a ghost is in its life cycle. */
+    public enum State {
+        /** Parked inside the ghost house, waiting for its release time. */
+        WAITING,
+        /** Roaming the maze (chasing, scattering or frightened). */
+        ACTIVE,
+        /** Eaten: only the eyes remain, racing back to the ghost house. */
+        EATEN
+    }
+
+    private final Kind kind;
+    private int column;
+    private int row;
+    private Direction direction = Direction.LEFT;
+    private State state = State.WAITING;
+    private boolean frightened;
+    private long nextMoveNanos;
+    private long releaseAtNanos;
+
+    Ghost(Kind kind) {
+        this.kind = kind;
+    }
+
+    Kind kind() {
+        return kind;
+    }
+
+    int column() {
+        return column;
+    }
+
+    int row() {
+        return row;
+    }
+
+    void position(int column, int row) {
+        this.column = column;
+        this.row = row;
+    }
+
+    Direction direction() {
+        return direction;
+    }
+
+    void direction(Direction direction) {
+        this.direction = direction;
+    }
+
+    State state() {
+        return state;
+    }
+
+    void state(State state) {
+        this.state = state;
+    }
+
+    boolean frightened() {
+        return frightened;
+    }
+
+    void frightened(boolean frightened) {
+        this.frightened = frightened;
+    }
+
+    long nextMoveNanos() {
+        return nextMoveNanos;
+    }
+
+    void nextMoveNanos(long nextMoveNanos) {
+        this.nextMoveNanos = nextMoveNanos;
+    }
+
+    long releaseAtNanos() {
+        return releaseAtNanos;
+    }
+
+    void releaseAtNanos(long releaseAtNanos) {
+        this.releaseAtNanos = releaseAtNanos;
+    }
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Gourman.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Gourman.java
@@ -1,0 +1,42 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS dev.tamboui:tamboui-tui:LATEST
+//DEPS dev.tamboui:tamboui-widgets:LATEST
+//DEPS dev.tamboui:tamboui-panama-backend:LATEST
+//DEPS dev.tamboui:tamboui-jline3-backend:LATEST
+//SOURCES GourmanGame.java GourmanException.java GameEvent.java GameListener.java Ghost.java Maze.java Direction.java
+
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import java.util.ServiceLoader;
+
+/**
+ * Entry point: launches the full-screen Gourman game. Run with {@code gourman/gourman}.
+ *
+ * <p>
+ * {@link GameListener} implementations found on the classpath via {@link ServiceLoader} (a
+ * {@code META-INF/services/dev.tamboui.demo.gourman.GameListener} entry) are subscribed before the
+ * game starts, so an external event publisher — e.g. one forwarding every {@link GameEvent} to
+ * Kafka — plugs in by just being on the classpath.
+ * </p>
+ */
+public final class Gourman {
+
+    private Gourman() {
+    }
+
+    /**
+     * Launches the game with every {@link ServiceLoader}-discovered listener subscribed.
+     *
+     * @param args ignored
+     */
+    public static void main(String[] args) {
+        GourmanGame game = new GourmanGame();
+        ServiceLoader.load(GameListener.class).forEach(game::addListener);
+        game.run();
+    }
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanException.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+/** Thrown when the game cannot start or the terminal backend fails. */
+public class GourmanException extends RuntimeException {
+
+    /**
+     * Creates the exception.
+     *
+     * @param message what failed
+     * @param cause the underlying failure
+     */
+    public GourmanException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanGame.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanGame.java
@@ -53,7 +53,8 @@ import dev.tamboui.widgets.paragraph.Paragraph;
  */
 public final class GourmanGame {
 
-    /** Creates a game; call {@link #run()} to start it. */
+    /** Creates a game; call {@link #run()} for the standalone loop or drive it with
+     * {@link #tick()}, {@link #handleKey(KeyEvent)} and {@link #boardCanvas(boolean)} to embed. */
     public GourmanGame() {
     }
 
@@ -102,6 +103,12 @@ public final class GourmanGame {
     private static final int CELL_PIXELS = 2;
     private static final int PIXELS_X = Maze.COLUMNS * CELL_PIXELS;
     private static final int PIXELS_Y = Maze.ROWS * CELL_PIXELS;
+    /** Exact character width the borderless {@link #boardCanvas(boolean)} widget requires. */
+    public static final int BOARD_WIDTH = Maze.COLUMNS * CELL_PIXELS;
+    /** Exact character height the borderless {@link #boardCanvas(boolean)} widget requires. */
+    public static final int BOARD_HEIGHT = Maze.ROWS;
+    /** Extra characters, per axis, that the bordered board adds around the borderless size. */
+    public static final int BOARD_BORDER = 2;
     private static final int BOARD_PANEL_WIDTH = PIXELS_X + 2;
     private static final int BOARD_PANEL_HEIGHT = Maze.ROWS + 2;
     private static final int SIDE_PANEL_WIDTH = 24;
@@ -176,8 +183,8 @@ public final class GourmanGame {
 
     // --- Game state ---
 
-    /** Starts a fresh game. Package-visible so tests can drive the game without a terminal. */
-    void newGame() {
+    /** Starts a fresh game: full pellets, starting lives, level 1. */
+    public void newGame() {
         maze.resetPellets();
         score = 0;
         lives = STARTING_LIVES;
@@ -222,7 +229,13 @@ public final class GourmanGame {
         return (long) (baseMillis * speedFactor() * Duration.ofMillis(1).toNanos());
     }
 
-    private void tick() {
+    /**
+     * Advances the game clock to now: movement, gravity of the mode schedule, phase changes.
+     * Call regularly (every 30-100ms) — the game catches up on wall-clock time, so the exact
+     * cadence only affects animation smoothness, not game speed. Used by embedding hosts that
+     * drive the game from their own event loop instead of {@link #run()}.
+     */
+    public void tick() {
         if (paused || phase == Phase.GAME_OVER) {
             return;
         }
@@ -475,7 +488,9 @@ public final class GourmanGame {
 
     private boolean handleEvent(Event event, TuiRunner runner) {
         if (event instanceof KeyEvent key) {
-            handleKey(key, runner);
+            if (handleKey(key)) {
+                runner.quit();
+            }
             return true;
         }
         if (event instanceof TickEvent) {
@@ -485,14 +500,21 @@ public final class GourmanGame {
         return false;
     }
 
-    private void handleKey(KeyEvent key, TuiRunner runner) {
+    /**
+     * Handles one key press (movement, pause, restart). Returns {@code true} when the player
+     * asked to quit the game — the standalone runner exits on it; an embedding host typically
+     * hides its game panel instead.
+     *
+     * @param key the pressed key
+     * @return whether the player asked to quit
+     */
+    public boolean handleKey(KeyEvent key) {
         if (key.isQuit() || key.isCharIgnoreCase('q')) {
-            runner.quit();
-            return;
+            return true;
         }
         if (key.isCharIgnoreCase('r')) {
             newGame();
-            return;
+            return false;
         }
         if (key.isCharIgnoreCase('p')) {
             boolean wasPaused = paused;
@@ -500,7 +522,7 @@ public final class GourmanGame {
             if (paused != wasPaused) {
                 publish(paused ? new GameEvent.GamePaused() : new GameEvent.GameResumed());
             }
-            return;
+            return false;
         }
         if (key.isLeft() || key.isCharIgnoreCase('h')) {
             desiredDirection = Direction.LEFT;
@@ -510,6 +532,18 @@ public final class GourmanGame {
             desiredDirection = Direction.UP;
         } else if (key.isDown() || key.isCharIgnoreCase('j')) {
             desiredDirection = Direction.DOWN;
+        }
+        return false;
+    }
+
+    /**
+     * Pauses play if a round is in progress (no-op otherwise). Embedding hosts call this when
+     * they hide the game panel so ghosts don't hunt an unattended Gourman; the p key resumes.
+     */
+    public void pause() {
+        if (!paused && phase == Phase.PLAYING) {
+            paused = true;
+            publish(new GameEvent.GamePaused());
         }
     }
 
@@ -558,8 +592,16 @@ public final class GourmanGame {
         frame.renderWidget(Paragraph.builder().text(Text.from(message)).build(), area);
     }
 
-    /** The board widget; package-visible so tests can render it headlessly into a buffer. */
-    Canvas boardCanvas(boolean bordered) {
+    /**
+     * The board as a plain widget, for embedding the game inside another TamboUI application
+     * (and for headless render tests). The widget must be given exactly {@code 56x31} characters
+     * ({@code 58x33} when {@code bordered}) — the canvas maps a fixed pixel grid onto its area,
+     * so any other size distorts the maze.
+     *
+     * @param bordered whether to wrap the board in its rounded, titled border
+     * @return the board widget
+     */
+    public Canvas boardCanvas(boolean bordered) {
         Color borderColor = phase == Phase.GAME_OVER ? Color.RED : Color.CYAN;
         Canvas.Builder builder = Canvas.builder()
                 // Bounds span [0, N-1] for N pixels so integer coordinates map 1:1 onto grid

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanGame.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanGame.java
@@ -160,6 +160,16 @@ public final class GourmanGame {
         listeners.add(Objects.requireNonNull(listener, "listener"));
     }
 
+    /**
+     * Unsubscribes a previously added listener; a host that shuts down its event transport while
+     * the game keeps running detaches it here. Unknown listeners are ignored.
+     *
+     * @param listener the listener to unsubscribe
+     */
+    public void removeListener(GameListener listener) {
+        listeners.remove(listener);
+    }
+
     private void publish(GameEvent event) {
         for (GameListener listener : listeners) {
             try {
@@ -590,6 +600,71 @@ public final class GourmanGame {
                 + " characters; this window is " + area.width() + "x" + area.height() + ".")));
         message.add(Line.from(Span.raw(" Enlarge the window or reduce the font size (Cmd -).").dim()));
         frame.renderWidget(Paragraph.builder().text(Text.from(message)).build(), area);
+    }
+
+    /**
+     * Resumes a round paused with {@link #pause()} or the p key (no-op otherwise). Embedding
+     * hosts call this when they show the game panel again.
+     */
+    public void resume() {
+        if (paused) {
+            paused = false;
+            publish(new GameEvent.GameResumed());
+        }
+    }
+
+    /**
+     * The current score.
+     *
+     * @return the score
+     */
+    public int score() {
+        return score;
+    }
+
+    /**
+     * The current level, starting at 1.
+     *
+     * @return the level
+     */
+    public int level() {
+        return level;
+    }
+
+    /**
+     * Lives remaining.
+     *
+     * @return the number of lives
+     */
+    public int lives() {
+        return lives;
+    }
+
+    /**
+     * Pellets (of both kinds) left on the maze.
+     *
+     * @return the pellet count
+     */
+    public int pelletsRemaining() {
+        return maze.pelletCount();
+    }
+
+    /**
+     * Whether play is currently paused.
+     *
+     * @return whether the game is paused
+     */
+    public boolean paused() {
+        return paused;
+    }
+
+    /**
+     * Whether the last life has been lost (the r key or {@link #newGame()} starts over).
+     *
+     * @return whether the game is over
+     */
+    public boolean gameOver() {
+        return phase == Phase.GAME_OVER;
     }
 
     /**

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanGame.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/GourmanGame.java
@@ -1,0 +1,786 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.IntStream;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.TickEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.block.Borders;
+import dev.tamboui.widgets.block.Title;
+import dev.tamboui.widgets.canvas.Canvas;
+import dev.tamboui.widgets.canvas.Context;
+import dev.tamboui.widgets.canvas.Marker;
+import dev.tamboui.widgets.canvas.shapes.Points;
+import dev.tamboui.widgets.paragraph.Paragraph;
+
+/**
+ * Full-screen terminal Gourman, rendered with TamboUI's canvas.
+ *
+ * <p>
+ * Movement is tile-based: Gourman and each ghost step one tile per their own interval, driven by
+ * the tick event. Turns are buffered — press a direction early and Gourman turns at the next tile
+ * where it fits. Ghosts alternate scatter and chase phases with their arcade personalities
+ * (Blinky chases, Pinky ambushes four tiles ahead, Inky doubles Blinky's pincer vector, Clyde
+ * chases only from afar), run away randomly while frightened, and race home as eyes when eaten.
+ * Eating a power pellet is worth 200/400/800/1600 per ghost in a chain; a level ends when every
+ * pellet is gone, and each level speeds everyone up.
+ * </p>
+ */
+public final class GourmanGame {
+
+    /** Creates a game; call {@link #run()} to start it. */
+    public GourmanGame() {
+    }
+
+    private static final Duration TICK_RATE = Duration.ofMillis(33);
+    private static final double NANOS_PER_SECOND = 1_000_000_000.0;
+
+    // Base movement intervals; each level multiplies them by SPEEDUP_PER_LEVEL (floored).
+    private static final long GOURMAN_INTERVAL_MILLIS = 130;
+    private static final long GHOST_INTERVAL_MILLIS = 140;
+    private static final long FRIGHTENED_INTERVAL_MILLIS = 210;
+    private static final long EATEN_INTERVAL_MILLIS = 50;
+    private static final double SPEEDUP_PER_LEVEL = 0.94;
+    private static final double MIN_SPEED_FACTOR = 0.5;
+
+    // Ghost mode schedule: scatter for 7s, then chase for 20s, repeating from each life/level start.
+    private static final long SCATTER_SECONDS = 7;
+    private static final long CHASE_SECONDS = 20;
+    private static final long FRIGHTENED_SECONDS = 6;
+    private static final long FRIGHTENED_FLASH_SECONDS = 2;
+
+    private static final Duration READY_PAUSE = Duration.ofSeconds(2);
+    private static final Duration DEATH_PAUSE = Duration.ofMillis(1500);
+    private static final Duration LEVEL_CLEAR_PAUSE = Duration.ofMillis(1500);
+    private static final Duration EATEN_GHOST_REST = Duration.ofSeconds(1);
+
+    private static final int PELLET_POINTS = 10;
+    private static final int POWER_PELLET_POINTS = 50;
+    private static final int GHOST_BASE_POINTS = 200;
+    private static final int EXTRA_LIFE_SCORE = 10_000;
+    private static final int STARTING_LIVES = 3;
+    // Clyde switches from chasing to his scatter corner within this many tiles of Gourman.
+    private static final int CLYDE_SHY_DISTANCE = 8;
+    // Pinky aims this many tiles ahead of Gourman; Inky's pincer pivots two tiles ahead.
+    private static final int PINKY_LOOKAHEAD = 4;
+    private static final int INKY_LOOKAHEAD = 2;
+
+    // Start tiles: Gourman below the ghost house, Blinky just above the door, the rest inside.
+    private static final int GOURMAN_START_COLUMN = 13;
+    private static final int GOURMAN_START_ROW = 23;
+    private static final int DOOR_EXIT_COLUMN = 13;
+    private static final int DOOR_EXIT_ROW = 11;
+    private static final int HOUSE_ROW = 14;
+    private static final int[] HOUSE_COLUMNS = { 13, 11, 15 };
+
+    // Canvas resolution: 2x2 half-block pixels per maze tile, so tiles render square.
+    private static final int CELL_PIXELS = 2;
+    private static final int PIXELS_X = Maze.COLUMNS * CELL_PIXELS;
+    private static final int PIXELS_Y = Maze.ROWS * CELL_PIXELS;
+    private static final int BOARD_PANEL_WIDTH = PIXELS_X + 2;
+    private static final int BOARD_PANEL_HEIGHT = Maze.ROWS + 2;
+    private static final int SIDE_PANEL_WIDTH = 24;
+    // Banner row: the empty stretch below the ghost house, where the arcade prints READY!.
+    private static final int BANNER_ROW = 17;
+
+    private static final Color WALL_COLOR = Color.rgb(66, 66, 255);
+    private static final Color DOOR_COLOR = Color.rgb(255, 184, 255);
+    private static final Color PELLET_COLOR = Color.rgb(255, 183, 174);
+    private static final Color GOURMAN_COLOR = Color.YELLOW;
+    private static final Color FRIGHTENED_COLOR = Color.rgb(60, 60, 255);
+    private static final Color EYES_COLOR = Color.WHITE;
+    private static final long BLINK_NANOS = Duration.ofMillis(400).toNanos();
+
+    /** What the fixed pauses between play are showing. PLAYING is the only phase that moves. */
+    private enum Phase {
+        READY, PLAYING, DYING, LEVEL_CLEAR, GAME_OVER
+    }
+
+    private final Maze maze = new Maze();
+    private final Random random = new Random();
+    private final List<Ghost> ghosts = new ArrayList<>();
+    private final List<GameListener> listeners = new CopyOnWriteArrayList<>();
+
+    private int gourmanColumn;
+    private int gourmanRow;
+    private Direction gourmanDirection = Direction.LEFT;
+    private Direction desiredDirection = Direction.LEFT;
+    private long nextGourmanMoveNanos;
+
+    private int score;
+    private int lives;
+    private int level;
+    private boolean extraLifeAwarded;
+    private boolean paused;
+    private Phase phase = Phase.READY;
+    private long phaseUntilNanos;
+    private long modeStartNanos;
+    private long frightenedUntilNanos;
+    private int ghostChain;
+
+    /**
+     * Subscribes a listener to every {@link GameEvent} this game emits. Listeners run on the
+     * game loop thread and must not block; see {@link GameListener}.
+     *
+     * @param listener the listener to subscribe
+     */
+    public void addListener(GameListener listener) {
+        listeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    private void publish(GameEvent event) {
+        for (GameListener listener : listeners) {
+            try {
+                listener.onEvent(event);
+            } catch (RuntimeException e) {
+                // A misbehaving listener must not break the game loop, and stdout belongs to the
+                // TUI, so there is nowhere to report it; skip the listener for this event.
+            }
+        }
+    }
+
+    /** Runs the game full-screen until the player quits; blocks the calling thread. */
+    public void run() {
+        newGame();
+        try (TuiRunner tui = TuiRunner.create(TuiConfig.builder().tickRate(TICK_RATE).build())) {
+            tui.run(this::handleEvent, this::render);
+        } catch (Exception e) {
+            throw new GourmanException("Gourman failed: " + e.getMessage(), e);
+        }
+    }
+
+    // --- Game state ---
+
+    /** Starts a fresh game. Package-visible so tests can drive the game without a terminal. */
+    void newGame() {
+        maze.resetPellets();
+        score = 0;
+        lives = STARTING_LIVES;
+        level = 1;
+        extraLifeAwarded = false;
+        paused = false;
+        resetPositions();
+        publish(new GameEvent.GameStarted(level, lives));
+    }
+
+    /** Puts every actor back on its start tile and freezes play for the READY pause. */
+    private void resetPositions() {
+        long now = System.nanoTime();
+        gourmanColumn = GOURMAN_START_COLUMN;
+        gourmanRow = GOURMAN_START_ROW;
+        gourmanDirection = Direction.LEFT;
+        desiredDirection = Direction.LEFT;
+        ghosts.clear();
+        Ghost.Kind[] kinds = Ghost.Kind.values();
+        IntStream.range(0, kinds.length).forEach(i -> {
+            Ghost ghost = new Ghost(kinds[i]);
+            if (kinds[i] == Ghost.Kind.BLINKY) {
+                ghost.position(DOOR_EXIT_COLUMN, DOOR_EXIT_ROW);
+                ghost.state(Ghost.State.ACTIVE);
+            } else {
+                ghost.position(HOUSE_COLUMNS[i - 1], HOUSE_ROW);
+                ghost.releaseAtNanos(now + kinds[i].releaseSeconds() * (long) NANOS_PER_SECOND);
+            }
+            ghosts.add(ghost);
+        });
+        frightenedUntilNanos = 0;
+        ghostChain = 0;
+        phase = Phase.READY;
+        phaseUntilNanos = now + READY_PAUSE.toNanos();
+    }
+
+    private double speedFactor() {
+        return Math.max(MIN_SPEED_FACTOR, Math.pow(SPEEDUP_PER_LEVEL, level - 1));
+    }
+
+    private long interval(long baseMillis) {
+        return (long) (baseMillis * speedFactor() * Duration.ofMillis(1).toNanos());
+    }
+
+    private void tick() {
+        if (paused || phase == Phase.GAME_OVER) {
+            return;
+        }
+        long now = System.nanoTime();
+        if (phase != Phase.PLAYING) {
+            if (now >= phaseUntilNanos) {
+                advancePhase(now);
+            }
+            return;
+        }
+        if (frightenedUntilNanos != 0 && now >= frightenedUntilNanos) {
+            frightenedUntilNanos = 0;
+            ghosts.forEach(ghost -> ghost.frightened(false));
+            publish(new GameEvent.FrightenedEnded());
+        }
+        while (now >= nextGourmanMoveNanos && phase == Phase.PLAYING) {
+            nextGourmanMoveNanos += interval(GOURMAN_INTERVAL_MILLIS);
+            moveGourman(now);
+        }
+        for (Ghost ghost : ghosts) {
+            while (now >= ghost.nextMoveNanos() && phase == Phase.PLAYING) {
+                ghost.nextMoveNanos(ghost.nextMoveNanos() + interval(ghostIntervalMillis(ghost)));
+                moveGhost(ghost, now);
+            }
+        }
+    }
+
+    private long ghostIntervalMillis(Ghost ghost) {
+        if (ghost.state() == Ghost.State.EATEN) {
+            return EATEN_INTERVAL_MILLIS;
+        }
+        if (ghost.frightened()) {
+            return FRIGHTENED_INTERVAL_MILLIS;
+        }
+        return GHOST_INTERVAL_MILLIS;
+    }
+
+    private void advancePhase(long now) {
+        if (phase == Phase.READY) {
+            phase = Phase.PLAYING;
+            modeStartNanos = now;
+            nextGourmanMoveNanos = now;
+            ghosts.forEach(ghost -> ghost.nextMoveNanos(now));
+            publish(new GameEvent.LevelStarted(level));
+            return;
+        }
+        if (phase == Phase.DYING) {
+            if (lives > 0) {
+                resetPositions();
+            } else {
+                phase = Phase.GAME_OVER;
+                publish(new GameEvent.GameOver(score, level));
+            }
+            return;
+        }
+        if (phase == Phase.LEVEL_CLEAR) {
+            level++;
+            maze.resetPellets();
+            resetPositions();
+        }
+    }
+
+    /** One Gourman step. Package-visible so tests can drive the game without a terminal. */
+    void moveGourman(long now) {
+        if (canMove(gourmanColumn, gourmanRow, desiredDirection)) {
+            gourmanDirection = desiredDirection;
+        }
+        if (canMove(gourmanColumn, gourmanRow, gourmanDirection)) {
+            gourmanColumn = Maze.wrapColumn(gourmanColumn + gourmanDirection.dx());
+            gourmanRow += gourmanDirection.dy();
+            publish(new GameEvent.GourmanMoved(gourmanColumn, gourmanRow, gourmanDirection));
+            eatPellet(now);
+        }
+        checkCollisions(now);
+    }
+
+    private void eatPellet(long now) {
+        int eaten = maze.eat(gourmanColumn, gourmanRow);
+        if (eaten == 1) {
+            publish(new GameEvent.PelletEaten(gourmanColumn, gourmanRow, maze.pelletCount()));
+            addScore(PELLET_POINTS);
+        } else if (eaten == 2) {
+            publish(new GameEvent.PowerPelletEaten(gourmanColumn, gourmanRow));
+            addScore(POWER_PELLET_POINTS);
+            frightenGhosts(now);
+        }
+        if (eaten != 0 && maze.pelletCount() == 0) {
+            phase = Phase.LEVEL_CLEAR;
+            phaseUntilNanos = now + LEVEL_CLEAR_PAUSE.toNanos();
+            publish(new GameEvent.LevelCleared(level, score));
+        }
+    }
+
+    private void frightenGhosts(long now) {
+        frightenedUntilNanos = now + FRIGHTENED_SECONDS * (long) NANOS_PER_SECOND;
+        ghostChain = 0;
+        for (Ghost ghost : ghosts) {
+            if (ghost.state() != Ghost.State.EATEN) {
+                ghost.frightened(true);
+                ghost.direction(ghost.direction().opposite());
+            }
+        }
+        publish(new GameEvent.GhostsFrightened(FRIGHTENED_SECONDS));
+    }
+
+    private void addScore(int points) {
+        score += points;
+        publish(new GameEvent.ScoreChanged(points, score));
+        if (!extraLifeAwarded && score >= EXTRA_LIFE_SCORE) {
+            extraLifeAwarded = true;
+            lives++;
+            publish(new GameEvent.ExtraLifeAwarded(score, lives));
+        }
+    }
+
+    private static boolean canMove(int column, int row, Direction direction) {
+        int targetColumn = Maze.wrapColumn(column + direction.dx());
+        int targetRow = row + direction.dy();
+        if (targetRow < 0 || targetRow >= Maze.ROWS) {
+            return false;
+        }
+        return Maze.passable(targetColumn, targetRow);
+    }
+
+    // --- Ghost movement ---
+
+    private void moveGhost(Ghost ghost, long now) {
+        if (ghost.state() == Ghost.State.WAITING) {
+            if (now >= ghost.releaseAtNanos()) {
+                ghost.position(DOOR_EXIT_COLUMN, DOOR_EXIT_ROW);
+                ghost.direction(Direction.LEFT);
+                ghost.state(Ghost.State.ACTIVE);
+                publish(new GameEvent.GhostReleased(ghost.kind()));
+            }
+            return;
+        }
+        Direction choice = chooseDirection(ghost);
+        ghost.direction(choice);
+        ghost.position(Maze.wrapColumn(ghost.column() + choice.dx()), ghost.row() + choice.dy());
+        publish(new GameEvent.GhostMoved(ghost.kind(), ghost.column(), ghost.row(), ghost.state(),
+                ghost.frightened()));
+        if (ghost.state() == Ghost.State.EATEN && ghost.column() == DOOR_EXIT_COLUMN && ghost.row() == DOOR_EXIT_ROW) {
+            // The eyes reached the doorstep: drop back into the house for a short rest.
+            ghost.position(HOUSE_COLUMNS[0], HOUSE_ROW);
+            ghost.state(Ghost.State.WAITING);
+            ghost.releaseAtNanos(now + EATEN_GHOST_REST.toNanos());
+            publish(new GameEvent.GhostReturned(ghost.kind()));
+        }
+        checkCollisions(now);
+    }
+
+    private Direction chooseDirection(Ghost ghost) {
+        List<Direction> options = new ArrayList<>(EnumSet.allOf(Direction.class));
+        options.removeIf(direction -> direction == ghost.direction().opposite()
+                || !canMove(ghost.column(), ghost.row(), direction));
+        if (options.isEmpty()) {
+            return ghost.direction().opposite();
+        }
+        if (ghost.frightened() && ghost.state() != Ghost.State.EATEN) {
+            return options.get(random.nextInt(options.size()));
+        }
+        int[] target = target(ghost);
+        Direction best = options.get(0);
+        long bestDistance = Long.MAX_VALUE;
+        for (Direction option : options) {
+            long distance = squaredDistance(Maze.wrapColumn(ghost.column() + option.dx()),
+                    ghost.row() + option.dy(), target[0], target[1]);
+            if (distance < bestDistance) {
+                bestDistance = distance;
+                best = option;
+            }
+        }
+        return best;
+    }
+
+    /** The tile a ghost steers toward, per the arcade targeting rules (simplified to full tiles). */
+    private int[] target(Ghost ghost) {
+        if (ghost.state() == Ghost.State.EATEN) {
+            return new int[] { DOOR_EXIT_COLUMN, DOOR_EXIT_ROW };
+        }
+        if (!chaseMode()) {
+            return new int[] { ghost.kind().scatterColumn(), ghost.kind().scatterRow() };
+        }
+        switch (ghost.kind()) {
+        case PINKY:
+            return new int[] { gourmanColumn + PINKY_LOOKAHEAD * gourmanDirection.dx(),
+                    gourmanRow + PINKY_LOOKAHEAD * gourmanDirection.dy() };
+        case INKY:
+            return inkyTarget();
+        case CLYDE:
+            if (squaredDistance(ghost.column(), ghost.row(), gourmanColumn,
+                    gourmanRow) > (long) CLYDE_SHY_DISTANCE * CLYDE_SHY_DISTANCE) {
+                return new int[] { gourmanColumn, gourmanRow };
+            }
+            return new int[] { ghost.kind().scatterColumn(), ghost.kind().scatterRow() };
+        default:
+            return new int[] { gourmanColumn, gourmanRow };
+        }
+    }
+
+    /** Inky's pincer: double the vector from Blinky to the tile two ahead of Gourman. */
+    private int[] inkyTarget() {
+        Ghost blinky = ghosts.get(0);
+        int pivotColumn = gourmanColumn + INKY_LOOKAHEAD * gourmanDirection.dx();
+        int pivotRow = gourmanRow + INKY_LOOKAHEAD * gourmanDirection.dy();
+        return new int[] { 2 * pivotColumn - blinky.column(), 2 * pivotRow - blinky.row() };
+    }
+
+    private boolean chaseMode() {
+        long elapsedSeconds = (long) ((System.nanoTime() - modeStartNanos) / NANOS_PER_SECOND);
+        return elapsedSeconds % (SCATTER_SECONDS + CHASE_SECONDS) >= SCATTER_SECONDS;
+    }
+
+    private static long squaredDistance(int column, int row, int targetColumn, int targetRow) {
+        long dc = column - (long) targetColumn;
+        long dr = row - (long) targetRow;
+        return dc * dc + dr * dr;
+    }
+
+    // --- Collisions ---
+
+    private void checkCollisions(long now) {
+        for (Ghost ghost : ghosts) {
+            if (ghost.column() != gourmanColumn || ghost.row() != gourmanRow
+                    || ghost.state() != Ghost.State.ACTIVE) {
+                continue;
+            }
+            if (ghost.frightened()) {
+                eatGhost(ghost);
+            } else {
+                lives--;
+                phase = Phase.DYING;
+                phaseUntilNanos = now + DEATH_PAUSE.toNanos();
+                publish(new GameEvent.GourmanDied(lives));
+                return;
+            }
+        }
+    }
+
+    private void eatGhost(Ghost ghost) {
+        int points = GHOST_BASE_POINTS << ghostChain;
+        ghostChain++;
+        ghost.frightened(false);
+        ghost.state(Ghost.State.EATEN);
+        publish(new GameEvent.GhostEaten(ghost.kind(), points, ghostChain));
+        addScore(points);
+    }
+
+    // --- Events ---
+
+    private boolean handleEvent(Event event, TuiRunner runner) {
+        if (event instanceof KeyEvent key) {
+            handleKey(key, runner);
+            return true;
+        }
+        if (event instanceof TickEvent) {
+            tick();
+            return true;
+        }
+        return false;
+    }
+
+    private void handleKey(KeyEvent key, TuiRunner runner) {
+        if (key.isQuit() || key.isCharIgnoreCase('q')) {
+            runner.quit();
+            return;
+        }
+        if (key.isCharIgnoreCase('r')) {
+            newGame();
+            return;
+        }
+        if (key.isCharIgnoreCase('p')) {
+            boolean wasPaused = paused;
+            paused = !paused && phase != Phase.GAME_OVER;
+            if (paused != wasPaused) {
+                publish(paused ? new GameEvent.GamePaused() : new GameEvent.GameResumed());
+            }
+            return;
+        }
+        if (key.isLeft() || key.isCharIgnoreCase('h')) {
+            desiredDirection = Direction.LEFT;
+        } else if (key.isRight() || key.isCharIgnoreCase('l')) {
+            desiredDirection = Direction.RIGHT;
+        } else if (key.isUp() || key.isCharIgnoreCase('k')) {
+            desiredDirection = Direction.UP;
+        } else if (key.isDown() || key.isCharIgnoreCase('j')) {
+            desiredDirection = Direction.DOWN;
+        }
+    }
+
+    // --- Rendering ---
+
+    private void render(Frame frame) {
+        Rect area = frame.area();
+        // The board must get its exact size: the canvas maps a fixed 56x62 pixel grid onto the
+        // panel, so a smaller area merges adjacent pixel rows/columns into the same character -
+        // walls bleed into corridors and the maze silently distorts. Refuse to render distorted;
+        // shed the block border and the side panel first, and past that show a resize hint.
+        if (area.width() < PIXELS_X || area.height() < Maze.ROWS) {
+            renderTooSmall(frame, area);
+            return;
+        }
+        // The rounded border costs 2 rows/columns; drop it when the terminal is that tight
+        // (32 rows is a common default height, one short of the bordered board's 33).
+        boolean bordered = area.width() >= BOARD_PANEL_WIDTH && area.height() >= BOARD_PANEL_HEIGHT;
+        int boardWidth = bordered ? BOARD_PANEL_WIDTH : PIXELS_X;
+        int boardHeight = bordered ? BOARD_PANEL_HEIGHT : Maze.ROWS;
+        List<Rect> rows = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(boardHeight), Constraint.fill())
+                .split(area);
+        if (area.width() < boardWidth + 1 + SIDE_PANEL_WIDTH) {
+            List<Rect> columns = Layout.horizontal()
+                    .constraints(Constraint.fill(), Constraint.length(boardWidth), Constraint.fill())
+                    .split(rows.get(1));
+            frame.renderWidget(boardCanvas(bordered), columns.get(1));
+            return;
+        }
+        List<Rect> columns = Layout.horizontal()
+                .constraints(Constraint.fill(), Constraint.length(boardWidth),
+                        Constraint.length(SIDE_PANEL_WIDTH), Constraint.fill())
+                .spacing(1)
+                .split(rows.get(1));
+        frame.renderWidget(boardCanvas(bordered), columns.get(1));
+        renderSidePanel(frame, columns.get(2));
+    }
+
+    private static void renderTooSmall(Frame frame, Rect area) {
+        List<Line> message = new ArrayList<>();
+        message.add(Line.from(Span.raw(" Terminal too small").bold().red()));
+        message.add(Line.from(Span.raw(" Gourman needs at least " + PIXELS_X + "x" + Maze.ROWS
+                + " characters; this window is " + area.width() + "x" + area.height() + ".")));
+        message.add(Line.from(Span.raw(" Enlarge the window or reduce the font size (Cmd -).").dim()));
+        frame.renderWidget(Paragraph.builder().text(Text.from(message)).build(), area);
+    }
+
+    /** The board widget; package-visible so tests can render it headlessly into a buffer. */
+    Canvas boardCanvas(boolean bordered) {
+        Color borderColor = phase == Phase.GAME_OVER ? Color.RED : Color.CYAN;
+        Canvas.Builder builder = Canvas.builder()
+                // Bounds span [0, N-1] for N pixels so integer coordinates map 1:1 onto grid
+                // cells; a [0, N] span aliases and blocks shrink at some positions.
+                .xBounds(0, PIXELS_X - 1)
+                .yBounds(0, PIXELS_Y - 1)
+                .marker(Marker.HALF_BLOCK)
+                .paint(this::paintBoard);
+        if (bordered) {
+            builder.block(roundedBlock(borderColor, " GOURMAN "));
+        }
+        return builder.build();
+    }
+
+    private void paintBoard(Context context) {
+        long now = System.nanoTime();
+        paintMaze(context, now);
+        for (Ghost ghost : ghosts) {
+            paintGhost(context, ghost, now);
+        }
+        if (phase != Phase.DYING || blinkOn(now)) {
+            paintGourman(context, now);
+        }
+        paintBanner(context);
+    }
+
+    private void paintMaze(Context context, long now) {
+        IntStream.range(0, Maze.ROWS).forEach(row -> IntStream.range(0, Maze.COLUMNS).forEach(column -> {
+            if (Maze.wall(column, row)) {
+                paintWallEdges(context, column, row);
+            } else if (Maze.door(column, row)) {
+                paintPixel(context, column * CELL_PIXELS, row * CELL_PIXELS, DOOR_COLOR);
+                paintPixel(context, column * CELL_PIXELS + 1, row * CELL_PIXELS, DOOR_COLOR);
+            } else if (maze.pellet(column, row)) {
+                // Text labels overlay the pixel grid, so pellets are crisp round dots that can
+                // never be confused with the half-block quanta the wall outlines are made of.
+                if (!occupied(column, row)) {
+                    printTile(context, column, row, Span.styled("・", Style.EMPTY.fg(PELLET_COLOR).bold()));
+                }
+            } else if (maze.powerPellet(column, row) && blinkOn(now) && !occupied(column, row)) {
+                printTile(context, column, row, Span.styled("〇", Style.EMPTY.fg(PELLET_COLOR).bold()));
+            }
+        }));
+    }
+
+    /**
+     * Walls render as outlines, not filled regions: only wall tiles that border open space
+     * (corridor or void) are painted, leaving wall interiors black. The outline is traced at
+     * character granularity — each exposed half-tile column paints both of its half-block
+     * pixels — because mixing half-height edges with full-height corners makes straight walls
+     * look crenellated (the corner characters bulge out of the line every few tiles).
+     */
+    private static void paintWallEdges(Context context, int column, int row) {
+        IntStream.range(0, CELL_PIXELS).forEach(sx -> {
+            int hx = sx == 0 ? -1 : 1;
+            boolean exposed = openForWallTracing(column + hx, row)
+                    || openForWallTracing(column, row - 1) || openForWallTracing(column, row + 1)
+                    || openForWallTracing(column + hx, row - 1) || openForWallTracing(column + hx, row + 1);
+            if (exposed) {
+                paintPixel(context, column * CELL_PIXELS + sx, row * CELL_PIXELS, WALL_COLOR);
+                paintPixel(context, column * CELL_PIXELS + sx, row * CELL_PIXELS + 1, WALL_COLOR);
+            }
+        });
+    }
+
+    /** Out-of-bounds counts as wall so the maze border draws a single line on its inner side. */
+    private static boolean openForWallTracing(int column, int row) {
+        if (column < 0 || column >= Maze.COLUMNS || row < 0 || row >= Maze.ROWS) {
+            return false;
+        }
+        return !Maze.wall(column, row);
+    }
+
+    /** Gourman chomps: one mouth pixel on the side he is facing blinks open and shut. */
+    private void paintGourman(Context context, long now) {
+        IntStream.range(0, CELL_PIXELS * CELL_PIXELS).forEach(i -> {
+            int sx = i % CELL_PIXELS;
+            int sy = i / CELL_PIXELS;
+            if (phase == Phase.PLAYING && blinkOn(now) && isMouthPixel(sx, sy)) {
+                return;
+            }
+            paintPixel(context, gourmanColumn * CELL_PIXELS + sx, gourmanRow * CELL_PIXELS + sy, GOURMAN_COLOR);
+        });
+    }
+
+    private boolean isMouthPixel(int sx, int sy) {
+        switch (gourmanDirection) {
+        case LEFT:
+            return sx == 0 && sy == 0;
+        case RIGHT:
+            return sx == 1 && sy == 0;
+        case UP:
+            return sx == 0 && sy == 0;
+        default:
+            return sx == 1 && sy == 1;
+        }
+    }
+
+    private void paintGhost(Context context, Ghost ghost, long now) {
+        if (ghost.state() == Ghost.State.EATEN) {
+            // Just the eyes racing home.
+            paintPixel(context, ghost.column() * CELL_PIXELS, ghost.row() * CELL_PIXELS, EYES_COLOR);
+            paintPixel(context, ghost.column() * CELL_PIXELS + 1, ghost.row() * CELL_PIXELS, EYES_COLOR);
+            return;
+        }
+        Color color = ghost.kind().color();
+        if (ghost.frightened()) {
+            boolean flashing = frightenedUntilNanos - now < FRIGHTENED_FLASH_SECONDS * (long) NANOS_PER_SECOND;
+            color = flashing && blinkOn(now) ? Color.WHITE : FRIGHTENED_COLOR;
+        }
+        // No eyes overlay: the half-block renderer shows only the TOP pixel's color when both
+        // halves of a character are painted, so white top pixels would repaint the whole ghost
+        // white. Solid bodies it is; Gourman stands out through his chomping mouth instead.
+        paintCell(context, ghost.column(), ghost.row(), color);
+    }
+
+    /** Whether an actor is standing on the tile (its pellet dot would print on top of it). */
+    private boolean occupied(int column, int row) {
+        for (Ghost ghost : ghosts) {
+            if (ghost.column() == column && ghost.row() == row) {
+                return true;
+            }
+        }
+        return gourmanColumn == column && gourmanRow == row;
+    }
+
+    /**
+     * Prints a glyph over a tile (labels overlay the pixel grid). Tiles are two characters wide
+     * with no middle character, so pellet glyphs are FULLWIDTH (East Asian wide) characters:
+     * they occupy both cells of the tile with the mark rendered dead center, which is the only
+     * way to truly center a dot in an even-width tile.
+     */
+    private static void printTile(Context context, int column, int row, Span glyph) {
+        context.print(column * CELL_PIXELS, PIXELS_Y - 1.0 - row * CELL_PIXELS, Line.from(glyph));
+    }
+
+    private static boolean blinkOn(long now) {
+        return now / BLINK_NANOS % 2 == 0;
+    }
+
+    /** Fills one maze tile as a square of canvas pixels (half-block marker: 2 per terminal row). */
+    private static void paintCell(Context context, int column, int row, Color color) {
+        double[][] points = new double[CELL_PIXELS * CELL_PIXELS][];
+        IntStream.range(0, CELL_PIXELS * CELL_PIXELS).forEach(i -> {
+            int px = column * CELL_PIXELS + i % CELL_PIXELS;
+            int py = row * CELL_PIXELS + i / CELL_PIXELS;
+            points[i] = new double[] { px, PIXELS_Y - 1 - py };
+        });
+        context.draw(Points.of(points, color));
+    }
+
+    private static void paintPixel(Context context, int px, int py, Color color) {
+        // The canvas y-axis points up; board rows count down from the top.
+        context.draw(Points.of(new double[][] { { px, PIXELS_Y - 1 - py } }, color));
+    }
+
+    private void paintBanner(Context context) {
+        if (paused) {
+            printCentered(context, "PAUSED", Color.YELLOW, true);
+        } else if (phase == Phase.READY) {
+            printCentered(context, "READY!", Color.YELLOW, false);
+        } else if (phase == Phase.GAME_OVER) {
+            printCentered(context, "GAME  OVER", Color.RED, true);
+        } else if (phase == Phase.LEVEL_CLEAR) {
+            printCentered(context, "LEVEL " + level + " CLEAR", Color.GREEN, false);
+        }
+    }
+
+    private static void printCentered(Context context, String text, Color color, boolean reversed) {
+        Style style = Style.EMPTY.fg(color).bold();
+        if (reversed) {
+            style = style.reversed();
+        }
+        double x = Math.max(0, (PIXELS_X - text.length()) / 2.0);
+        context.print(x, PIXELS_Y - 1.0 - BANNER_ROW * CELL_PIXELS, Line.from(Span.styled(text, style)));
+    }
+
+    private void renderSidePanel(Frame frame, Rect area) {
+        List<Line> panelLines = new ArrayList<>();
+        panelLines.add(statLine("Score", Integer.toString(score)));
+        panelLines.add(statLine("Level", Integer.toString(level)));
+        panelLines.add(livesLine());
+        panelLines.add(Line.from(Span.raw("")));
+        panelLines.add(Line.from(Span.raw(" Pellets left  ").dim(),
+                Span.raw(Integer.toString(maze.pelletCount())).bold().white()));
+        panelLines.add(Line.from(Span.raw("")));
+        panelLines.add(keyLine("← → ↑ ↓ / hjkl", "move"));
+        panelLines.add(keyLine("p", "pause"));
+        panelLines.add(keyLine("r", "restart"));
+        panelLines.add(keyLine("q", "quit"));
+        Paragraph panel = Paragraph.builder()
+                .text(Text.from(panelLines))
+                .block(roundedBlock(Color.DARK_GRAY, null))
+                .build();
+        frame.renderWidget(panel, area);
+    }
+
+    private Line livesLine() {
+        String[] icons = new String[Math.max(0, lives)];
+        Arrays.fill(icons, "●");
+        return Line.from(Span.raw(" Lives  ").dim(),
+                Span.raw(String.join(" ", icons)).fg(GOURMAN_COLOR).bold());
+    }
+
+    private static Line statLine(String label, String value) {
+        return Line.from(Span.raw(" " + label + "  ").dim(), Span.raw(value).bold().white());
+    }
+
+    private static Line keyLine(String keys, String action) {
+        return Line.from(Span.raw(" " + keys).yellow(), Span.raw("  " + action).dim());
+    }
+
+    private static Block roundedBlock(Color color, String title) {
+        Block.Builder builder = Block.builder()
+                .borders(Borders.ALL)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.EMPTY.fg(color));
+        if (title != null) {
+            builder.title(Title.from(Line.from(Span.styled(title, Style.EMPTY.fg(color).bold()))));
+        }
+        return builder.build();
+    }
+
+}

--- a/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Maze.java
+++ b/demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Maze.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import java.util.stream.IntStream;
+
+/**
+ * The classic 28x31 maze: static walls plus the per-level pellet state. {@code #} is a wall,
+ * {@code .} a pellet, {@code o} a power pellet, {@code -} the ghost-house door and spaces are
+ * open corridor. The tunnel row wraps horizontally at both edges.
+ */
+final class Maze {
+
+    static final int COLUMNS = 28;
+    static final int ROWS = 31;
+    static final int TUNNEL_ROW = 14;
+
+    private static final char WALL = '#';
+    private static final char DOOR = '-';
+    private static final char PELLET = '.';
+    private static final char POWER = 'o';
+
+    private static final String[] LAYOUT = {
+            "############################",
+            "#............##............#",
+            "#.####.#####.##.#####.####.#",
+            "#o####.#####.##.#####.####o#",
+            "#.####.#####.##.#####.####.#",
+            "#..........................#",
+            "#.####.##.########.##.####.#",
+            "#.####.##.########.##.####.#",
+            "#......##....##....##......#",
+            "######.##### ## #####.######",
+            "     #.##### ## #####.#     ",
+            "     #.##          ##.#     ",
+            "     #.## ###--### ##.#     ",
+            "######.## #      # ##.######",
+            "      .   #      #   .      ",
+            "######.## #      # ##.######",
+            "     #.## ######## ##.#     ",
+            "     #.##          ##.#     ",
+            "     #.## ######## ##.#     ",
+            "######.## ######## ##.######",
+            "#............##............#",
+            "#.####.#####.##.#####.####.#",
+            "#.####.#####.##.#####.####.#",
+            "#o..##.......  .......##..o#",
+            "###.##.##.########.##.##.###",
+            "###.##.##.########.##.##.###",
+            "#......##....##....##......#",
+            "#.##########.##.##########.#",
+            "#.##########.##.##########.#",
+            "#..........................#",
+            "############################" };
+
+    private final boolean[][] pellets = new boolean[ROWS][COLUMNS];
+    private final boolean[][] powerPellets = new boolean[ROWS][COLUMNS];
+    private int pelletCount;
+
+    Maze() {
+        resetPellets();
+    }
+
+    /** Restores every pellet and power pellet, for a new level or a new game. */
+    void resetPellets() {
+        pelletCount = 0;
+        IntStream.range(0, ROWS).forEach(row -> IntStream.range(0, COLUMNS).forEach(column -> {
+            char tile = LAYOUT[row].charAt(column);
+            pellets[row][column] = tile == PELLET;
+            powerPellets[row][column] = tile == POWER;
+            if (tile == PELLET || tile == POWER) {
+                pelletCount++;
+            }
+        }));
+    }
+
+    static boolean wall(int column, int row) {
+        return LAYOUT[row].charAt(column) == WALL;
+    }
+
+    static boolean door(int column, int row) {
+        return LAYOUT[row].charAt(column) == DOOR;
+    }
+
+    /** Whether an actor may occupy the tile. The ghost-house door blocks everyone. */
+    static boolean passable(int column, int row) {
+        return !wall(column, row) && !door(column, row);
+    }
+
+    /** Wraps a column index through the side tunnels. */
+    static int wrapColumn(int column) {
+        return Math.floorMod(column, COLUMNS);
+    }
+
+    boolean pellet(int column, int row) {
+        return pellets[row][column];
+    }
+
+    boolean powerPellet(int column, int row) {
+        return powerPellets[row][column];
+    }
+
+    /** Removes and reports the pellet on the tile: 0 = none, 1 = pellet, 2 = power pellet. */
+    int eat(int column, int row) {
+        if (pellets[row][column]) {
+            pellets[row][column] = false;
+            pelletCount--;
+            return 1;
+        }
+        if (powerPellets[row][column]) {
+            powerPellets[row][column] = false;
+            pelletCount--;
+            return 2;
+        }
+        return 0;
+    }
+
+    int pelletCount() {
+        return pelletCount;
+    }
+
+}

--- a/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/BoardRenderTest.java
+++ b/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/BoardRenderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Renders the real board widget into a buffer and checks the pellet glyphs are uniform. */
+class BoardRenderTest {
+
+    private static final int PANEL_WIDTH = Maze.COLUMNS * 2 + 2;
+    private static final int PANEL_HEIGHT = Maze.ROWS + 2;
+
+    @Test
+    void everyPelletRendersAsTheSameGlyph() {
+        Buffer buffer = renderBoard();
+        Maze maze = new Maze();
+        IntStream.range(0, Maze.ROWS).forEach(row -> IntStream.range(0, Maze.COLUMNS).forEach(column -> {
+            if (!maze.pellet(column, row)) {
+                return;
+            }
+            // Tile (column, row) occupies buffer cells (1 + 2*column, 1 + row) and its right
+            // neighbor, inside the block border. The pellet is a fullwidth dot spanning both
+            // cells (glyph + continuation), so the mark sits dead center in the tile.
+            assertThat(buffer.get(1 + column * 2, 1 + row).symbol())
+                    .as("pellet glyph at %d,%d", column, row).isEqualTo("・");
+            assertThat(buffer.get(1 + column * 2 + 1, 1 + row).isContinuation())
+                    .as("continuation cell of pellet tile %d,%d", column, row).isTrue();
+        }));
+    }
+
+    @Test
+    void dumpBoard() {
+        Buffer buffer = renderBoard();
+        StringBuilder dump = new StringBuilder();
+        IntStream.range(0, PANEL_HEIGHT).forEach(y -> {
+            IntStream.range(0, PANEL_WIDTH).forEach(x -> {
+                String symbol = buffer.get(x, y).symbol();
+                dump.append(symbol.isEmpty() ? " " : symbol);
+            });
+            dump.append('\n');
+        });
+        System.out.println(dump);
+    }
+
+    private static Buffer renderBoard() {
+        GourmanGame game = new GourmanGame();
+        Buffer buffer = Buffer.empty(new Rect(0, 0, PANEL_WIDTH, PANEL_HEIGHT));
+        game.boardCanvas(true).render(buffer.area(), buffer);
+        return buffer;
+    }
+
+}

--- a/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/GameEventsTest.java
+++ b/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/GameEventsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GameEventsTest {
+
+    @Test
+    void startingAGamePublishesGameStarted() {
+        GourmanGame game = new GourmanGame();
+        List<GameEvent> events = new CopyOnWriteArrayList<>();
+        game.addListener(events::add);
+        game.newGame();
+        assertThat(events).containsExactly(new GameEvent.GameStarted(1, 3));
+    }
+
+    @Test
+    void movingOntoAPelletPublishesMoveEatAndScore() {
+        GourmanGame game = new GourmanGame();
+        List<GameEvent> events = new CopyOnWriteArrayList<>();
+        game.newGame();
+        game.addListener(events::add);
+        // Gourman starts at (13, 23) facing LEFT; (12, 23) holds a pellet.
+        game.moveGourman(System.nanoTime());
+        assertThat(events).containsExactly(
+                new GameEvent.GourmanMoved(12, 23, Direction.LEFT),
+                new GameEvent.PelletEaten(12, 23, 243),
+                new GameEvent.ScoreChanged(10, 10));
+    }
+
+    @Test
+    void aThrowingListenerIsIsolatedFromTheGameAndOtherListeners() {
+        GourmanGame game = new GourmanGame();
+        List<GameEvent> events = new CopyOnWriteArrayList<>();
+        game.newGame();
+        game.addListener(event -> {
+            throw new IllegalStateException("misbehaving listener");
+        });
+        game.addListener(events::add);
+        game.moveGourman(System.nanoTime());
+        assertThat(events).isNotEmpty();
+    }
+
+}

--- a/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/GameEventsTest.java
+++ b/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/GameEventsTest.java
@@ -37,6 +37,25 @@ class GameEventsTest {
     }
 
     @Test
+    void stateAccessorsTrackTheGame() {
+        GourmanGame game = new GourmanGame();
+        game.newGame();
+        assertThat(game.score()).isZero();
+        assertThat(game.lives()).isEqualTo(3);
+        assertThat(game.level()).isEqualTo(1);
+        assertThat(game.pelletsRemaining()).isEqualTo(244);
+        assertThat(game.paused()).isFalse();
+        assertThat(game.gameOver()).isFalse();
+        game.moveGourman(System.nanoTime());
+        assertThat(game.score()).isEqualTo(10);
+        assertThat(game.pelletsRemaining()).isEqualTo(243);
+        game.pause();
+        // pause() only suspends active play; the game is still in the READY countdown here.
+        game.resume();
+        assertThat(game.paused()).isFalse();
+    }
+
+    @Test
     void aThrowingListenerIsIsolatedFromTheGameAndOtherListeners() {
         GourmanGame game = new GourmanGame();
         List<GameEvent> events = new CopyOnWriteArrayList<>();

--- a/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/MazeTest.java
+++ b/demos/gourman-demo/src/test/java/dev/tamboui/demo/gourman/MazeTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.demo.gourman;
+
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MazeTest {
+
+    @Test
+    void layoutIsExactlyTwentyEightByThirtyOne() {
+        IntStream.range(0, Maze.ROWS).forEach(row -> IntStream.range(0, Maze.COLUMNS)
+                .forEach(column -> assertThat(Maze.wall(column, row) || Maze.door(column, row)
+                        || Maze.passable(column, row)).isTrue()));
+    }
+
+    @Test
+    void borderIsWalledExceptForTheTunnel() {
+        // Rows 10-18 are the inset middle section: their edge tiles are void space outside the
+        // playfield, enclosed by walls, so only the tunnel row must be open at the border there.
+        IntStream.range(0, Maze.ROWS).filter(row -> row < 10 || row > 18).forEach(row -> {
+            assertThat(Maze.passable(0, row)).as("row %d left", row).isFalse();
+            assertThat(Maze.passable(Maze.COLUMNS - 1, row)).as("row %d right", row).isFalse();
+        });
+        assertThat(Maze.passable(0, Maze.TUNNEL_ROW)).isTrue();
+        assertThat(Maze.passable(Maze.COLUMNS - 1, Maze.TUNNEL_ROW)).isTrue();
+    }
+
+    @Test
+    void tunnelPocketsAreSealedFromTheVoid() {
+        // From the tunnel, the rows above and below the outer stretch must be walls so actors
+        // can never step off the playfield into the void pockets.
+        IntStream.range(0, 6).forEach(column -> {
+            assertThat(Maze.passable(column, Maze.TUNNEL_ROW - 1)).as("above col %d", column).isFalse();
+            assertThat(Maze.passable(column, Maze.TUNNEL_ROW + 1)).as("below col %d", column).isFalse();
+            assertThat(Maze.passable(Maze.COLUMNS - 1 - column, Maze.TUNNEL_ROW - 1)).isFalse();
+            assertThat(Maze.passable(Maze.COLUMNS - 1 - column, Maze.TUNNEL_ROW + 1)).isFalse();
+        });
+    }
+
+    @Test
+    void tunnelWrapsColumns() {
+        assertThat(Maze.wrapColumn(-1)).isEqualTo(Maze.COLUMNS - 1);
+        assertThat(Maze.wrapColumn(Maze.COLUMNS)).isZero();
+    }
+
+    @Test
+    void mazeHasFourPowerPelletsAndPlentyOfPellets() {
+        Maze maze = new Maze();
+        long power = count(maze, true);
+        long pellets = count(maze, false);
+        assertThat(power).isEqualTo(4);
+        assertThat(pellets).isGreaterThan(200);
+        assertThat(maze.pelletCount()).isEqualTo(power + pellets);
+    }
+
+    @Test
+    void eatingRemovesAndCountsDown() {
+        Maze maze = new Maze();
+        int before = maze.pelletCount();
+        assertThat(maze.eat(1, 1)).isEqualTo(1);
+        assertThat(maze.eat(1, 1)).isZero();
+        assertThat(maze.eat(1, 3)).isEqualTo(2);
+        assertThat(maze.pelletCount()).isEqualTo(before - 2);
+        maze.resetPellets();
+        assertThat(maze.pelletCount()).isEqualTo(before);
+    }
+
+    @Test
+    void startTilesAreOpen() {
+        assertThat(Maze.passable(13, 23)).isTrue();
+        assertThat(Maze.passable(13, 11)).isTrue();
+        assertThat(Maze.passable(13, 14)).isTrue();
+        assertThat(Maze.door(13, 12)).isTrue();
+        assertThat(Maze.door(14, 12)).isTrue();
+    }
+
+    private static long count(Maze maze, boolean power) {
+        return IntStream.range(0, Maze.ROWS)
+                .mapToLong(row -> IntStream.range(0, Maze.COLUMNS)
+                        .filter(column -> power ? maze.powerPellet(column, row) : maze.pellet(column, row))
+                        .count())
+                .sum();
+    }
+
+}

--- a/docs/video/gourman-demo.tape
+++ b/docs/video/gourman-demo.tape
@@ -1,0 +1,21 @@
+Source shared_.tape
+
+# Setup
+Hide
+Type jbang gourman-demo
+Enter
+Sleep 2
+Show
+
+# Recording
+Sleep 3
+Screenshot screenshots/gourman-demo.svg
+Type "l"
+Sleep 2
+Type "k"
+Sleep 2
+Type "j"
+Sleep 2
+Type "h"
+Sleep 3
+Type "q"

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -22,6 +22,9 @@
     "form-table-demo": {
       "script-ref": "demos/form-table-demo/src/main/java/dev/tamboui/demo/layout/FormTableDemo.java"
     },
+    "gourman-demo": {
+      "script-ref": "demos/gourman-demo/src/main/java/dev/tamboui/demo/gourman/Gourman.java"
+    },
     "inline-progress-demo": {
       "script-ref": "demos/inline-progress-demo/src/main/java/dev/tamboui/demo/InlineProgressDemo.java"
     },


### PR DESCRIPTION
## What

A new demo: **Gourman**, a Pac-Man style maze game rendered entirely with the `Canvas` widget. The name is from the French *gourmand* — keeping with the tambouille spirit (and avoiding the Bandai Namco trademark and the `pacman` binary-name collision with the Arch package manager).

- Classic 28x31 maze with wrapping tunnel, pellets, power pellets and the ghost house
- Arcade ghost AI: scatter/chase phases and per-ghost personalities (Blinky chases, Pinky ambushes four tiles ahead, Inky mirrors Blinky's pincer, Clyde is shy), frightened mode with 200/400/800/1600 chains, eyes racing home when eaten
- Levels that speed up, lives, bonus life, pause/restart
- Rendering notes that may interest other Canvas users:
  - `xBounds`/`yBounds` are set to `[0, N-1]` for an N-pixel grid so integer coordinates map 1:1 onto grid cells (a `[0, N]` span aliases)
  - walls are traced as character-granular outlines (half-block edges mixed with full-height corners looks crenellated)
  - pellets are fullwidth glyphs (`・`, `〇`) so a dot can be dead-centered in a two-cell tile
  - the board refuses to render when the layout can't give it its exact size (sheds border, then side panel, then shows a resize hint)

## Pluggable game events

The game publishes every state change (`GameStarted`, `GourmanMoved`, `PelletEaten`, `GhostEaten`, `GameOver`, ... — a sealed `GameEvent` hierarchy) to `GameListener`s registered programmatically or discovered via `ServiceLoader`. Listeners are isolated (a throwing listener can't break the game loop) and documented as non-blocking. This makes the demo double as an event-source: we use it downstream to stream game events into a message broker.

## Checklist

- `./gradlew :demos:gourman-demo:build` green (includes javadoc `-Werror`, spotless, and 12 unit tests: maze integrity, event stream contract, headless board-buffer render)
- `docs/video/gourman-demo.tape` added; `jbang-catalog.json` regenerated via `updateJBangCatalog`
- Demo conventions followed: `dev.tamboui.demo-project` plugin, `dev.tamboui.demo.gourman` package, Java 21, license headers, jbang `//DEPS`/`//SOURCES` header on the main class

Per the AI policy in CONTRIBUTING: this was developed with LLM assistance (Claude Code); all code has been human-reviewed, run interactively in a terminal, and is maintained by the author.
