### PR TITLE
fix(panama): dispatch SIGWINCH through JVM signal bridge

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,6 +78,9 @@ jobs:
       - uses: ./.github/actions/shared-build-setup
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Test Panama signal handling in native image
+        if: runner.os != 'Windows'
+        run: ./gradlew :tamboui-panama-backend:nativeTest
       - name: Build native executable
         run: ./gradlew demos:filemanager-demo:nativeCompile
       # - name: Run demo, send q after 2s (Unix) fails as no pty.

--- a/tamboui-panama-backend/build.gradle.kts
+++ b/tamboui-panama-backend/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("dev.tamboui.java-library")
+    id("org.graalvm.buildtools.native")
 }
 
 description = "Panama FFI backend for TamboUI TUI library"
@@ -12,6 +13,13 @@ tasks.withType<JavaCompile>().configureEach {
 
 tasks.withType<Test> {
     jvmArgs("--enable-native-access=ALL-UNNAMED")
+}
+
+graalvmNative {
+    binaries.named("test") {
+        buildArgs.addAll("--enable-native-access=ALL-UNNAMED", "-H:+SharedArenaSupport")
+    }
+    toolchainDetection.set(false)
 }
 
 dependencies {

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/unix/SignalBridge.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/unix/SignalBridge.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.backend.panama.unix;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import dev.tamboui.terminal.BackendException;
+
+/**
+ * Bridges Unix signals through the JVM signal dispatcher.
+ */
+final class SignalBridge implements AutoCloseable {
+
+    private static final Class<?> SIGNAL_CLASS = loadClass("sun.misc.Signal");
+    private static final Class<?> SIGNAL_HANDLER_CLASS = loadClass("sun.misc.SignalHandler");
+    private static final Constructor<?> SIGNAL_CONSTRUCTOR = constructor();
+    private static final Method HANDLE_METHOD = handleMethod();
+
+    private final Object signal;
+    private final Object previousHandler;
+    private boolean closed;
+
+    private SignalBridge(String name, Runnable handler) {
+        try {
+            signal = SIGNAL_CONSTRUCTOR.newInstance(name);
+            Object signalHandler = Proxy.newProxyInstance(
+                    SignalBridge.class.getClassLoader(),
+                    new Class<?>[] {SIGNAL_HANDLER_CLASS},
+                    (proxy, method, args) -> {
+                        if (method.getDeclaringClass() == SIGNAL_HANDLER_CLASS) {
+                            handler.run();
+                        }
+                        return null;
+                    });
+            previousHandler = HANDLE_METHOD.invoke(null, signal, signalHandler);
+        } catch (ReflectiveOperationException e) {
+            throw new BackendException("Failed to install JVM signal handler for " + name, e);
+        }
+    }
+
+    static SignalBridge onWindowChange(Runnable handler) {
+        return new SignalBridge("WINCH", handler);
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            try {
+                HANDLE_METHOD.invoke(null, signal, previousHandler);
+                closed = true;
+            } catch (ReflectiveOperationException e) {
+                throw new BackendException("Failed to restore JVM signal handler", e);
+            }
+        }
+    }
+
+    private static Class<?> loadClass(String name) {
+        try {
+            return Class.forName(name);
+        } catch (ClassNotFoundException e) {
+            throw new BackendException("JVM signal handling is unavailable", e);
+        }
+    }
+
+    private static Constructor<?> constructor() {
+        try {
+            return SIGNAL_CLASS.getConstructor(String.class);
+        } catch (NoSuchMethodException e) {
+            throw new BackendException("JVM signal handling is unavailable", e);
+        }
+    }
+
+    private static Method handleMethod() {
+        try {
+            return SIGNAL_CLASS.getMethod("handle", SIGNAL_CLASS, SIGNAL_HANDLER_CLASS);
+        } catch (NoSuchMethodException e) {
+            throw new BackendException("JVM signal handling is unavailable", e);
+        }
+    }
+}

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/unix/UnixTerminal.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/unix/UnixTerminal.java
@@ -19,7 +19,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import dev.tamboui.backend.panama.PlatformTerminal;
 import dev.tamboui.error.RuntimeIOException;
 import dev.tamboui.layout.Size;
-import dev.tamboui.terminal.BackendException;
 
 /**
  * Unix terminal operations using Panama FFI.
@@ -75,9 +74,8 @@ public final class UnixTerminal implements PlatformTerminal {
     private int peekedChar = -2;
     private final ReentrantLock resizeLock = new ReentrantLock();
     private Runnable resizeHandler;
-    private boolean resizePending;
-    private MemorySegment previousSigaction;  // Previous sigaction struct (for restoration)
-    private Arena signalArena;
+    private volatile boolean resizePending;
+    private SignalBridge signalBridge;
 
     /**
      * Creates a new Unix terminal instance.
@@ -429,9 +427,8 @@ public final class UnixTerminal implements PlatformTerminal {
     /**
      * Registers a handler to be called when the terminal is resized.
      * <p>
-     * On Unix systems, this installs a SIGWINCH signal handler using Panama FFI.
-     * The signal handler sets a flag which is checked from the main event loop
-     * (via {@link #read(int)}), ensuring the handler is called from a safe context.
+     * SIGWINCH is dispatched through the JVM signal bridge. The bridge callback
+     * only marks the resize as pending; {@link #read(int)} invokes the handler.
      * <p>
      * Only one handler can be registered at a time; subsequent calls
      * will replace the previous handler.
@@ -441,43 +438,12 @@ public final class UnixTerminal implements PlatformTerminal {
     public void onResize(Runnable handler) {
         resizeLock.lock();
         try {
-            this.resizeHandler = handler;
-            if (handler != null && signalArena == null) {
-                // Create a dedicated arena for the signal handler that lives as long as needed
-                signalArena = Arena.ofShared();
-
-                // Create the upcall stub for our signal handler
-                // IMPORTANT: We only set a flag here, NOT call the handler directly.
-                // Calling complex code from signal context can cause crashes.
-                var signalHandlerStub = LibC.createSignalHandler(signalArena, signum -> {
-                    resizeLock.lock();
-                    try {
-                        resizePending = true;
-                    } finally {
-                        resizeLock.unlock();
-                    }
-                });
-
-                // Use sigaction() instead of signal() for better reliability on macOS
-                // Allocate sigaction structs
-                MemorySegment newSigaction = LibC.allocateSigaction(signalArena);
-                MemorySegment oldSigaction = LibC.allocateSigaction(signalArena);
-                
-                // Set up new sigaction: handler pointer, NULL trampoline, empty mask, SA_RESTART flag
-                LibC.setSigactionHandler(newSigaction, signalHandlerStub);
-                LibC.setSigactionTramp(newSigaction, MemorySegment.NULL);  // NULL for simple handlers
-                LibC.setSigactionMask(newSigaction, 0);
-                LibC.setSigactionFlags(newSigaction, LibC.SA_RESTART);
-                
-                // Install the signal handler and save the previous one
-                int sigactionResult = LibC.sigaction(LibC.SIGWINCH, newSigaction, oldSigaction);
-                
-                if (sigactionResult != 0) {
-                    throw new BackendException("Failed to install signal handler for Unix terminal (errno=" + LibC.getLastErrno() + ")");
-                }
-                
-                // Save the old sigaction for restoration on close
-                previousSigaction = oldSigaction;
+            resizeHandler = handler;
+            if (handler != null && signalBridge == null) {
+                signalBridge = SignalBridge.onWindowChange(() -> resizePending = true);
+            } else if (handler == null && signalBridge != null) {
+                signalBridge.close();
+                signalBridge = null;
             }
         } finally {
             resizeLock.unlock();
@@ -513,18 +479,11 @@ public final class UnixTerminal implements PlatformTerminal {
                 disableRawMode();
             }
         } finally {
-            // Restore previous SIGWINCH handler using sigaction
-            if (previousSigaction != null) {
-                LibC.sigaction(LibC.SIGWINCH, previousSigaction, MemorySegment.NULL);
-                previousSigaction = null;
+            if (signalBridge != null) {
+                signalBridge.close();
+                signalBridge = null;
             }
             resizeHandler = null;
-
-            // Close the signal arena (this invalidates the upcall stub)
-            if (signalArena != null) {
-                signalArena.close();
-                signalArena = null;
-            }
 
             // Don't close stdin on macOS
             if (!PlatformConstants.isMacOS()) {

--- a/tamboui-panama-backend/src/main/java/module-info.java
+++ b/tamboui-panama-backend/src/main/java/module-info.java
@@ -11,6 +11,7 @@ import dev.tamboui.terminal.BackendProvider;
  * Requires Java 22 or later for the finalized FFI API.
  */
 module dev.tamboui.panama.backend {
+    requires jdk.unsupported;
     requires transitive dev.tamboui.core;
 
     exports dev.tamboui.backend.panama;

--- a/tamboui-panama-backend/src/main/resources/META-INF/native-image/dev.tamboui.panama.backend/tamboui-panama-backend/reachability-metadata.json
+++ b/tamboui-panama-backend/src/main/resources/META-INF/native-image/dev.tamboui.panama.backend/tamboui-panama-backend/reachability-metadata.json
@@ -5,6 +5,16 @@
       "methods": [
         { "name": "accept", "parameterTypes": ["int"] }
       ]
+    },
+    {
+      "type": "sun.misc.Signal",
+      "methods": [
+        { "name": "<init>", "parameterTypes": ["java.lang.String"] },
+        { "name": "handle", "parameterTypes": ["sun.misc.Signal", "sun.misc.SignalHandler"] }
+      ]
+    },
+    {
+      "type": { "proxy": ["sun.misc.SignalHandler"] }
     }
   ],
   "foreign": {

--- a/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/unix/SignalBridgeTest.java
+++ b/tamboui-panama-backend/src/test/java/dev/tamboui/backend/panama/unix/SignalBridgeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.backend.panama.unix;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnabledOnOs({OS.LINUX, OS.MAC})
+class SignalBridgeTest {
+
+    @Test
+    void dispatchesOperatingSystemWinchSignalAndRestoresPreviousHandler() throws Exception {
+        CountDownLatch restored = new CountDownLatch(1);
+
+        try (SignalBridge previous = SignalBridge.onWindowChange(restored::countDown)) {
+            assertNotNull(previous);
+            CountDownLatch received = new CountDownLatch(1);
+            try (SignalBridge bridge = SignalBridge.onWindowChange(received::countDown)) {
+                assertNotNull(bridge);
+                sendWinch();
+                assertTrue(received.await(5, TimeUnit.SECONDS), "SIGWINCH was not dispatched");
+            }
+
+            sendWinch();
+            assertTrue(restored.await(5, TimeUnit.SECONDS), "Previous SIGWINCH handler was not restored");
+        }
+    }
+
+    private static void sendWinch() throws Exception {
+        Process kill = new ProcessBuilder(
+                "kill", "-WINCH", Long.toString(ProcessHandle.current().pid()))
+                .start();
+        assertEquals(0, kill.waitFor());
+    }
+}


### PR DESCRIPTION
## Summary

- replace the raw Panama `sigaction()` upcall with a JVM-managed `SIGWINCH` bridge
- keep resize callbacks deferred to the terminal input loop
- add a native-image test that sends a real `SIGWINCH` and verifies handler restoration
- run the Panama native test on Linux and macOS CI

## Rationale

The existing handler lets the kernel enter Java through an FFM upcall while an arbitrary thread may be between Java and native states. Even though the callback only marks a resize as pending, entering Java and acquiring a `ReentrantLock` from signal context can trigger the SubstrateVM failure reported in #405.

The replacement follows the approach used by Aesh and JLine. It registers `sun.misc.Signal` reflectively, allowing the JVM to own the platform signal handler and dispatch the Java callback from a valid JVM context. The callback only sets a volatile flag; the input loop still invokes the application resize handler and reads the new size with `ioctl(TIOCGWINSZ)`.

This keeps resize handling event-driven. Polling would avoid signal APIs altogether, but it would add periodic native calls while idle and up to one polling interval of resize latency.

## Tradeoffs

`sun.misc.Signal` is an internal API, so the Panama module now declares `jdk.unsupported` and includes native-image reflection/proxy metadata. Signal handlers are also process-global. The bridge restores the previous handler when removed or closed, matching the existing lifecycle behavior.

The native regression test covers both JVM-managed delivery and restoration under GraalVM native-image. If a future JDK or GraalVM stops supporting this bridge, the native CI job should fail and polling remains a fallback.

## Testing

- `./gradlew -q test`
- `./gradlew -q build`
- `./gradlew -q javadoc`
- `./gradlew -q :tamboui-panama-backend:nativeTest`

Fixes #405
