### PR TITLE
fix(widgets): full eighth-level resolution for DualSparkline bottom series

### DIFF
--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/sparkline/DualSparkline.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/sparkline/DualSparkline.java
@@ -6,6 +6,7 @@ package dev.tamboui.widgets.sparkline;
 
 import java.util.List;
 import java.util.function.LongFunction;
+import java.util.stream.IntStream;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.layout.Rect;
@@ -299,8 +300,18 @@ public final class DualSparkline implements Widget {
                         ch = barSet.full();
                         style = bottomStyle;
                     } else if (barPx > threshold) {
-                        ch = barSet.symbolForLevel(1.0 - (double) (barPx - threshold) / 8.0);
-                        style = bottomStyle.reversed();
+                        // Complement the effective level of the symbol the top series
+                        // would draw, not the raw pixel fraction, so coarse bar sets
+                        // (e.g. THREE_LEVELS, where several eighths share a symbol)
+                        // quantize identically on both halves.
+                        int eighths = effectiveEighths(barSet, (int) (barPx - threshold));
+                        if (eighths == 8) {
+                            ch = barSet.full();
+                            style = bottomStyle;
+                        } else {
+                            ch = barSet.symbolForLevel((8 - eighths) / 8.0);
+                            style = bottomStyle.reversed();
+                        }
                     } else {
                         ch = barSet.empty();
                         style = bottomStyle;
@@ -339,6 +350,18 @@ public final class DualSparkline implements Widget {
                 }
             }
         }
+    }
+
+    /**
+     * Returns the highest canonical eighth level (1-8) that the bar set maps to the
+     * same symbol as the given level — the fill actually represented on screen.
+     */
+    private static int effectiveEighths(Sparkline.BarSet barSet, int eighths) {
+        String symbol = barSet.symbolForLevel(eighths / 8.0);
+        return IntStream.rangeClosed(eighths, 8)
+                .filter(k -> barSet.symbolForLevel(k / 8.0).equals(symbol))
+                .max()
+                .orElse(eighths);
     }
 
     private long computeMax() {

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/sparkline/DualSparkline.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/sparkline/DualSparkline.java
@@ -24,7 +24,9 @@ import dev.tamboui.widgets.block.Block;
  * <p>
  * The top series renders as bars growing <em>upward</em> from the centre; the bottom series renders as bars growing
  * <em>downward</em> from the centre. Sub-pixel resolution is achieved using Unicode block characters (▁▂▃▄▅▆▇█), giving
- * smooth visual gradation within a single character row. This layout matches the style of macOS Activity Monitor's
+ * smooth visual gradation within a single character row. Because Unicode has no top-anchored eighth blocks, partial
+ * cells of the bottom series are drawn as the complement block glyph in inverse video, which yields the same
+ * eighth-level resolution as the top series. This layout matches the style of macOS Activity Monitor's
  * network and disk activity graphs.
  * <p>
  * Example usage:
@@ -112,7 +114,6 @@ public final class DualSparkline implements Widget {
     private final Long max;
     private final Block block;
     private final Sparkline.BarSet barSet;
-    private final Sparkline.BarSet reversedBarSet;
     private final Sparkline.RenderDirection direction;
     private final boolean showYAxis;
     private final LongFunction<String> yAxisFormatter;
@@ -124,7 +125,6 @@ public final class DualSparkline implements Widget {
         this.max = builder.max;
         this.block = builder.block;
         this.barSet = builder.barSet;
-        this.reversedBarSet = builder.barSet.reversed();
         this.direction = builder.direction;
         this.showYAxis = builder.showYAxis;
         this.yAxisFormatter = builder.yAxisFormatter;
@@ -287,19 +287,24 @@ public final class DualSparkline implements Widget {
                     style = DIM;
                 } else if (r >= bottomStart && r < bottomStart + bottomHalfH) {
                     // Bottom series: bars grow downward from the centre.
-                    // Uses reversed bar set so partial cells fill from the top,
-                    // connecting smoothly to full blocks above.
+                    // Unicode has no top-anchored eighth blocks (only ▔, ▀ and █), so a
+                    // partial cell is drawn as the complement glyph — the part of the
+                    // cell NOT covered by the bar — in inverse video: the glyph area
+                    // takes the cell background and the remainder takes the bar colour,
+                    // giving the same eighth-level resolution as the top series.
                     int rowOffset = r - bottomStart; // 0 at row nearest centre
                     long barPx = botVal * bottomHalfH * 8 / effectiveMax;
                     long threshold = (long) rowOffset * 8;
                     if (barPx >= threshold + 8) {
-                        ch = reversedBarSet.full();
+                        ch = barSet.full();
+                        style = bottomStyle;
                     } else if (barPx > threshold) {
-                        ch = reversedBarSet.symbolForLevel((double) (barPx - threshold) / 8.0);
+                        ch = barSet.symbolForLevel(1.0 - (double) (barPx - threshold) / 8.0);
+                        style = bottomStyle.reversed();
                     } else {
-                        ch = reversedBarSet.empty();
+                        ch = barSet.empty();
+                        style = bottomStyle;
                     }
-                    style = bottomStyle;
                 } else {
                     // Spare row (even height) — empty
                     ch = barSet.empty();

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/sparkline/DualSparklineTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/sparkline/DualSparklineTest.java
@@ -251,19 +251,24 @@ class DualSparklineTest {
     @Test
     @DisplayName("THREE_LEVELS bar set uses coarser symbols")
     void withThreeLevelsBarSet() {
-        // With THREE_LEVELS, 6/8=0.75 → "█" (not "▆" as in NINE_LEVELS)
+        // With THREE_LEVELS, 3/8 → "▄" and 6/8=0.75 → "█" (not "▃"/"▆" as in
+        // NINE_LEVELS). The bottom series quantizes identically to the top:
+        // 6/8 collapses to a full cell (no inverse video) and 3/8 renders as
+        // the complement of the effective half level ("▄" in inverse video).
         DualSparkline chart = DualSparkline.builder()
-                .topData(0, 6, 8)
-                .bottomData(0, 6, 8)
+                .topData(0, 3, 6, 8)
+                .bottomData(0, 3, 6, 8)
                 .barSet(Sparkline.BarSet.THREE_LEVELS)
                 .showYAxis(false)
                 .build();
-        Rect area = new Rect(0, 0, 3, 3);
+        Rect area = new Rect(0, 0, 4, 3);
         Buffer buffer = Buffer.empty(area);
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent(" ██", "───", " ▄█");
+        assertThat(buffer).hasContent(" ▄██", "────", " ▄██");
+        assertThat(buffer).hasStyleAt(1, 2, Style.EMPTY.reversed());
+        assertThat(buffer).hasStyleAt(2, 2, Style.EMPTY);
     }
 
     @Test

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/sparkline/DualSparklineTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/sparkline/DualSparklineTest.java
@@ -56,13 +56,15 @@ class DualSparklineTest {
     }
 
     @Test
-    @DisplayName("Bottom series uses reversed (upper) block characters")
-    void bottomSeriesUsesReversedBlocks() {
-        // 4/8 = 0.5 → top uses ▄ (lower half), bottom should use ▀ (upper half)
+    @DisplayName("Bottom series renders partial cells as complement glyph in inverse video")
+    void bottomSeriesUsesInverseVideoPartials() {
+        // 4/8 = 0.5 → top uses ▄ (lower half); bottom uses the complement glyph ▄
+        // with the REVERSED modifier, so the top half of the cell shows the bar colour
         DualSparkline chart = DualSparkline.builder()
                 .topData(4)
                 .bottomData(4)
                 .max(8)
+                .bottomStyle(Style.EMPTY.fg(Color.BLUE))
                 .showYAxis(false)
                 .build();
         Rect area = new Rect(0, 0, 1, 3);
@@ -70,7 +72,29 @@ class DualSparklineTest {
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent("▄", "─", "▀");
+        assertThat(buffer).hasContent("▄", "─", "▄");
+        assertThat(buffer).hasStyleAt(0, 2, Style.EMPTY.fg(Color.BLUE).reversed());
+    }
+
+    @Test
+    @DisplayName("Bottom series keeps eighth-level resolution via inverse video")
+    void bottomSeriesKeepsEighthResolution() {
+        // Bottom values 1..7 of max 8 render as the complement glyphs ▇▆▅▄▃▂▁ in
+        // inverse video — no collapse to the coarse ▔/▀/█ upper-block ladder
+        DualSparkline chart = DualSparkline.builder()
+                .topData(0, 0, 0, 0, 0, 0, 0)
+                .bottomData(1, 2, 3, 4, 5, 6, 7)
+                .max(8)
+                .showYAxis(false)
+                .build();
+        Rect area = new Rect(0, 0, 7, 3);
+        Buffer buffer = Buffer.empty(area);
+
+        chart.render(area, buffer);
+
+        assertThat(buffer).hasContent("       ", "───────", "▇▆▅▄▃▂▁");
+        assertThat(buffer).hasStyleAt(0, 2, Style.EMPTY.reversed());
+        assertThat(buffer).hasStyleAt(6, 2, Style.EMPTY.reversed());
     }
 
     @Test
@@ -168,7 +192,7 @@ class DualSparklineTest {
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent(" ▄█", "───", " ▀█");
+        assertThat(buffer).hasContent(" ▄█", "───", " ▄█");
     }
 
     @Test
@@ -186,7 +210,7 @@ class DualSparklineTest {
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent("▄█", "──", "▀█");
+        assertThat(buffer).hasContent("▄█", "──", "▄█");
     }
 
     @Test
@@ -203,7 +227,7 @@ class DualSparklineTest {
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent("▂▄█", "───", "▔▀█");
+        assertThat(buffer).hasContent("▂▄█", "───", "▆▄█");
     }
 
     @Test
@@ -221,7 +245,7 @@ class DualSparklineTest {
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent("▆▇█", "───", "███");
+        assertThat(buffer).hasContent("▆▇█", "───", "▂▁█");
     }
 
     @Test
@@ -239,7 +263,7 @@ class DualSparklineTest {
 
         chart.render(area, buffer);
 
-        assertThat(buffer).hasContent(" ██", "───", " ██");
+        assertThat(buffer).hasContent(" ██", "───", " ▄█");
     }
 
     @Test
@@ -291,7 +315,7 @@ class DualSparklineTest {
         chart.render(area, buffer);
 
         // 4/8 → "▄", 8/8 → "█"; columns 2-4 remain empty
-        assertThat(buffer).hasContent("▄█   ", "──   ", "▀█   ");
+        assertThat(buffer).hasContent("▄█   ", "──   ", "▄█   ");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The bottom series of a `DualSparkline` renders much coarser than the top series. Unicode block elements only include eighth-blocks that grow from the bottom of the cell (▁▂▃▄▅▆▇█); for downward-growing bars only ▔ (upper one-eighth), ▀ (upper half) and █ exist, so `NINE_LEVELS_REVERSED` collapses nine levels into a three-step ladder:

```
top:    ▂▃▄▅▆▇██▇▆▅▄▃▂      (smooth)
bottom: ▔▔▀▀▀███▀▀▀▔▔▔      (staircase)
```

## Fix

Render partial bottom cells with the classic inverse-video trick (as used by btop and friends): draw the **complement** glyph from the forward bar set — the part of the cell *not* covered by the bar — with the `REVERSED` style modifier. The glyph area then shows the cell background and the remainder shows the bar colour, i.e. a downward bar with the same eighth-level resolution as the top series. Full and empty cells are unchanged.

`BarSet.reversed()`, `NINE_LEVELS_REVERSED` and `THREE_LEVELS_REVERSED` remain public API but are no longer used by `DualSparkline`.

## Testing

- Updated `DualSparklineTest` expectations (bottom partials are now complement glyphs with reversed style).
- New tests: partial-cell inverse video (glyph + style assertion) and an eighth-resolution ramp `1..7 → ▇▆▅▄▃▂▁` asserting no collapse to the ▔/▀/█ ladder.
- `:tamboui-widgets:test` and `:tamboui-toolkit:test`: 1734 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
