### PR TITLE
fix: Handle Ctrl+Space (NUL) in EventParser

### DIFF
--- a/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
+++ b/tamboui-tui/src/main/java/dev/tamboui/tui/event/EventParser.java
@@ -82,6 +82,8 @@ public final class EventParser {
 
     private static Event parseControlChar(int c, Bindings bindings) {
         switch (c) {
+            case 0:
+                return KeyEvent.ofChar(' ', KeyModifiers.CTRL, bindings); // Ctrl+Space (NUL)
             case 3:
                 return KeyEvent.ofChar('c', KeyModifiers.CTRL, bindings); // Ctrl+C
             case 8:


### PR DESCRIPTION
## Summary

- Ctrl+Space sends NUL (0x00) in terminals, but `EventParser.parseControlChar()` only handled control chars 1-26 in the default case, causing Ctrl+Space to produce `KeyCode.UNKNOWN`
- Added `case 0:` to map NUL to `KeyEvent.ofChar(' ', KeyModifiers.CTRL)`, making Ctrl+Space a recognized key event
- This is commonly used as a code-completion trigger in editors

## Test plan

- [ ] Verify Ctrl+Space produces a `KeyEvent` with `code=CHAR`, `character=' '`, `modifiers=CTRL`
- [ ] Verify no regression in other control character handling (Ctrl+C, Tab, Enter, etc.)

_Claude Code on behalf of davsclaus_