### PR TITLE
feat: add synchronized output (Mode 2026) to prevent screen tearing

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jline = "3.25.1"
-aesh-terminal = "3.14.1"
+aesh-terminal = "3.16.4"
 junit = "5.14.3"
 assertj = "3.27.7"
 native-build-tools = "0.11.4"

--- a/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
+++ b/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
@@ -215,6 +215,16 @@ public class AeshBackend extends AbstractBackend {
     }
 
     @Override
+    public void beginSynchronizedUpdate() throws IOException {
+        outputBuffer.append(MODE_2026_BSU);
+    }
+
+    @Override
+    public void endSynchronizedUpdate() throws IOException {
+        outputBuffer.append(MODE_2026_ESU);
+    }
+
+    @Override
     public void scrollUp(int lines) throws IOException {
         outputBuffer.append(CSI).append(lines).append("S");
         flush();

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Backend.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Backend.java
@@ -127,6 +127,41 @@ public interface Backend extends AutoCloseable {
         // Optional: not all backends support mouse
     }
 
+    /** Mode 2026 Begin Synchronized Update escape sequence. */
+    String MODE_2026_BSU = "\033[?2026h";
+    /** Mode 2026 End Synchronized Update escape sequence. */
+    String MODE_2026_ESU = "\033[?2026l";
+
+    /**
+     * Begins a synchronized update (Mode 2026 BSU).
+     * <p>
+     * When supported, the terminal buffers all subsequent output until
+     * {@link #endSynchronizedUpdate()} is called, then renders everything
+     * in a single frame. This prevents screen tearing during redraws.
+     * <p>
+     * Terminals that do not support Mode 2026 safely ignore the escape sequence.
+     *
+     * @throws IOException if the operation fails
+     */
+    default void beginSynchronizedUpdate() throws IOException {
+        // Optional: not all backends support synchronized output
+    }
+
+    /**
+     * Ends a synchronized update (Mode 2026 ESU).
+     * <p>
+     * The terminal renders all buffered output since the last
+     * {@link #beginSynchronizedUpdate()} call as a single atomic frame.
+     * <p>
+     * Must be called in a {@code finally} block to avoid leaving the
+     * terminal in a stuck buffering state.
+     *
+     * @throws IOException if the operation fails
+     */
+    default void endSynchronizedUpdate() throws IOException {
+        // Optional: not all backends support synchronized output
+    }
+
     /**
      * Enables bracketed paste mode ({@code ESC[?2004h}).
      * <p>

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/Terminal.java
@@ -149,36 +149,46 @@ public final class Terminal<B extends Backend> implements AutoCloseable {
 
                 // Calculate diff and draw (zero-allocation DoD variant)
                 previousBuffer.diff(currentBuffer, diffResult);
-                if (!diffResult.isEmpty()) {
-                    backend.draw(diffResult);
-                }
-                diffResult.clear();  // Clear after use to release Cell refs for GC
 
-                // Handle cursor
-                if (frame.isCursorVisible()) {
-                    frame.cursorPosition().ifPresent(pos -> {
-                        try {
-                            backend.setCursorPosition(pos);
-                            if (hiddenCursor) {
-                                backend.showCursor();
-                                hiddenCursor = false;
-                            }
-                        } catch (IOException e) {
-                            throw new RuntimeIOException(
-                                    String.format("Failed to set cursor position to %s: %s", pos, e.getMessage()), e);
-                        }
-                    });
-                } else if (!hiddenCursor) {
-                    try {
-                        backend.hideCursor();
-                        hiddenCursor = true;
-                    } catch (IOException e) {
-                        throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
+                // Wrap rendering in synchronized update (Mode 2026) to prevent tearing.
+                // BSU, draw data, cursor ops, and ESU are all written to the output
+                // buffer and flushed together in a single syscall for atomic rendering.
+                backend.beginSynchronizedUpdate();
+                try {
+                    if (!diffResult.isEmpty()) {
+                        backend.draw(diffResult);
                     }
-                }
 
-                // Flush output
-                backend.flush();
+                    // Handle cursor
+                    if (frame.isCursorVisible()) {
+                        frame.cursorPosition().ifPresent(pos -> {
+                            try {
+                                backend.setCursorPosition(pos);
+                                if (hiddenCursor) {
+                                    backend.showCursor();
+                                    hiddenCursor = false;
+                                }
+                            } catch (IOException e) {
+                                throw new RuntimeIOException(
+                                        String.format("Failed to set cursor position to %s: %s", pos, e.getMessage()),
+                                        e);
+                            }
+                        });
+                    } else if (!hiddenCursor) {
+                        try {
+                            backend.hideCursor();
+                            hiddenCursor = true;
+                        } catch (IOException e) {
+                            throw new RuntimeIOException("Failed to hide cursor: " + e.getMessage(), e);
+                        }
+                    }
+                } finally {
+                    diffResult.clear();  // Release Cell refs for GC even on error
+                    // Write ESU before flushing so BSU + draw + ESU are sent atomically.
+                    // Done in finally to avoid leaving the terminal in a stuck buffering state.
+                    backend.endSynchronizedUpdate();
+                    backend.flush();
+                }
 
                 // Swap buffers
                 Buffer temp = previousBuffer;

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/SynchronizedOutputTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/SynchronizedOutputTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.terminal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.buffer.DiffResult;
+import dev.tamboui.layout.Position;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.layout.Size;
+import dev.tamboui.style.Style;
+import dev.tamboui.widget.Widget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that Terminal.draw() wraps rendering with Mode 2026
+ * synchronized output (BSU/ESU) and flushes in the correct order.
+ */
+class SynchronizedOutputTest {
+
+    /** Simple widget that writes a character at (0,0). */
+    private static final Widget SIMPLE_WIDGET = (area, buf) ->
+            buf.setString(0, 0, "A", Style.EMPTY);
+
+    @Test
+    @DisplayName("draw() wraps rendering with BSU/ESU in correct order")
+    void drawWrapsWithSynchronizedUpdate() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame ->
+                frame.renderWidget(SIMPLE_WIDGET, Rect.of(10, 5)));
+
+        List<String> calls = backend.calls();
+        assertThat(calls).containsExactly(
+                "beginSynchronizedUpdate",
+                "draw",
+                "endSynchronizedUpdate",
+                "flush");
+    }
+
+    @Test
+    @DisplayName("draw() sends BSU/ESU even with no diff")
+    void drawSendsSyncUpdateEvenWithNoDiff() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        // First draw to establish the buffer
+        terminal.draw(frame -> {});
+        backend.clearCalls();
+
+        // Second draw with same content — no diff, but BSU/ESU still sent
+        terminal.draw(frame -> {});
+
+        List<String> calls = backend.calls();
+        assertThat(calls).contains("beginSynchronizedUpdate", "endSynchronizedUpdate", "flush");
+        // No "draw" call since there's no diff
+        assertThat(calls).doesNotContain("draw");
+    }
+
+    @Test
+    @DisplayName("endSynchronizedUpdate is always before flush")
+    void endSyncAlwaysBeforeFlush() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame ->
+                frame.renderWidget(SIMPLE_WIDGET, Rect.of(10, 5)));
+
+        List<String> calls = backend.calls();
+        int esuIndex = calls.indexOf("endSynchronizedUpdate");
+        int flushIndex = calls.indexOf("flush");
+        assertThat(esuIndex).isGreaterThanOrEqualTo(0);
+        assertThat(flushIndex).isGreaterThan(esuIndex);
+    }
+
+    @Test
+    @DisplayName("beginSynchronizedUpdate is always before draw")
+    void beginSyncAlwaysBeforeDraw() {
+        RecordingBackend backend = new RecordingBackend(10, 5);
+        Terminal<RecordingBackend> terminal = new Terminal<>(backend);
+
+        terminal.draw(frame ->
+                frame.renderWidget(SIMPLE_WIDGET, Rect.of(10, 5)));
+
+        List<String> calls = backend.calls();
+        int bsuIndex = calls.indexOf("beginSynchronizedUpdate");
+        int drawIndex = calls.indexOf("draw");
+        assertThat(bsuIndex).isGreaterThanOrEqualTo(0);
+        assertThat(drawIndex).isGreaterThan(bsuIndex);
+    }
+
+    /**
+     * A minimal backend that records the order of synchronized output
+     * and flush calls for assertion.
+     */
+    private static class RecordingBackend implements Backend {
+
+        private final int width;
+        private final int height;
+        private final List<String> calls = new ArrayList<>();
+
+        RecordingBackend(int width, int height) {
+            this.width = width;
+            this.height = height;
+        }
+
+        List<String> calls() {
+            return Collections.unmodifiableList(calls);
+        }
+
+        void clearCalls() {
+            calls.clear();
+        }
+
+        @Override
+        public void beginSynchronizedUpdate() throws IOException {
+            calls.add("beginSynchronizedUpdate");
+        }
+
+        @Override
+        public void endSynchronizedUpdate() throws IOException {
+            calls.add("endSynchronizedUpdate");
+        }
+
+        @Override
+        public void draw(DiffResult diff) throws IOException {
+            calls.add("draw");
+        }
+
+        @Override
+        public void flush() throws IOException {
+            calls.add("flush");
+        }
+
+        @Override
+        public void clear() throws IOException {
+        }
+
+        @Override
+        public Size size() throws IOException {
+            return new Size(width, height);
+        }
+
+        @Override
+        public void showCursor() throws IOException {
+        }
+
+        @Override
+        public void hideCursor() throws IOException {
+        }
+
+        @Override
+        public Position getCursorPosition() throws IOException {
+            return Position.ORIGIN;
+        }
+
+        @Override
+        public void setCursorPosition(Position position) throws IOException {
+        }
+
+        @Override
+        public void enterAlternateScreen() throws IOException {
+        }
+
+        @Override
+        public void leaveAlternateScreen() throws IOException {
+        }
+
+        @Override
+        public void enableRawMode() throws IOException {
+        }
+
+        @Override
+        public void disableRawMode() throws IOException {
+        }
+
+        @Override
+        public void onResize(Runnable handler) {
+        }
+
+        @Override
+        public int read(int timeoutMs) throws IOException {
+            return -2;
+        }
+
+        @Override
+        public int peek(int timeoutMs) throws IOException {
+            return -2;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -185,6 +185,16 @@ public class JLineBackend extends AbstractBackend {
     }
 
     @Override
+    public void beginSynchronizedUpdate() throws IOException {
+        writer.print(MODE_2026_BSU);
+    }
+
+    @Override
+    public void endSynchronizedUpdate() throws IOException {
+        writer.print(MODE_2026_ESU);
+    }
+
+    @Override
     public void scrollUp(int lines) throws IOException {
         writer.print(CSI + lines + "S");
         writer.flush();

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -167,6 +167,16 @@ public class PanamaBackend extends AbstractBackend {
     }
 
     @Override
+    public void beginSynchronizedUpdate() throws IOException {
+        outputBuffer.appendAscii(MODE_2026_BSU);
+    }
+
+    @Override
+    public void endSynchronizedUpdate() throws IOException {
+        outputBuffer.appendAscii(MODE_2026_ESU);
+    }
+
+    @Override
     public void scrollUp(int lines) throws IOException {
         outputBuffer.csi().appendInt(lines).append((byte) 'S');
         flush();


### PR DESCRIPTION
Wrap Terminal.draw() with Mode 2026 BSU/ESU sequences so the terminal buffers all frame output and renders it atomically. This eliminates visible tearing on supported terminals (Kitty, Ghostty, WezTerm, Foot, Contour, iTerm2, Mintty) with no impact on unsupported ones which safely ignore the escape sequences.

Changes:
- Backend interface: add MODE_2026_BSU/ESU constants and beginSynchronizedUpdate()/endSynchronizedUpdate() default methods
- Terminal.draw(): wrap diff rendering + cursor handling in BSU/ESU with ESU in finally block to prevent stuck buffering state
- All 3 backends implement the methods (Aesh, JLine, Panama)
- SynchronizedOutputTest verifies correct call ordering

Also upgrade aesh-terminal from 3.14.1 to 3.16.4.

Replaces PR #282 (created against older codebase, now conflicting).