### PR TITLE
fix: skip Mode 2027 query to eliminate 500ms startup penalty (#409)

### DIFF
--- a/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
+++ b/tamboui-aesh-backend/src/main/java/dev/tamboui/backend/aesh/AeshBackend.java
@@ -21,7 +21,6 @@ import org.aesh.terminal.utils.ANSI;
 import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Size;
 import dev.tamboui.terminal.AbstractBackend;
-import dev.tamboui.terminal.Mode2027Status;
 import dev.tamboui.terminal.Mode2027Support;
 
 /**
@@ -81,7 +80,6 @@ public class AeshBackend extends AbstractBackend {
     private AeshBackend(Connection connection, boolean ownConnection) throws IOException {
         this.connection = Objects.requireNonNull(connection, "connection cannot be null");
         this.ownConnection = ownConnection;
-        this.connection.openNonBlocking();
         this.outputBuffer = new StringBuilder();
         this.inputQueue = new LinkedBlockingQueue<>();
         this.inAlternateScreen = false;
@@ -101,6 +99,9 @@ public class AeshBackend extends AbstractBackend {
                 resizeHandler.run();
             }
         });
+
+        // Start reader AFTER handlers are set up to avoid losing input (#409)
+        this.connection.openNonBlocking();
     }
 
     @Override
@@ -172,12 +173,11 @@ public class AeshBackend extends AbstractBackend {
     @Override
     public void enableRawMode() throws IOException {
         savedAttributes = connection.enterRawMode();
-        // Query and enable Mode 2027 (grapheme cluster mode) after entering raw mode
-        Mode2027Status status = Mode2027Support.query(this, 500);
-        if (status.isSupported()) {
-            Mode2027Support.enable(this);
-            mode2027Enabled = true;
-        }
+        // Enable Mode 2027 (grapheme cluster mode) unconditionally.
+        // Terminals that don't support it safely ignore the escape sequence.
+        // No DECRQM query — avoids 500ms timeout penalty (#409).
+        Mode2027Support.enable(this);
+        mode2027Enabled = true;
     }
 
     @Override

--- a/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
+++ b/tamboui-jline3-backend/src/main/java/dev/tamboui/backend/jline3/JLineBackend.java
@@ -18,7 +18,6 @@ import org.jline.utils.NonBlockingReader;
 import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Size;
 import dev.tamboui.terminal.AbstractBackend;
-import dev.tamboui.terminal.Mode2027Status;
 import dev.tamboui.terminal.Mode2027Support;
 
 /**
@@ -141,13 +140,11 @@ public class JLineBackend extends AbstractBackend {
         attrs.setLocalFlag(Attributes.LocalFlag.ISIG, false);
         terminal.setAttributes(attrs);
 
-        // Query and enable Mode 2027 (grapheme cluster mode) after entering raw mode
-        // to prevent the response from being echoed to the terminal
-        Mode2027Status status = Mode2027Support.query(this, 500);
-        if (status.isSupported()) {
-            Mode2027Support.enable(this);
-            mode2027Enabled = true;
-        }
+        // Enable Mode 2027 (grapheme cluster mode) unconditionally.
+        // Terminals that don't support it safely ignore the escape sequence.
+        // No DECRQM query — avoids 500ms timeout penalty (#409).
+        Mode2027Support.enable(this);
+        mode2027Enabled = true;
     }
 
     @Override

--- a/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
+++ b/tamboui-panama-backend/src/main/java/dev/tamboui/backend/panama/PanamaBackend.java
@@ -13,7 +13,6 @@ import dev.tamboui.backend.panama.windows.WindowsTerminal;
 import dev.tamboui.layout.Position;
 import dev.tamboui.layout.Size;
 import dev.tamboui.terminal.AbstractBackend;
-import dev.tamboui.terminal.Mode2027Status;
 import dev.tamboui.terminal.Mode2027Support;
 
 /**
@@ -125,13 +124,11 @@ public class PanamaBackend extends AbstractBackend {
     public void enableRawMode() throws IOException {
         terminal.enableRawMode();
 
-        // Query and enable Mode 2027 (grapheme cluster mode) after entering raw mode
-        // to prevent the response from being echoed to the terminal
-        Mode2027Status status = Mode2027Support.query(this, 500);
-        if (status.isSupported()) {
-            Mode2027Support.enable(this);
-            mode2027Enabled = true;
-        }
+        // Enable Mode 2027 (grapheme cluster mode) unconditionally.
+        // Terminals that don't support it safely ignore the escape sequence.
+        // No DECRQM query — avoids 500ms timeout penalty (#409).
+        Mode2027Support.enable(this);
+        mode2027Enabled = true;
     }
 
     @Override


### PR DESCRIPTION
Enable Mode 2027 (grapheme cluster mode) unconditionally without querying via DECRQM first. Terminals that don't support Mode 2027 safely ignore the escape sequence — same as Mode 2026 (synchronized output).

The DECRQM query caused a 500ms timeout on:
- Terminals that don't respond (most terminals)
- AeshBackend where the response was consumed by the EventDecoder before reaching the inputQueue
- PanamaBackend when the terminal doesn't support Mode 2027

Also fix AeshBackend constructor race: move openNonBlocking() after stdinHandler setup to avoid losing input that arrives before the handler is registered.