### PR TITLE
Add text wrap support to TextArea

### DIFF
--- a/docs/src/docs/asciidoc/widgets.adoc
+++ b/docs/src/docs/asciidoc/widgets.adoc
@@ -160,11 +160,12 @@ Displays multi-line text with wrapping and alignment:
 include::{snippets-dir}/dev/tamboui/docs/snippets/WidgetsSnippets.java[tags=paragraph]
 ----
 
-Wrap modes:
+Wrap modes, set with `.overflow(...)` (CSS property: `text-overflow`):
 
-* `Wrap.NONE` - No wrapping, text is clipped
-* `Wrap.CHARACTER` - Wrap at any character
-* `Wrap.WORD` - Wrap at word boundaries
+* `Overflow.CLIP` - No wrapping, text is clipped
+* `Overflow.WRAP_CHARACTER` - Wrap at any character
+* `Overflow.WRAP_WORD` - Wrap at word boundaries
+* `Overflow.ELLIPSIS` / `ELLIPSIS_START` / `ELLIPSIS_MIDDLE` - Truncate with `...` at the end, start, or middle
 
 == Selection Widgets
 
@@ -551,11 +552,29 @@ State methods:
 * `state.scrollUp(amount)` / `state.scrollDown(amount, visibleRows)` - Manual scrolling
 * `state.clear()` - Clear all content
 
+Wrap modes:
+
+By default a long line is clipped and the view scrolls horizontally. Set `.overflow(...)` on
+`TextArea.Builder` (or `.overflow(...)` / `.wrapWord()` / `.wrapCharacter()` / `.clip()` on
+`TextAreaElement`) to wrap it across multiple screen rows instead:
+
+* `Overflow.CLIP` - No wrapping, horizontal scrolling (default)
+* `Overflow.WRAP_CHARACTER` - Wrap at any character
+* `Overflow.WRAP_WORD` - Wrap at word boundaries
+
+While wrapping, `Up`/`Down` move the cursor by visual row rather than by logical line, and the
+line-number gutter shows a number only on the first row of each logical line.
+
+NOTE: Unlike `Paragraph`, a text area does not support the truncating modes (`Overflow.ELLIPSIS`,
+`ELLIPSIS_START`, `ELLIPSIS_MIDDLE`) - the cursor can move into text they would hide. They fall
+back to `Overflow.CLIP`.
+
 CSS properties:
 
 * `cursor-color` - Cursor highlight color
 * `placeholder-color` - Placeholder text color
 * `line-number-color` - Line number gutter color
+* `text-overflow` - Wrap mode (`clip`, `wrap-word`, `wrap-character`)
 
 [[checkbox]]
 === Checkbox

--- a/docs/src/docs/asciidoc/widgets.adoc
+++ b/docs/src/docs/asciidoc/widgets.adoc
@@ -550,6 +550,7 @@ State methods:
 * `state.moveCursorToLineStart()` / `moveCursorToLineEnd()` - Jump to line boundaries
 * `state.moveCursorToStart()` / `moveCursorToEnd()` - Jump to document boundaries
 * `state.scrollUp(amount)` / `state.scrollDown(amount, visibleRows)` - Manual scrolling
+  (`scrollDown(amount, visibleRows, visibleCols, overflow)` counts wrapped rows when wrapping)
 * `state.clear()` - Clear all content
 
 Wrap modes:
@@ -562,8 +563,11 @@ By default a long line is clipped and the view scrolls horizontally. Set `.overf
 * `Overflow.WRAP_CHARACTER` - Wrap at any character
 * `Overflow.WRAP_WORD` - Wrap at word boundaries
 
-While wrapping, `Up`/`Down` move the cursor by visual row rather than by logical line, and the
-line-number gutter shows a number only on the first row of each logical line.
+While wrapping, `Up`/`Down` move the cursor by visual row rather than by logical line, keeping
+its screen column, and the line-number gutter shows a number only on the first row of each
+logical line. A line whose last row fills the whole width is followed by an empty row, so the
+cursor at the end of that line stays visible. In the Toolkit DSL, a wrapping `TextAreaElement`
+asks its container for enough rows to show every wrapped line.
 
 NOTE: Unlike `Paragraph`, a text area does not support the truncating modes (`Overflow.ELLIPSIS`,
 `ELLIPSIS_START`, `ELLIPSIS_MIDDLE`) - the cursor can move into text they would hide. They fall

--- a/tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java
+++ b/tamboui-css/demos/css-demo/src/main/java/dev/tamboui/demo/CssDemo.java
@@ -24,6 +24,7 @@ import dev.tamboui.toolkit.elements.ListElement;
 import dev.tamboui.toolkit.event.EventResult;
 import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.input.TextAreaState;
 
 import static dev.tamboui.toolkit.Toolkit.*;
 
@@ -52,6 +53,9 @@ public class CssDemo implements Element {
         "Notifications"
     );
     private final ListElement<?> navList;
+    private final TextAreaState overflowState = new TextAreaState(
+        "The text-overflow CSS property controls how this long line behaves: "
+        + "the dark theme wraps it at word boundaries while the light theme clips it at the pane edge.");
 
     private CssDemo() {
         styleEngine = StyleEngine.create();
@@ -140,12 +144,22 @@ public class CssDemo implements Element {
                 text("  - Styles come from CSS files")
             )).id("about-panel").focusable().title("About").rounded())
 
-            // Footer
-            .bottom(panel(() -> row(
-                text("Programmatic ").bold().cyan(),
-                text("+ CSS ").addClass("primary"),
-                text("= Powerful Styling").addClass("success")
-            )).rounded())
+            // Footer: a text area whose overflow mode comes from the theme's
+            // text-overflow property (dark = wrap-word, light = clip) - toggling
+            // the theme with [t] re-wraps this text with zero code involved.
+            .bottom(column(
+                textArea(overflowState)
+                    .id("overflow-area")
+                    .title("text-overflow from CSS (watch me on [t])")
+                    .showCursor(false)
+                    .rounded()
+                    .length(4),
+                panel(() -> row(
+                    text("Programmatic ").bold().cyan(),
+                    text("+ CSS ").addClass("primary"),
+                    text("= Powerful Styling").addClass("success")
+                )).rounded().length(3)
+            ).length(7))
         .render(frame, area, context);
     }
 

--- a/tamboui-css/demos/css-demo/src/main/resources/themes-css/dark.tcss
+++ b/tamboui-css/demos/css-demo/src/main/resources/themes-css/dark.tcss
@@ -116,3 +116,8 @@ ListElement-item:nth-child(odd) {
     color: cyan;
     text-style: bold;
 }
+
+/* Overflow showcase: dark theme wraps the demo text area at word boundaries */
+#overflow-area {
+    text-overflow: wrap-word;
+}

--- a/tamboui-css/demos/css-demo/src/main/resources/themes-css/light.tcss
+++ b/tamboui-css/demos/css-demo/src/main/resources/themes-css/light.tcss
@@ -117,3 +117,8 @@ ListElement-item:nth-child(odd) {
     color: #0066cc;
     text-style: bold;
 }
+
+/* Overflow showcase: light theme clips the demo text area at the pane edge */
+#overflow-area {
+    text-overflow: clip;
+}

--- a/tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java
+++ b/tamboui-toolkit/demos/textarea-demo/src/main/java/dev/tamboui/demo/TextAreaDemo.java
@@ -64,18 +64,20 @@ public class TextAreaDemo implements Element {
               - Press Enter for new lines
               - Use Home/End for line navigation
 
+            This editor uses the default clip mode, so this long line simply runs off the right edge of the pane instead of wrapping.
+
             Try editing this text!""");
 
-        // Notes area starts empty with placeholder
-        notesState = new TextAreaState();
+        // Notes area demonstrates word wrapping while editing
+        notesState = new TextAreaState(
+            "This pane wraps at word boundaries: type or paste a long sentence and watch it "
+            + "reflow as you edit. Up/Down move by visual row, not logical line.");
 
-        // Read-only area with pre-filled content
+        // Read-only area demonstrates character wrapping
         readOnlyState = new TextAreaState("""
-            This area demonstrates:
-            - showLineNumbers()
-            - Custom lineNumberStyle()
-            - Text that cannot be edited
-            (Focus is disabled)""");
+            This read-only pane wraps by character, breaking anywhere:
+            ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT
+            (also shows line numbers and a disabled cursor)""");
 
         // Initialize counts
         updateCounts();
@@ -125,7 +127,7 @@ public class TextAreaDemo implements Element {
                 // Left column - Main editor
                 column(
                     textArea(mainEditorState)
-                        .title("Main Editor")
+                        .title("Main Editor (clip)")
                         .showLineNumbers()
                         .rounded()
                         .focusedBorderColor(Color.CYAN)
@@ -138,7 +140,8 @@ public class TextAreaDemo implements Element {
                 column(
                     // Notes area with placeholder
                     textArea(notesState)
-                        .title("Notes")
+                        .title("Notes (word wrap)")
+                        .wrapWord()
                         .placeholder("Type your notes here...")
                         .rounded()
                         .focusedBorderColor(Color.CYAN)
@@ -147,7 +150,8 @@ public class TextAreaDemo implements Element {
 
                     // Read-only display area (not focusable)
                     textArea(readOnlyState)
-                        .title("Display (Read-only)")
+                        .title("Display (char wrap, read-only)")
+                        .wrapCharacter()
                         .showLineNumbers()
                         .lineNumberStyle(Style.EMPTY.fg(Color.CYAN))
                         .showCursor(false)
@@ -161,8 +165,9 @@ public class TextAreaDemo implements Element {
                         text(" Home/End - Line start/end").dim(),
                         text(" Enter - New line").dim(),
                         text(" Tab - 4 spaces").dim(),
-                        text(" Backspace/Del - Delete").dim()
-                    )).title("Help").rounded().length(9)
+                        text(" Backspace/Del - Delete").dim(),
+                        text(" Panes: clip / word / char wrap").dim()
+                    )).title("Help").rounded().length(10)
                 ).fill()
             ).fill(),
 

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -324,6 +324,20 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         // Add border height
         int borderHeight = (title != null || borderType != null) ? 2 : 0;
         int height = lineCount + borderHeight;
+
+        // Wrapped lines take more than one row each; ask the widget, which knows the width its
+        // border and line-number gutter leave for text.
+        Overflow effectiveOverflow = resolveOverflow(context);
+        if (availableWidth > 0 && state != null
+                && (effectiveOverflow == Overflow.WRAP_WORD || effectiveOverflow == Overflow.WRAP_CHARACTER)) {
+            boolean isFocused = context != null && elementId != null && context.isFocused(elementId);
+            height = TextArea.builder()
+                    .showLineNumbers(showLineNumbers)
+                    .overflow(effectiveOverflow)
+                    .block(buildBlock(context, isFocused))
+                    .build()
+                    .preferredHeight(availableWidth, state);
+        }
         return Size.of(width, height);
     }
 
@@ -467,27 +481,8 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             .placeholderStyle(effectivePlaceholderStyle)
             .showLineNumbers(showLineNumbers)
             .lineNumberStyle(effectiveLineNumberStyle)
-            .overflow(effectiveOverflow);
-
-        Color effectiveBorderColor = isFocused && focusedBorderColor != null
-                ? focusedBorderColor
-                : borderColor;
-
-        if (title != null || borderType != null || effectiveBorderColor != null) {
-            Block.Builder blockBuilder = Block.builder()
-                    .borders(Borders.ALL)
-                    .styleResolver(styleResolver(context));
-            if (title != null) {
-                blockBuilder.title(Title.from(title));
-            }
-            if (borderType != null) {
-                blockBuilder.borderType(borderType);
-            }
-            if (effectiveBorderColor != null) {
-                blockBuilder.borderColor(effectiveBorderColor);
-            }
-            builder.block(blockBuilder.build());
-        }
+            .overflow(effectiveOverflow)
+            .block(buildBlock(context, isFocused));
 
         TextArea widget = builder.build();
 
@@ -498,6 +493,30 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         } else {
             frame.renderStatefulWidget(widget, area, state);
         }
+    }
+
+    /** Returns the border block to draw around the text, or null when there is none. */
+    private Block buildBlock(RenderContext context, boolean isFocused) {
+        Color effectiveBorderColor = isFocused && focusedBorderColor != null
+                ? focusedBorderColor
+                : borderColor;
+
+        if (title == null && borderType == null && effectiveBorderColor == null) {
+            return null;
+        }
+        Block.Builder blockBuilder = Block.builder()
+                .borders(Borders.ALL)
+                .styleResolver(context != null ? styleResolver(context) : null);
+        if (title != null) {
+            blockBuilder.title(Title.from(title));
+        }
+        if (borderType != null) {
+            blockBuilder.borderType(borderType);
+        }
+        if (effectiveBorderColor != null) {
+            blockBuilder.borderColor(effectiveBorderColor);
+        }
+        return blockBuilder.build();
     }
 
     /**

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.RenderContext;
@@ -72,6 +73,8 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     private boolean showCursor = true;
     private boolean showLineNumbers = false;
     private Style lineNumberStyle;
+    private Overflow wrap;
+    private int lastVisibleWidth;
     private TextChangeListener changeListener;
 
     /** Creates a new text area element with a default state. */
@@ -198,6 +201,48 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     }
 
     /**
+     * Sets the wrap mode.
+     * <p>
+     * {@link Overflow#CLIP} (the default) preserves horizontal-scroll behavior. {@code
+     * WRAP_WORD}/{@code WRAP_CHARACTER} wrap long lines across multiple screen rows instead,
+     * and Up/Down move the cursor by visual row rather than logical line.
+     *
+     * @param overflow the wrap mode
+     * @return this builder
+     */
+    public TextAreaElement overflow(Overflow overflow) {
+        this.wrap = overflow;
+        return this;
+    }
+
+    /**
+     * Disables wrapping (horizontal scroll instead). This is the default.
+     *
+     * @return this builder
+     */
+    public TextAreaElement clip() {
+        return overflow(Overflow.CLIP);
+    }
+
+    /**
+     * Wraps long lines at word boundaries.
+     *
+     * @return this builder
+     */
+    public TextAreaElement wrapWord() {
+        return overflow(Overflow.WRAP_WORD);
+    }
+
+    /**
+     * Wraps long lines at character boundaries.
+     *
+     * @return this builder
+     */
+    public TextAreaElement wrapCharacter() {
+        return overflow(Overflow.WRAP_CHARACTER);
+    }
+
+    /**
      * Sets the title for the border.
      *
      * @param title the border title
@@ -314,7 +359,7 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         if (!focused) {
             return EventResult.UNHANDLED;
         }
-        boolean handled = handleTextAreaKey(state, event);
+        boolean handled = handleTextAreaKey(state, event, lastVisibleWidth, wrap);
         if (handled && changeListener != null) {
             changeListener.onTextChange(state.text());
         }
@@ -324,7 +369,7 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     /**
      * Handles common key events for text area input.
      */
-    private static boolean handleTextAreaKey(TextAreaState state, KeyEvent event) {
+    private static boolean handleTextAreaKey(TextAreaState state, KeyEvent event, int visibleWidth, Overflow wrap) {
         switch (event.code()) {
             case BACKSPACE:
                 state.deleteBackward();
@@ -339,10 +384,10 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
                 state.moveCursorRight();
                 return true;
             case UP:
-                state.moveCursorUp();
+                state.moveCursorUp(visibleWidth, wrap);
                 return true;
             case DOWN:
-                state.moveCursorDown();
+                state.moveCursorDown(visibleWidth, wrap);
                 return true;
             case HOME:
                 state.moveCursorToLineStart();
@@ -391,12 +436,14 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             .placeholder(placeholder)
             .placeholderStyle(effectivePlaceholderStyle)
             .showLineNumbers(showLineNumbers)
-            .lineNumberStyle(effectiveLineNumberStyle);
+            .lineNumberStyle(effectiveLineNumberStyle)
+            .wrap(wrap);
 
         Color effectiveBorderColor = isFocused && focusedBorderColor != null
                 ? focusedBorderColor
                 : borderColor;
 
+        Block block = null;
         if (title != null || borderType != null || effectiveBorderColor != null) {
             Block.Builder blockBuilder = Block.builder()
                     .borders(Borders.ALL)
@@ -410,8 +457,11 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             if (effectiveBorderColor != null) {
                 blockBuilder.borderColor(effectiveBorderColor);
             }
-            builder.block(blockBuilder.build());
+            block = blockBuilder.build();
+            builder.block(block);
         }
+
+        lastVisibleWidth = computeVisibleWidth(area, block);
 
         TextArea widget = builder.build();
 
@@ -420,6 +470,26 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         } else {
             frame.renderStatefulWidget(widget, area, state);
         }
+    }
+
+    /**
+     * Computes the text-content width available inside {@code area}, after the block border
+     * (if any) and the line-number gutter (if enabled) — mirroring {@code TextArea}'s own
+     * layout math, since that width isn't otherwise exposed back to the element.
+     */
+    private int computeVisibleWidth(Rect area, Block block) {
+        Rect inputArea = block != null ? block.inner(area) : area;
+        if (inputArea.isEmpty()) {
+            return 0;
+        }
+        int gutterWidth = 0;
+        if (showLineNumbers) {
+            int lineDigits = String.valueOf(state.lineCount()).length();
+            gutterWidth = Math.max(2, lineDigits) + 2;
+        }
+        return gutterWidth > 0 && inputArea.width() > gutterWidth
+            ? inputArea.width() - gutterWidth
+            : inputArea.width();
     }
 
     /**

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
+import dev.tamboui.style.StandardProperties;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.element.RenderContext;
@@ -47,6 +48,10 @@ import dev.tamboui.widgets.input.TextAreaState;
  *   <li>{@code TextAreaElement-line-number} - The line number style (default: dim)</li>
  * </ul>
  * <p>
+ * The {@code text-overflow} CSS property selects the overflow mode ({@code clip},
+ * {@code wrap-word}, {@code wrap-character}); a programmatic {@link #overflow(Overflow)}
+ * value takes precedence. Ellipsis values fall back to clip for text areas.</p>
+ * <p>
  * Example CSS:
  * <pre>{@code
  * TextAreaElement-cursor { text-style: reversed; background: cyan; }
@@ -74,6 +79,7 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     private boolean showLineNumbers = false;
     private Style lineNumberStyle;
     private Overflow overflow;
+    private Overflow renderedOverflow;
     private TextChangeListener changeListener;
 
     /** Creates a new text area element with a default state. */
@@ -362,7 +368,8 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         }
         // Wrap against the width the widget last rendered with, so Up/Down move by the same
         // visual rows the user is looking at.
-        boolean handled = handleTextAreaKey(state, event, state.lastRenderedWidth(), overflow);
+        boolean handled = handleTextAreaKey(state, event, state.lastRenderedWidth(),
+                renderedOverflow != null ? renderedOverflow : overflow);
         if (handled && changeListener != null) {
             changeListener.onTextChange(state.text());
         }
@@ -420,6 +427,24 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         }
     }
 
+    /**
+     * Resolves the overflow mode: programmatic value takes precedence, then the
+     * {@code text-overflow} CSS property, then {@link Overflow#CLIP}. The resolved
+     * value is also used by key handling (Up/Down by visual row), which caches the
+     * value seen at the last render since no CSS context is available at event time.
+     */
+    private Overflow resolveOverflow(RenderContext context) {
+        if (overflow != null) {
+            return overflow;
+        }
+        if (context != null) {
+            return context.resolveStyle(this)
+                    .flatMap(resolver -> resolver.get(StandardProperties.TEXT_OVERFLOW))
+                    .orElse(Overflow.CLIP);
+        }
+        return Overflow.CLIP;
+    }
+
     @Override
     protected void renderContent(Frame frame, Rect area, RenderContext context) {
         if (area.isEmpty()) {
@@ -429,6 +454,8 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         boolean isFocused = elementId != null && context.isFocused(elementId);
 
         // Resolve styles with priority: explicit > CSS > default
+        Overflow effectiveOverflow = resolveOverflow(context);
+        renderedOverflow = effectiveOverflow;
         Style effectiveCursorStyle = resolveEffectiveStyle(context, "cursor", cursorStyle, DEFAULT_CURSOR_STYLE);
         Style effectivePlaceholderStyle = resolveEffectiveStyle(context, "placeholder", placeholderStyle, DEFAULT_PLACEHOLDER_STYLE);
         Style effectiveLineNumberStyle = resolveEffectiveStyle(context, "line-number", lineNumberStyle, DEFAULT_LINE_NUMBER_STYLE);
@@ -440,7 +467,7 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             .placeholderStyle(effectivePlaceholderStyle)
             .showLineNumbers(showLineNumbers)
             .lineNumberStyle(effectiveLineNumberStyle)
-            .overflow(overflow);
+            .overflow(effectiveOverflow);
 
         Color effectiveBorderColor = isFocused && focusedBorderColor != null
                 ? focusedBorderColor

--- a/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
+++ b/tamboui-toolkit/src/main/java/dev/tamboui/toolkit/elements/TextAreaElement.java
@@ -73,8 +73,7 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     private boolean showCursor = true;
     private boolean showLineNumbers = false;
     private Style lineNumberStyle;
-    private Overflow wrap;
-    private int lastVisibleWidth;
+    private Overflow overflow;
     private TextChangeListener changeListener;
 
     /** Creates a new text area element with a default state. */
@@ -201,17 +200,19 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     }
 
     /**
-     * Sets the wrap mode.
+     * Sets the overflow (wrap) mode.
      * <p>
      * {@link Overflow#CLIP} (the default) preserves horizontal-scroll behavior. {@code
      * WRAP_WORD}/{@code WRAP_CHARACTER} wrap long lines across multiple screen rows instead,
-     * and Up/Down move the cursor by visual row rather than logical line.
+     * and Up/Down move the cursor by visual row rather than logical line. The truncating modes
+     * ({@code ELLIPSIS}, {@code ELLIPSIS_START}, {@code ELLIPSIS_MIDDLE}) would hide text the
+     * caret can still reach, so a text area falls back to {@code CLIP} for them.
      *
-     * @param overflow the wrap mode
+     * @param overflow the overflow mode
      * @return this builder
      */
     public TextAreaElement overflow(Overflow overflow) {
-        this.wrap = overflow;
+        this.overflow = overflow;
         return this;
     }
 
@@ -359,7 +360,9 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
         if (!focused) {
             return EventResult.UNHANDLED;
         }
-        boolean handled = handleTextAreaKey(state, event, lastVisibleWidth, wrap);
+        // Wrap against the width the widget last rendered with, so Up/Down move by the same
+        // visual rows the user is looking at.
+        boolean handled = handleTextAreaKey(state, event, state.lastRenderedWidth(), overflow);
         if (handled && changeListener != null) {
             changeListener.onTextChange(state.text());
         }
@@ -369,7 +372,7 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
     /**
      * Handles common key events for text area input.
      */
-    private static boolean handleTextAreaKey(TextAreaState state, KeyEvent event, int visibleWidth, Overflow wrap) {
+    private static boolean handleTextAreaKey(TextAreaState state, KeyEvent event, int visibleWidth, Overflow overflow) {
         switch (event.code()) {
             case BACKSPACE:
                 state.deleteBackward();
@@ -384,10 +387,10 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
                 state.moveCursorRight();
                 return true;
             case UP:
-                state.moveCursorUp(visibleWidth, wrap);
+                state.moveCursorUp(visibleWidth, overflow);
                 return true;
             case DOWN:
-                state.moveCursorDown(visibleWidth, wrap);
+                state.moveCursorDown(visibleWidth, overflow);
                 return true;
             case HOME:
                 state.moveCursorToLineStart();
@@ -437,13 +440,12 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             .placeholderStyle(effectivePlaceholderStyle)
             .showLineNumbers(showLineNumbers)
             .lineNumberStyle(effectiveLineNumberStyle)
-            .wrap(wrap);
+            .overflow(overflow);
 
         Color effectiveBorderColor = isFocused && focusedBorderColor != null
                 ? focusedBorderColor
                 : borderColor;
 
-        Block block = null;
         if (title != null || borderType != null || effectiveBorderColor != null) {
             Block.Builder blockBuilder = Block.builder()
                     .borders(Borders.ALL)
@@ -457,39 +459,18 @@ public final class TextAreaElement extends StyledElement<TextAreaElement> {
             if (effectiveBorderColor != null) {
                 blockBuilder.borderColor(effectiveBorderColor);
             }
-            block = blockBuilder.build();
-            builder.block(block);
+            builder.block(blockBuilder.build());
         }
-
-        lastVisibleWidth = computeVisibleWidth(area, block);
 
         TextArea widget = builder.build();
 
+        // The widget records the content width it used on the state; see
+        // TextAreaState.lastRenderedWidth(), which key handling reads back.
         if (showCursor && isFocused) {
             widget.renderWithCursor(area, frame.buffer(), state, frame);
         } else {
             frame.renderStatefulWidget(widget, area, state);
         }
-    }
-
-    /**
-     * Computes the text-content width available inside {@code area}, after the block border
-     * (if any) and the line-number gutter (if enabled) — mirroring {@code TextArea}'s own
-     * layout math, since that width isn't otherwise exposed back to the element.
-     */
-    private int computeVisibleWidth(Rect area, Block block) {
-        Rect inputArea = block != null ? block.inner(area) : area;
-        if (inputArea.isEmpty()) {
-            return 0;
-        }
-        int gutterWidth = 0;
-        if (showLineNumbers) {
-            int lineDigits = String.valueOf(state.lineCount()).length();
-            gutterWidth = Math.max(2, lineDigits) + 2;
-        }
-        return gutterWidth > 0 && inputArea.width() > gutterWidth
-            ? inputArea.width() - gutterWidth
-            : inputArea.width();
     }
 
     /**

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -13,6 +13,7 @@ import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
@@ -596,6 +597,46 @@ class TextAreaElementTest extends AbstractElementTest {
 
             assertThat(state.cursorRow()).isEqualTo(0); // still logical line 0
             assertThat(state.cursorCol()).isEqualTo(8); // start of "three" segment, not end of doc
+        }
+
+        @Test
+        @DisplayName("Up/Down wrap against the same width the border and gutter left for text")
+        void arrowKeysUseTheRenderedContentWidth() {
+            // 20 wide minus the border (2) and the line-number gutter (4) leaves 14 for text,
+            // so "one two three four five" wraps into "one two three" / "four five".
+            Rect area = new Rect(0, 0, 20, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState("one two three four five");
+            TextAreaElement element = textArea(state).wrapWord().showLineNumbers().rounded();
+            element.render(frame, area, RenderContext.empty());
+            state.moveCursorToStart();
+
+            assertThat(state.lastRenderedWidth()).isEqualTo(14);
+
+            element.handleKeyEvent(new KeyEvent(KeyCode.DOWN, KeyModifiers.NONE, '\0'), true);
+
+            // Start of "four five": wrapping at the full area width would not have broken at all.
+            assertThat(state.cursorCol()).isEqualTo(14);
+        }
+
+        @Test
+        @DisplayName("A truncating overflow mode falls back to clipping instead of wrapping")
+        void truncatingOverflowFallsBackToClip() {
+            Rect area = new Rect(0, 0, 7, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart(); // avoid CLIP auto-scrolling to the end-of-text cursor
+
+            textArea(state).overflow(Overflow.ELLIPSIS)
+                .render(frame, area, RenderContext.empty());
+
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("o");
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo(" "); // no wrap onto row 1
+            assertThat(buffer.get(6, 0).symbol()).isEqualTo("o"); // "one two"[6], not an ellipsis
         }
     }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -543,4 +543,59 @@ class TextAreaElementTest extends AbstractElementTest {
             assertThat(buffer.get(0, 0).style().fg()).contains(Color.YELLOW);
         }
     }
+
+    @Nested
+    @DisplayName("Wrapping")
+    class Wrapping {
+
+        @Test
+        @DisplayName("wrapWord() wraps long lines across multiple screen rows")
+        void wrapWordWrapsLongLines() {
+            Rect area = new Rect(0, 0, 7, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            textArea().text("one two three").wrapWord()
+                .render(frame, area, RenderContext.empty());
+
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("o");
+            assertThat(buffer.get(4, 0).symbol()).isEqualTo("t"); // "one two"[4] == 't'
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo("t"); // "three" wraps to row 1
+            assertThat(buffer.get(4, 1).symbol()).isEqualTo("e");
+        }
+
+        @Test
+        @DisplayName("Without wrap(), a long line is clipped, not wrapped (unchanged default)")
+        void noWrapClipsByDefault() {
+            Rect area = new Rect(0, 0, 7, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart(); // avoid CLIP auto-scrolling to the end-of-text cursor
+
+            textArea(state).render(frame, area, RenderContext.empty());
+
+            assertThat(buffer.get(0, 0).symbol()).isEqualTo("o");
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo(" "); // row 1 stays empty, no wrap
+        }
+
+        @Test
+        @DisplayName("Up/Down move the cursor by visual row once a wrapped layout has been rendered")
+        void arrowKeysMoveByVisualRowWhenWrapped() {
+            Rect area = new Rect(0, 0, 7, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState("one two three");
+            TextAreaElement element = textArea(state).wrapWord();
+            element.render(frame, area, RenderContext.empty()); // establishes the 7-wide layout
+            state.moveCursorToStart(); // back to row 0, col 0 (first visual row)
+
+            element.handleKeyEvent(new KeyEvent(KeyCode.DOWN, KeyModifiers.NONE, '\0'), true);
+
+            assertThat(state.cursorRow()).isEqualTo(0); // still logical line 0
+            assertThat(state.cursorCol()).isEqualTo(8); // start of "three" segment, not end of doc
+        }
+    }
 }

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -4,16 +4,20 @@
  */
 package dev.tamboui.toolkit.elements;
 
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.*;
 
 import dev.tamboui.buffer.Buffer;
+import dev.tamboui.css.Styleable;
+import dev.tamboui.css.cascade.CssStyleResolver;
 import dev.tamboui.css.engine.StyleEngine;
 import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Overflow;
+import dev.tamboui.style.StandardProperties;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.toolkit.AbstractElementTest;
@@ -392,6 +396,78 @@ class TextAreaElementTest extends AbstractElementTest {
             element.handleKeyEvent(new KeyEvent(KeyCode.CHAR, KeyModifiers.NONE, 'H'), false);
 
             assertThat(capturedText.get()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("CSS text-overflow")
+    class CssTextOverflow {
+
+        private RenderContext cssContext(Overflow cssOverflow) {
+            CssStyleResolver cssResolver = CssStyleResolver.builder()
+                    .set(StandardProperties.TEXT_OVERFLOW, cssOverflow)
+                    .build();
+            return new RenderContext() {
+                @Override
+                public boolean isFocused(String elementId) {
+                    return false;
+                }
+
+                @Override
+                public boolean hasFocus() {
+                    return false;
+                }
+
+                @Override
+                public Optional<CssStyleResolver> resolveStyle(Styleable styleable) {
+                    return Optional.of(cssResolver);
+                }
+            };
+        }
+
+        @Test
+        @DisplayName("resolves text-overflow from CSS when no programmatic overflow is set")
+        void resolvesOverflowFromCss() {
+            Rect area = new Rect(0, 0, 10, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            textArea().text("aaaa bbbb cccc")
+                .render(frame, area, cssContext(Overflow.WRAP_WORD));
+
+            // "cccc" wrapped onto the second visual row
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo("c");
+        }
+
+        @Test
+        @DisplayName("programmatic overflow wins over CSS")
+        void programmaticOverflowWinsOverCss() {
+            Rect area = new Rect(0, 0, 10, 3);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            textArea().text("aaaa bbbb cccc").clip()
+                .render(frame, area, cssContext(Overflow.WRAP_WORD));
+
+            // Clip stays in effect: nothing wraps onto the second row
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo(" ");
+        }
+
+        @Test
+        @DisplayName("Up/Down honor the CSS-resolved overflow after render")
+        void keyHandlingUsesCssResolvedOverflow() {
+            TextAreaElement element = textArea().text("aaaa bbbb cccc");
+            element.getState().moveCursorToStart();
+            Rect area = new Rect(0, 0, 10, 3);
+            Buffer buffer = Buffer.empty(area);
+            element.render(Frame.forTesting(buffer), area, cssContext(Overflow.WRAP_WORD));
+
+            // Down on the only logical line: with wrapping in effect the cursor
+            // moves to the next visual row (start of "cccc"); with clip it would
+            // not move at all.
+            element.handleKeyEvent(new KeyEvent(KeyCode.DOWN, KeyModifiers.NONE, '\0'), true);
+
+            assertThat(element.getState().cursorCol()).isEqualTo(10);
         }
     }
 

--- a/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
+++ b/tamboui-toolkit/src/test/java/dev/tamboui/toolkit/elements/TextAreaElementTest.java
@@ -29,6 +29,8 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.KeyModifiers;
 import dev.tamboui.widgets.input.TextAreaState;
 
+import static dev.tamboui.toolkit.Toolkit.column;
+import static dev.tamboui.toolkit.Toolkit.text;
 import static dev.tamboui.toolkit.Toolkit.textArea;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -469,6 +471,16 @@ class TextAreaElementTest extends AbstractElementTest {
 
             assertThat(element.getState().cursorCol()).isEqualTo(10);
         }
+
+        @Test
+        @DisplayName("preferredSize wraps when the overflow comes from CSS")
+        void preferredSizeUsesCssResolvedOverflow() {
+            TextAreaElement element = textArea().text("aaaa bbbb cccc");
+
+            // "aaaa bbbb" / "cccc" at width 10; with clip it would be the single logical line.
+            assertThat(element.preferredSize(10, -1, cssContext(Overflow.WRAP_WORD)).height()).isEqualTo(2);
+            assertThat(element.preferredSize(10, -1, cssContext(Overflow.CLIP)).height()).isEqualTo(1);
+        }
     }
 
     @Nested
@@ -713,6 +725,36 @@ class TextAreaElementTest extends AbstractElementTest {
             assertThat(buffer.get(0, 0).symbol()).isEqualTo("o");
             assertThat(buffer.get(0, 1).symbol()).isEqualTo(" "); // no wrap onto row 1
             assertThat(buffer.get(6, 0).symbol()).isEqualTo("o"); // "one two"[6], not an ellipsis
+        }
+
+        @Test
+        @DisplayName("In a column, a wrapped text area gets a row for every wrapped line")
+        void columnSizesWrappedTextArea() {
+            Rect area = new Rect(0, 0, 7, 5);
+            Buffer buffer = Buffer.empty(area);
+            Frame frame = Frame.forTesting(buffer);
+
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart();
+            column(textArea(state).wrapWord(), text("below"))
+                .render(frame, area, RenderContext.empty());
+
+            // Sized by logical lines, the text area would get one row: "three" would be clipped
+            // and "below" would sit on row 1.
+            assertThat(buffer.get(0, 1).symbol()).isEqualTo("t"); // "three"
+            assertThat(buffer.get(0, 2).symbol()).isEqualTo("b"); // "below"
+        }
+
+        @Test
+        @DisplayName("preferredSize counts wrapped rows at the width left by the border and gutter")
+        void preferredSizeCountsWrappedRows() {
+            // 20 wide minus the border (2) and the gutter (4) leaves 14: "one two three" /
+            // "four five", plus the 2 border rows.
+            TextAreaElement element = textArea(new TextAreaState("one two three four five"))
+                .wrapWord().showLineNumbers().rounded();
+
+            assertThat(element.preferredSize(20, -1, RenderContext.empty()).height()).isEqualTo(4);
+            assertThat(element.clip().preferredSize(20, -1, RenderContext.empty()).height()).isEqualTo(3);
         }
     }
 }

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
@@ -62,13 +62,13 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
     private final Style placeholderStyle;
     private final boolean showLineNumbers;
     private final Style lineNumberStyle;
-    private final Overflow wrap;
+    private final Overflow overflow;
 
     private TextArea(Builder builder) {
         this.block = builder.block;
         this.placeholder = builder.placeholder;
         this.showLineNumbers = builder.showLineNumbers;
-        this.wrap = builder.resolveWrap();
+        this.overflow = builder.resolveOverflow();
 
         // Resolve style-aware properties
         Color resolvedBg = builder.resolveBackground();
@@ -134,26 +134,16 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
             return;
         }
 
-        // Calculate line number gutter width
-        int gutterWidth = 0;
-        if (showLineNumbers) {
-            int lineDigits = String.valueOf(state.lineCount()).length();
-            gutterWidth = Math.max(2, lineDigits) + 2; // digits + space + separator
-        }
-
-        Rect textArea = inputArea;
-        if (gutterWidth > 0 && inputArea.width() > gutterWidth) {
-            textArea = new Rect(
-                inputArea.left() + gutterWidth,
-                inputArea.top(),
-                inputArea.width() - gutterWidth,
-                inputArea.height()
-            );
-        }
+        int gutterWidth = gutterWidth(state);
+        Rect textArea = textAreaRect(inputArea, gutterWidth);
 
         String text = state.text();
         int visibleHeight = textArea.height();
         int visibleWidth = textArea.width();
+
+        // Publish the width actually used, so callers outside the render pass (key handling in
+        // the toolkit element, for one) wrap against the same value instead of recomputing it.
+        state.lastRenderedWidth(visibleWidth);
 
         // Show placeholder if empty
         if (text.isEmpty() && !placeholder.isEmpty()) {
@@ -162,13 +152,35 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
         }
 
         // Ensure cursor is visible
-        state.ensureCursorVisible(visibleHeight, visibleWidth, wrap);
+        state.ensureCursorVisible(visibleHeight, visibleWidth, overflow);
 
-        if (wrap == Overflow.CLIP) {
-            renderClipped(inputArea, textArea, gutterWidth, buffer, state, visibleHeight, visibleWidth);
-        } else {
+        if (TextAreaState.isWrapping(overflow)) {
             renderWrapped(inputArea, textArea, gutterWidth, buffer, state, visibleHeight, visibleWidth);
+        } else {
+            renderClipped(inputArea, textArea, gutterWidth, buffer, state, visibleHeight, visibleWidth);
         }
+    }
+
+    /** Width of the line-number gutter: digits + space + separator, or 0 when hidden. */
+    private int gutterWidth(TextAreaState state) {
+        if (!showLineNumbers) {
+            return 0;
+        }
+        int lineDigits = String.valueOf(state.lineCount()).length();
+        return Math.max(2, lineDigits) + 2;
+    }
+
+    /** The area left for text inside {@code inputArea} once the gutter is carved off. */
+    private static Rect textAreaRect(Rect inputArea, int gutterWidth) {
+        if (gutterWidth <= 0 || inputArea.width() <= gutterWidth) {
+            return inputArea;
+        }
+        return new Rect(
+            inputArea.left() + gutterWidth,
+            inputArea.top(),
+            inputArea.width() - gutterWidth,
+            inputArea.height()
+        );
     }
 
     private void renderClipped(Rect inputArea, Rect textArea, int gutterWidth, Buffer buffer, TextAreaState state,
@@ -213,7 +225,7 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
 
     private void renderWrapped(Rect inputArea, Rect textArea, int gutterWidth, Buffer buffer, TextAreaState state,
                                 int visibleHeight, int visibleWidth) {
-        List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(visibleWidth, wrap);
+        List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(visibleWidth, overflow);
         int scrollRow = state.scrollRow();
 
         for (int y = 0; y < visibleHeight; y++) {
@@ -279,28 +291,25 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
             return;
         }
 
-        int gutterWidth = 0;
-        if (showLineNumbers) {
-            int lineDigits = String.valueOf(state.lineCount()).length();
-            gutterWidth = Math.max(2, lineDigits) + 2;
-        }
-
-        Rect textArea = inputArea;
-        if (gutterWidth > 0 && inputArea.width() > gutterWidth) {
-            textArea = new Rect(
-                inputArea.left() + gutterWidth,
-                inputArea.top(),
-                inputArea.width() - gutterWidth,
-                inputArea.height()
-            );
-        }
+        Rect textArea = textAreaRect(inputArea, gutterWidth(state));
 
         int scrollRow = state.scrollRow();
         int scrollCol = state.scrollCol();
 
         int relativeRow;
         int relativeCol;
-        if (wrap == Overflow.CLIP) {
+        if (TextAreaState.isWrapping(overflow)) {
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(textArea.width(), overflow);
+            int cursorDisplayIndex =
+                TextAreaState.findCursorDisplayRowIndex(rows, state.cursorRow(), state.cursorCol());
+            TextAreaState.DisplayRow row = rows.get(cursorDisplayIndex);
+
+            relativeRow = cursorDisplayIndex - scrollRow;
+            String cursorLine = state.getLine(row.logicalRow());
+            // A cursor snapped forward past a word-wrap break sits before this row's start.
+            int cursorCol = Math.max(row.startCol(), state.cursorCol());
+            relativeCol = CharWidth.of(cursorLine.substring(row.startCol(), cursorCol));
+        } else {
             int cursorRow = state.cursorRow();
             int cursorCol = state.cursorCol();
 
@@ -315,14 +324,6 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
                 int to = Math.min(cursorCol, cursorLine.length());
                 relativeCol = CharWidth.of(cursorLine.substring(from, to));
             }
-        } else {
-            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(textArea.width(), wrap);
-            int cursorDisplayIndex = TextAreaState.findDisplayRowIndex(rows, state.cursorRow(), state.cursorCol());
-            TextAreaState.DisplayRow row = rows.get(cursorDisplayIndex);
-
-            relativeRow = cursorDisplayIndex - scrollRow;
-            String cursorLine = state.getLine(row.logicalRow());
-            relativeCol = CharWidth.of(cursorLine.substring(row.startCol(), state.cursorCol()));
         }
 
         if (relativeRow >= 0 && relativeRow < textArea.height() &&
@@ -348,7 +349,7 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
         private Style placeholderStyle = Style.EMPTY.dim();
         private boolean showLineNumbers = false;
         private Style lineNumberStyle = Style.EMPTY.dim();
-        private Overflow wrap;
+        private Overflow overflow;
         private StylePropertyResolver styleResolver = StylePropertyResolver.empty();
 
         // Style-aware properties (resolved via styleResolver in build())
@@ -438,17 +439,19 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
         }
 
         /**
-         * Sets the wrap mode.
+         * Sets the overflow (wrap) mode, mirroring {@code Paragraph.Builder.overflow}.
          * <p>
          * {@link Overflow#CLIP} (the default) preserves today's horizontal-scroll behavior.
          * {@code WRAP_WORD}/{@code WRAP_CHARACTER} wrap long lines across multiple screen rows
-         * instead of scrolling horizontally.
+         * instead of scrolling horizontally. The truncating modes ({@code ELLIPSIS},
+         * {@code ELLIPSIS_START}, {@code ELLIPSIS_MIDDLE}) would hide text the caret can still
+         * reach, so a text area falls back to {@code CLIP} for them.
          *
-         * @param wrap the wrap mode
+         * @param overflow the overflow mode
          * @return this builder
          */
-        public Builder wrap(Overflow wrap) {
-            this.wrap = wrap;
+        public Builder overflow(Overflow overflow) {
+            this.overflow = overflow;
             return this;
         }
 
@@ -562,9 +565,11 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
             return styleResolver.resolve(LINE_NUMBER_COLOR, lineNumberColor);
         }
 
-        private Overflow resolveWrap() {
-            Overflow resolved = styleResolver.resolve(StandardProperties.TEXT_OVERFLOW, wrap);
-            return resolved != null ? resolved : Overflow.CLIP;
+        private Overflow resolveOverflow() {
+            Overflow resolved = styleResolver.resolve(StandardProperties.TEXT_OVERFLOW, overflow);
+            // Normalize here so the rest of the widget only ever sees a mode it implements;
+            // `text-overflow: ellipsis` from a shared stylesheet must not silently char-wrap.
+            return TextAreaState.isWrapping(resolved) ? resolved : Overflow.CLIP;
         }
     }
 }

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
@@ -4,11 +4,14 @@
  */
 package dev.tamboui.widgets.input;
 
+import java.util.List;
+
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.ColorConverter;
+import dev.tamboui.style.Overflow;
 import dev.tamboui.style.PropertyDefinition;
 import dev.tamboui.style.PropertyRegistry;
 import dev.tamboui.style.StandardProperties;
@@ -59,11 +62,13 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
     private final Style placeholderStyle;
     private final boolean showLineNumbers;
     private final Style lineNumberStyle;
+    private final Overflow wrap;
 
     private TextArea(Builder builder) {
         this.block = builder.block;
         this.placeholder = builder.placeholder;
         this.showLineNumbers = builder.showLineNumbers;
+        this.wrap = builder.resolveWrap();
 
         // Resolve style-aware properties
         Color resolvedBg = builder.resolveBackground();
@@ -157,32 +162,28 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
         }
 
         // Ensure cursor is visible
-        state.ensureCursorVisible(visibleHeight, visibleWidth);
+        state.ensureCursorVisible(visibleHeight, visibleWidth, wrap);
 
-        // Render visible lines
+        if (wrap == Overflow.CLIP) {
+            renderClipped(inputArea, textArea, gutterWidth, buffer, state, visibleHeight, visibleWidth);
+        } else {
+            renderWrapped(inputArea, textArea, gutterWidth, buffer, state, visibleHeight, visibleWidth);
+        }
+    }
+
+    private void renderClipped(Rect inputArea, Rect textArea, int gutterWidth, Buffer buffer, TextAreaState state,
+                                int visibleHeight, int visibleWidth) {
         int scrollRow = state.scrollRow();
         int scrollCol = state.scrollCol();
 
         for (int y = 0; y < visibleHeight; y++) {
             int lineIndex = scrollRow + y;
             int screenY = textArea.top() + y;
+            boolean hasLine = lineIndex < state.lineCount();
 
-            // Render line number if enabled
-            if (showLineNumbers && gutterWidth > 0) {
-                if (lineIndex < state.lineCount()) {
-                    String lineNum = String.format("%" + (gutterWidth - 2) + "d ", lineIndex + 1);
-                    buffer.setString(inputArea.left(), screenY, lineNum, lineNumberStyle);
-                    buffer.set(inputArea.left() + gutterWidth - 1, screenY,
-                        new Cell("|", lineNumberStyle));
-                } else {
-                    // Empty line number area
-                    for (int x = inputArea.left(); x < inputArea.left() + gutterWidth; x++) {
-                        buffer.set(x, screenY, new Cell(" ", lineNumberStyle));
-                    }
-                }
-            }
+            renderGutterCell(inputArea, gutterWidth, screenY, hasLine ? lineIndex + 1 : -1, buffer);
 
-            if (lineIndex < state.lineCount()) {
+            if (hasLine) {
                 String line = state.getLine(lineIndex);
 
                 // Calculate visible portion of line
@@ -206,6 +207,55 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
                 for (int x = textArea.left(); x < textArea.right(); x++) {
                     buffer.set(x, screenY, new Cell(" ", style));
                 }
+            }
+        }
+    }
+
+    private void renderWrapped(Rect inputArea, Rect textArea, int gutterWidth, Buffer buffer, TextAreaState state,
+                                int visibleHeight, int visibleWidth) {
+        List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(visibleWidth, wrap);
+        int scrollRow = state.scrollRow();
+
+        for (int y = 0; y < visibleHeight; y++) {
+            int rowIndex = scrollRow + y;
+            int screenY = textArea.top() + y;
+
+            if (rowIndex < rows.size()) {
+                TextAreaState.DisplayRow row = rows.get(rowIndex);
+                String line = state.getLine(row.logicalRow());
+                String visibleText = line.substring(row.startCol(), row.endCol());
+
+                // Only the first wrapped row of a logical line shows its line number.
+                int lineNumber = row.startCol() == 0 ? row.logicalRow() + 1 : -1;
+                renderGutterCell(inputArea, gutterWidth, screenY, lineNumber, buffer);
+
+                buffer.setString(textArea.left(), screenY, visibleText, style);
+
+                int visibleTextWidth = CharWidth.of(visibleText);
+                int textEnd = textArea.left() + visibleTextWidth;
+                for (int x = textEnd; x < textArea.right(); x++) {
+                    buffer.set(x, screenY, new Cell(" ", style));
+                }
+            } else {
+                renderGutterCell(inputArea, gutterWidth, screenY, -1, buffer);
+                for (int x = textArea.left(); x < textArea.right(); x++) {
+                    buffer.set(x, screenY, new Cell(" ", style));
+                }
+            }
+        }
+    }
+
+    private void renderGutterCell(Rect inputArea, int gutterWidth, int screenY, int lineNumber, Buffer buffer) {
+        if (!showLineNumbers || gutterWidth <= 0) {
+            return;
+        }
+        if (lineNumber > 0) {
+            String lineNum = String.format("%" + (gutterWidth - 2) + "d ", lineNumber);
+            buffer.setString(inputArea.left(), screenY, lineNum, lineNumberStyle);
+            buffer.set(inputArea.left() + gutterWidth - 1, screenY, new Cell("|", lineNumberStyle));
+        } else {
+            for (int x = inputArea.left(); x < inputArea.left() + gutterWidth; x++) {
+                buffer.set(x, screenY, new Cell(" ", lineNumberStyle));
             }
         }
     }
@@ -245,22 +295,34 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
             );
         }
 
-        int cursorRow = state.cursorRow();
-        int cursorCol = state.cursorCol();
         int scrollRow = state.scrollRow();
         int scrollCol = state.scrollCol();
 
-        // Check if cursor is visible
-        int relativeRow = cursorRow - scrollRow;
-        // Convert char-offset cursor column to display column relative to scroll
+        int relativeRow;
         int relativeCol;
-        if (cursorCol < scrollCol) {
-            relativeCol = -1; // cursor is left of the viewport
+        if (wrap == Overflow.CLIP) {
+            int cursorRow = state.cursorRow();
+            int cursorCol = state.cursorCol();
+
+            // Check if cursor is visible
+            relativeRow = cursorRow - scrollRow;
+            // Convert char-offset cursor column to display column relative to scroll
+            if (cursorCol < scrollCol) {
+                relativeCol = -1; // cursor is left of the viewport
+            } else {
+                String cursorLine = state.getLine(cursorRow);
+                int from = Math.min(scrollCol, cursorLine.length());
+                int to = Math.min(cursorCol, cursorLine.length());
+                relativeCol = CharWidth.of(cursorLine.substring(from, to));
+            }
         } else {
-            String cursorLine = state.getLine(cursorRow);
-            int from = Math.min(scrollCol, cursorLine.length());
-            int to = Math.min(cursorCol, cursorLine.length());
-            relativeCol = CharWidth.of(cursorLine.substring(from, to));
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(textArea.width(), wrap);
+            int cursorDisplayIndex = TextAreaState.findDisplayRowIndex(rows, state.cursorRow(), state.cursorCol());
+            TextAreaState.DisplayRow row = rows.get(cursorDisplayIndex);
+
+            relativeRow = cursorDisplayIndex - scrollRow;
+            String cursorLine = state.getLine(row.logicalRow());
+            relativeCol = CharWidth.of(cursorLine.substring(row.startCol(), state.cursorCol()));
         }
 
         if (relativeRow >= 0 && relativeRow < textArea.height() &&
@@ -286,6 +348,7 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
         private Style placeholderStyle = Style.EMPTY.dim();
         private boolean showLineNumbers = false;
         private Style lineNumberStyle = Style.EMPTY.dim();
+        private Overflow wrap;
         private StylePropertyResolver styleResolver = StylePropertyResolver.empty();
 
         // Style-aware properties (resolved via styleResolver in build())
@@ -371,6 +434,21 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
          */
         public Builder lineNumberStyle(Style style) {
             this.lineNumberStyle = style;
+            return this;
+        }
+
+        /**
+         * Sets the wrap mode.
+         * <p>
+         * {@link Overflow#CLIP} (the default) preserves today's horizontal-scroll behavior.
+         * {@code WRAP_WORD}/{@code WRAP_CHARACTER} wrap long lines across multiple screen rows
+         * instead of scrolling horizontally.
+         *
+         * @param wrap the wrap mode
+         * @return this builder
+         */
+        public Builder wrap(Overflow wrap) {
+            this.wrap = wrap;
             return this;
         }
 
@@ -482,6 +560,11 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
 
         private Color resolveLineNumberColor() {
             return styleResolver.resolve(LINE_NUMBER_COLOR, lineNumberColor);
+        }
+
+        private Overflow resolveWrap() {
+            Overflow resolved = styleResolver.resolve(StandardProperties.TEXT_OVERFLOW, wrap);
+            return resolved != null ? resolved : Overflow.CLIP;
         }
     }
 }

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextArea.java
@@ -300,8 +300,7 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
         int relativeCol;
         if (TextAreaState.isWrapping(overflow)) {
             List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(textArea.width(), overflow);
-            int cursorDisplayIndex =
-                TextAreaState.findCursorDisplayRowIndex(rows, state.cursorRow(), state.cursorCol());
+            int cursorDisplayIndex = state.findCursorDisplayRowIndex(rows, textArea.width());
             TextAreaState.DisplayRow row = rows.get(cursorDisplayIndex);
 
             relativeRow = cursorDisplayIndex - scrollRow;
@@ -336,6 +335,27 @@ public final class TextArea implements StatefulWidget<TextAreaState> {
             Cell currentCell = buffer.get(cursorX, cursorY);
             buffer.set(cursorX, cursorY, currentCell.patchStyle(cursorStyle));
         }
+    }
+
+    /**
+     * Returns the height, in rows, needed to show all of {@code state}'s text without scrolling
+     * when rendered {@code width} columns wide: one row per display row (see
+     * {@link TextAreaState#computeDisplayRows}), plus the rows taken by the block, if any.
+     * <p>
+     * This uses the same border and gutter math as {@link #render}, so layout code can size a
+     * wrapping text area without re-deriving it.
+     *
+     * @param width the width of the area the widget will be rendered into
+     * @param state the text area state
+     * @return the height that fits the whole text
+     */
+    public int preferredHeight(int width, TextAreaState state) {
+        // Tall enough that the block's insets are the only thing taken off the height.
+        Rect area = new Rect(0, 0, width, Short.MAX_VALUE);
+        Rect inputArea = block != null ? block.inner(area) : area;
+        int textWidth = textAreaRect(inputArea, gutterWidth(state)).width();
+        int rows = state.computeDisplayRows(textWidth, overflow).size();
+        return rows + area.height() - inputArea.height();
     }
 
     /**

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextAreaState.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextAreaState.java
@@ -5,6 +5,7 @@
 package dev.tamboui.widgets.input;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import dev.tamboui.style.Overflow;
@@ -20,6 +21,16 @@ public final class TextAreaState {
     private int cursorCol;
     private int scrollRow;
     private int scrollCol;
+    private int lastRenderedWidth;
+
+    /** Bumped on every text mutation; used to invalidate the cached display rows. */
+    private int textVersion;
+
+    // Cached result of the most recent computeDisplayRows() call.
+    private List<DisplayRow> cachedRows;
+    private int cachedWidth;
+    private Overflow cachedOverflow;
+    private int cachedVersion = -1;
 
     /** Creates a new empty text area state. */
     public TextAreaState() {
@@ -119,6 +130,25 @@ public final class TextAreaState {
         return scrollCol;
     }
 
+    /**
+     * Returns the text-content width, in display columns, that the most recent render used
+     * (that is, the area width minus any block border and line-number gutter).
+     * <p>
+     * This is the single source of truth for callers that need the wrap width outside of a
+     * render pass, such as {@code Up}/{@code Down} key handling. It is {@code 0} until the
+     * widget has been rendered at least once.
+     *
+     * @return the last rendered text-content width, or {@code 0} if never rendered
+     */
+    public int lastRenderedWidth() {
+        return lastRenderedWidth;
+    }
+
+    /** Records the text-content width used by a render pass. Called by {@link TextArea}. */
+    void lastRenderedWidth(int width) {
+        this.lastRenderedWidth = width;
+    }
+
     // --- Text Modification ---
 
     /**
@@ -127,6 +157,7 @@ public final class TextAreaState {
      * @param c the character to insert
      */
     public void insert(char c) {
+        textVersion++;
         if (c == '\n') {
             insertNewline();
         } else {
@@ -157,6 +188,7 @@ public final class TextAreaState {
 
     /** Deletes the grapheme cluster before the cursor. */
     public void deleteBackward() {
+        textVersion++;
         if (cursorCol > 0) {
             StringBuilder line = lines.get(cursorRow);
             int start = GraphemeClusters.clusterStart(line, cursorCol);
@@ -174,6 +206,7 @@ public final class TextAreaState {
 
     /** Deletes the grapheme cluster after the cursor. */
     public void deleteForward() {
+        textVersion++;
         StringBuilder currentLine = lines.get(cursorRow);
         if (cursorCol < currentLine.length()) {
             int end = GraphemeClusters.clusterEnd(currentLine, cursorCol);
@@ -216,21 +249,22 @@ public final class TextAreaState {
     /**
      * Moves the cursor up one row.
      * <p>
-     * With {@link Overflow#CLIP}, behaves exactly like {@link #moveCursorUp()} (one logical
-     * row). With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, moves to the previous visual
-     * (wrapped) row, which may be a wrapped segment of the same logical line or the last
-     * segment of the previous logical line.
+     * With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, moves to the previous visual (wrapped)
+     * row, which may be a wrapped segment of the same logical line or the last segment of the
+     * previous logical line. Every other {@link Overflow} value (including {@code null}) is
+     * treated as {@link Overflow#CLIP} and behaves exactly like {@link #moveCursorUp()} (one
+     * logical row) — see {@link #computeDisplayRows}.
      *
      * @param visibleCols the number of visible columns (used to compute wrapped rows)
-     * @param wrap        the wrap mode
+     * @param overflow    the overflow mode
      */
-    public void moveCursorUp(int visibleCols, Overflow wrap) {
-        if (wrap == null || wrap == Overflow.CLIP) {
+    public void moveCursorUp(int visibleCols, Overflow overflow) {
+        if (!isWrapping(overflow)) {
             moveCursorUpClip();
             return;
         }
 
-        List<DisplayRow> rows = computeDisplayRows(visibleCols, wrap);
+        List<DisplayRow> rows = computeDisplayRows(visibleCols, overflow);
         int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
         if (index <= 0) {
             return;
@@ -253,21 +287,22 @@ public final class TextAreaState {
     /**
      * Moves the cursor down one row.
      * <p>
-     * With {@link Overflow#CLIP}, behaves exactly like {@link #moveCursorDown()} (one logical
-     * row). With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, moves to the next visual (wrapped)
-     * row, which may be a wrapped segment of the same logical line or the first segment of the
-     * next logical line.
+     * With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, moves to the next visual (wrapped) row,
+     * which may be a wrapped segment of the same logical line or the first segment of the next
+     * logical line. Every other {@link Overflow} value (including {@code null}) is treated as
+     * {@link Overflow#CLIP} and behaves exactly like {@link #moveCursorDown()} (one logical
+     * row) — see {@link #computeDisplayRows}.
      *
      * @param visibleCols the number of visible columns (used to compute wrapped rows)
-     * @param wrap        the wrap mode
+     * @param overflow    the overflow mode
      */
-    public void moveCursorDown(int visibleCols, Overflow wrap) {
-        if (wrap == null || wrap == Overflow.CLIP) {
+    public void moveCursorDown(int visibleCols, Overflow overflow) {
+        if (!isWrapping(overflow)) {
             moveCursorDownClip();
             return;
         }
 
-        List<DisplayRow> rows = computeDisplayRows(visibleCols, wrap);
+        List<DisplayRow> rows = computeDisplayRows(visibleCols, overflow);
         int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
         if (index < 0 || index >= rows.size() - 1) {
             return;
@@ -326,35 +361,70 @@ public final class TextAreaState {
             this.endCol = endCol;
         }
 
-        /** @return the logical (newline-delimited) line index this row belongs to */
+        /**
+         * Returns the logical (newline-delimited) line index this row belongs to.
+         *
+         * @return the logical line index
+         */
         public int logicalRow() {
             return logicalRow;
         }
 
-        /** @return the char offset (inclusive) where this row starts within its logical line */
+        /**
+         * Returns where this row starts within its logical line.
+         *
+         * @return the inclusive char offset of the row start
+         */
         public int startCol() {
             return startCol;
         }
 
-        /** @return the char offset (exclusive) where this row ends within its logical line */
+        /**
+         * Returns where this row ends within its logical line.
+         *
+         * @return the exclusive char offset of the row end
+         */
         public int endCol() {
             return endCol;
         }
     }
 
     /**
+     * Returns whether {@code overflow} makes a text area wrap.
+     * <p>
+     * Only {@link Overflow#WRAP_WORD} and {@link Overflow#WRAP_CHARACTER} wrap. A text area is
+     * an editor, so the truncating modes ({@code ELLIPSIS}, {@code ELLIPSIS_START},
+     * {@code ELLIPSIS_MIDDLE}) would hide text the caret can still reach; they are treated as
+     * {@link Overflow#CLIP} (horizontal scroll) instead, as is {@code null}.
+     *
+     * @param overflow the overflow mode, may be null
+     * @return true if the mode wraps
+     */
+    static boolean isWrapping(Overflow overflow) {
+        return overflow == Overflow.WRAP_WORD || overflow == Overflow.WRAP_CHARACTER;
+    }
+
+    /**
      * Computes the visual rows produced by wrapping every logical line to {@code visibleWidth}.
      * <p>
-     * With {@link Overflow#CLIP} (or a non-positive width) each logical line maps to exactly
-     * one display row, matching the unwrapped behavior.
+     * Only {@link Overflow#WRAP_WORD} and {@link Overflow#WRAP_CHARACTER} wrap; every other
+     * value (and a non-positive width) maps each logical line to exactly one display row,
+     * matching the unwrapped {@link Overflow#CLIP} behavior. See {@link #isWrapping}.
+     * <p>
+     * The result is cached and reused until the text, the width, or the mode changes, so
+     * calling this several times per frame is cheap.
      *
      * @param visibleWidth the width available for text, in display columns
-     * @param wrap         the wrap mode
-     * @return the display rows, in document order
+     * @param overflow     the overflow mode
+     * @return an unmodifiable list of the display rows, in document order
      */
-    public List<DisplayRow> computeDisplayRows(int visibleWidth, Overflow wrap) {
+    public List<DisplayRow> computeDisplayRows(int visibleWidth, Overflow overflow) {
+        if (cachedVersion == textVersion && cachedWidth == visibleWidth && cachedOverflow == overflow) {
+            return cachedRows;
+        }
+
         List<DisplayRow> result = new ArrayList<>();
-        boolean noWrap = wrap == null || wrap == Overflow.CLIP || visibleWidth <= 0;
+        boolean noWrap = !isWrapping(overflow) || visibleWidth <= 0;
         for (int row = 0; row < lines.size(); row++) {
             String line = lines.get(row).toString();
             if (noWrap) {
@@ -365,14 +435,19 @@ public final class TextAreaState {
                 result.add(new DisplayRow(row, 0, 0));
                 continue;
             }
-            List<int[]> segments = wrap == Overflow.WRAP_WORD
+            List<int[]> segments = overflow == Overflow.WRAP_WORD
                 ? wrapLineByWord(line, visibleWidth)
                 : wrapLineByCharacter(line, visibleWidth);
             for (int[] segment : segments) {
                 result.add(new DisplayRow(row, segment[0], segment[1]));
             }
         }
-        return result;
+
+        cachedRows = Collections.unmodifiableList(result);
+        cachedWidth = visibleWidth;
+        cachedOverflow = overflow;
+        cachedVersion = textVersion;
+        return cachedRows;
     }
 
     private static List<int[]> wrapLineByCharacter(String line, int maxWidth) {
@@ -497,23 +572,24 @@ public final class TextAreaState {
     /**
      * Adjusts scroll offsets to keep the cursor visible.
      * <p>
-     * With {@link Overflow#CLIP}, behaves exactly like {@link #ensureCursorVisible(int, int)}.
      * With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, {@code scrollRow} is treated as an index
      * into the wrapped display rows (see {@link #computeDisplayRows}) and {@code scrollCol} is
-     * always {@code 0}, since a wrapped row always fits within {@code visibleCols}.
+     * always {@code 0}, since a wrapped row always fits within {@code visibleCols}. Every other
+     * {@link Overflow} value (including {@code null}) is treated as {@link Overflow#CLIP} and
+     * behaves exactly like {@link #ensureCursorVisible(int, int)}.
      *
      * @param visibleRows the number of visible rows
      * @param visibleCols the number of visible columns
-     * @param wrap        the wrap mode
+     * @param overflow    the overflow mode
      */
-    public void ensureCursorVisible(int visibleRows, int visibleCols, Overflow wrap) {
-        if (wrap == null || wrap == Overflow.CLIP) {
+    public void ensureCursorVisible(int visibleRows, int visibleCols, Overflow overflow) {
+        if (!isWrapping(overflow)) {
             ensureCursorVisibleClip(visibleRows, visibleCols);
             return;
         }
 
-        List<DisplayRow> rows = computeDisplayRows(visibleCols, wrap);
-        int cursorDisplayIndex = findDisplayRowIndex(rows, cursorRow, cursorCol);
+        List<DisplayRow> rows = computeDisplayRows(visibleCols, overflow);
+        int cursorDisplayIndex = findCursorDisplayRowIndex(rows, cursorRow, cursorCol);
 
         if (cursorDisplayIndex < scrollRow) {
             scrollRow = cursorDisplayIndex;
@@ -548,6 +624,10 @@ public final class TextAreaState {
     /**
      * Finds the index within {@code rows} (as returned by {@link #computeDisplayRows}) of the
      * display row containing the given logical position.
+     * <p>
+     * A position on whitespace consumed by a word-wrap break belongs to no row and resolves to
+     * the row before the break; see {@link #findCursorDisplayRowIndex} for where such a
+     * position is drawn.
      *
      * @param rows       the display rows to search
      * @param logicalRow the logical (newline-delimited) line index
@@ -565,6 +645,26 @@ public final class TextAreaState {
             }
         }
         return best;
+    }
+
+    /**
+     * Like {@link #findDisplayRowIndex}, but resolves where the cursor is actually *drawn*.
+     * <p>
+     * A word-wrap break consumes the whitespace between two rows, so {@code "one two three"} at
+     * width 7 yields {@code [0,7)} and {@code [8,13)} — leaving char offset 7 (the consumed
+     * space, reachable with Left/Right) inside no display row. Such a position is drawn at the
+     * start of the following row, where the caret visually lands.
+     * <p>
+     * Cursor <em>movement</em> deliberately does not snap: {@code moveCursorUp} clamps to offset
+     * 7 as the end of the first visual row, and {@code moveCursorDown} must then return to the
+     * second one.
+     */
+    static int findCursorDisplayRowIndex(List<DisplayRow> rows, int logicalRow, int col) {
+        int index = findDisplayRowIndex(rows, logicalRow, col);
+        if (index + 1 >= rows.size() || col < rows.get(index).endCol()) {
+            return index;
+        }
+        return rows.get(index + 1).logicalRow() == logicalRow ? index + 1 : index;
     }
 
     private static int findScrollColForCursor(String line, int cursorCol, int visibleCols) {
@@ -648,6 +748,7 @@ public final class TextAreaState {
 
     /** Clears all text and resets the cursor and scroll positions. */
     public void clear() {
+        textVersion++;
         lines.clear();
         lines.add(new StringBuilder());
         cursorRow = 0;
@@ -662,6 +763,7 @@ public final class TextAreaState {
      * @param newText the new text content
      */
     public void setText(String newText) {
+        textVersion++;
         lines.clear();
         if (newText == null || newText.isEmpty()) {
             lines.add(new StringBuilder());

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextAreaState.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextAreaState.java
@@ -7,6 +7,7 @@ package dev.tamboui.widgets.input;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.tamboui.style.Overflow;
 import dev.tamboui.text.CharWidth;
 
 /**
@@ -207,20 +208,83 @@ public final class TextAreaState {
         }
     }
 
-    /** Moves the cursor one row up. */
+    /** Moves the cursor one logical row up (assumes {@link Overflow#CLIP}, no wrapping). */
     public void moveCursorUp() {
+        moveCursorUpClip();
+    }
+
+    /**
+     * Moves the cursor up one row.
+     * <p>
+     * With {@link Overflow#CLIP}, behaves exactly like {@link #moveCursorUp()} (one logical
+     * row). With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, moves to the previous visual
+     * (wrapped) row, which may be a wrapped segment of the same logical line or the last
+     * segment of the previous logical line.
+     *
+     * @param visibleCols the number of visible columns (used to compute wrapped rows)
+     * @param wrap        the wrap mode
+     */
+    public void moveCursorUp(int visibleCols, Overflow wrap) {
+        if (wrap == null || wrap == Overflow.CLIP) {
+            moveCursorUpClip();
+            return;
+        }
+
+        List<DisplayRow> rows = computeDisplayRows(visibleCols, wrap);
+        int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
+        if (index <= 0) {
+            return;
+        }
+        moveCursorToDisplayRow(rows.get(index - 1));
+    }
+
+    private void moveCursorUpClip() {
         if (cursorRow > 0) {
             cursorRow--;
             cursorCol = Math.min(cursorCol, lines.get(cursorRow).length());
         }
     }
 
-    /** Moves the cursor one row down. */
+    /** Moves the cursor one logical row down (assumes {@link Overflow#CLIP}, no wrapping). */
     public void moveCursorDown() {
+        moveCursorDownClip();
+    }
+
+    /**
+     * Moves the cursor down one row.
+     * <p>
+     * With {@link Overflow#CLIP}, behaves exactly like {@link #moveCursorDown()} (one logical
+     * row). With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, moves to the next visual (wrapped)
+     * row, which may be a wrapped segment of the same logical line or the first segment of the
+     * next logical line.
+     *
+     * @param visibleCols the number of visible columns (used to compute wrapped rows)
+     * @param wrap        the wrap mode
+     */
+    public void moveCursorDown(int visibleCols, Overflow wrap) {
+        if (wrap == null || wrap == Overflow.CLIP) {
+            moveCursorDownClip();
+            return;
+        }
+
+        List<DisplayRow> rows = computeDisplayRows(visibleCols, wrap);
+        int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
+        if (index < 0 || index >= rows.size() - 1) {
+            return;
+        }
+        moveCursorToDisplayRow(rows.get(index + 1));
+    }
+
+    private void moveCursorDownClip() {
         if (cursorRow < lines.size() - 1) {
             cursorRow++;
             cursorCol = Math.min(cursorCol, lines.get(cursorRow).length());
         }
+    }
+
+    private void moveCursorToDisplayRow(DisplayRow target) {
+        cursorRow = target.logicalRow();
+        cursorCol = Math.max(target.startCol(), Math.min(cursorCol, target.endCol()));
     }
 
     /** Moves the cursor to the start of the current line. */
@@ -245,15 +309,221 @@ public final class TextAreaState {
         cursorCol = lines.get(cursorRow).length();
     }
 
+    // --- Wrapping ---
+
+    /**
+     * One visually-wrapped row of a logical line: the character-offset range
+     * {@code [startCol, endCol)} of that line rendered on a single screen row.
+     */
+    public static final class DisplayRow {
+        private final int logicalRow;
+        private final int startCol;
+        private final int endCol;
+
+        DisplayRow(int logicalRow, int startCol, int endCol) {
+            this.logicalRow = logicalRow;
+            this.startCol = startCol;
+            this.endCol = endCol;
+        }
+
+        /** @return the logical (newline-delimited) line index this row belongs to */
+        public int logicalRow() {
+            return logicalRow;
+        }
+
+        /** @return the char offset (inclusive) where this row starts within its logical line */
+        public int startCol() {
+            return startCol;
+        }
+
+        /** @return the char offset (exclusive) where this row ends within its logical line */
+        public int endCol() {
+            return endCol;
+        }
+    }
+
+    /**
+     * Computes the visual rows produced by wrapping every logical line to {@code visibleWidth}.
+     * <p>
+     * With {@link Overflow#CLIP} (or a non-positive width) each logical line maps to exactly
+     * one display row, matching the unwrapped behavior.
+     *
+     * @param visibleWidth the width available for text, in display columns
+     * @param wrap         the wrap mode
+     * @return the display rows, in document order
+     */
+    public List<DisplayRow> computeDisplayRows(int visibleWidth, Overflow wrap) {
+        List<DisplayRow> result = new ArrayList<>();
+        boolean noWrap = wrap == null || wrap == Overflow.CLIP || visibleWidth <= 0;
+        for (int row = 0; row < lines.size(); row++) {
+            String line = lines.get(row).toString();
+            if (noWrap) {
+                result.add(new DisplayRow(row, 0, line.length()));
+                continue;
+            }
+            if (line.isEmpty()) {
+                result.add(new DisplayRow(row, 0, 0));
+                continue;
+            }
+            List<int[]> segments = wrap == Overflow.WRAP_WORD
+                ? wrapLineByWord(line, visibleWidth)
+                : wrapLineByCharacter(line, visibleWidth);
+            for (int[] segment : segments) {
+                result.add(new DisplayRow(row, segment[0], segment[1]));
+            }
+        }
+        return result;
+    }
+
+    private static List<int[]> wrapLineByCharacter(String line, int maxWidth) {
+        List<int[]> segments = new ArrayList<>();
+        int start = 0;
+        int width = 0;
+        int i = 0;
+        int len = line.length();
+        while (i < len) {
+            int codePoint = line.codePointAt(i);
+            int codePointWidth = CharWidth.of(codePoint);
+            int charCount = Character.charCount(codePoint);
+
+            if (width + codePointWidth > maxWidth) {
+                if (width == 0) {
+                    // Single character wider than maxWidth: give it its own row.
+                    segments.add(new int[] {start, i + charCount});
+                    i += charCount;
+                    start = i;
+                    width = 0;
+                    continue;
+                }
+                segments.add(new int[] {start, i});
+                start = i;
+                width = 0;
+                continue;
+            }
+
+            width += codePointWidth;
+            i += charCount;
+        }
+        segments.add(new int[] {start, len});
+        return segments;
+    }
+
+    private static List<int[]> wrapLineByWord(String line, int maxWidth) {
+        List<Integer> cpOffsets = new ArrayList<>();
+        List<Integer> cpWidths = new ArrayList<>();
+        int i = 0;
+        while (i < line.length()) {
+            int codePoint = line.codePointAt(i);
+            cpOffsets.add(i);
+            cpWidths.add(CharWidth.of(codePoint));
+            i += Character.charCount(codePoint);
+        }
+        cpOffsets.add(line.length());
+        int cpCount = cpWidths.size();
+
+        List<int[]> segments = new ArrayList<>();
+        int pos = 0;
+        while (pos < cpCount) {
+            int lineEnd = findNextWordBreakByWidth(line, cpOffsets, cpWidths, pos, cpCount, maxWidth);
+            segments.add(new int[] {cpOffsets.get(pos), cpOffsets.get(lineEnd)});
+
+            // Skip whitespace consumed by the break so the next row never starts with it.
+            int nextPos = lineEnd;
+            while (nextPos < cpCount && Character.isWhitespace(line.codePointAt(cpOffsets.get(nextPos)))) {
+                nextPos++;
+            }
+            pos = nextPos;
+        }
+        return segments;
+    }
+
+    private static int findNextWordBreakByWidth(String text, List<Integer> cpOffsets, List<Integer> cpWidths,
+                                                  int startPos, int cpCount, int maxWidth) {
+        int width = 0;
+        int maxEnd = startPos;
+        while (maxEnd < cpCount) {
+            int codePointWidth = cpWidths.get(maxEnd);
+            if (width + codePointWidth > maxWidth) {
+                break;
+            }
+            width += codePointWidth;
+            maxEnd++;
+        }
+
+        if (maxEnd == startPos) {
+            // Single code point wider than maxWidth: force progress.
+            maxEnd = Math.min(startPos + 1, cpCount);
+        }
+
+        if (maxEnd >= cpCount) {
+            return cpCount;
+        }
+
+        // The fit already ends exactly at a word boundary; no need to backtrack.
+        if (Character.isWhitespace(text.codePointAt(cpOffsets.get(maxEnd)))) {
+            return maxEnd;
+        }
+
+        for (int idx = maxEnd - 1; idx > startPos; idx--) {
+            int codePoint = text.codePointAt(cpOffsets.get(idx));
+            if (Character.isWhitespace(codePoint)) {
+                return idx;
+            }
+        }
+
+        for (int idx = maxEnd - 1; idx > startPos; idx--) {
+            int codePoint = text.codePointAt(cpOffsets.get(idx));
+            if (codePoint == '-' || codePoint == '/' || codePoint == '\\') {
+                return idx + 1;
+            }
+        }
+
+        return maxEnd;
+    }
+
     // --- Scrolling ---
 
     /**
-     * Adjusts scroll offsets to keep the cursor visible.
+     * Adjusts scroll offsets to keep the cursor visible, assuming {@link Overflow#CLIP}
+     * (no wrapping, horizontal scroll instead).
      *
      * @param visibleRows the number of visible rows
      * @param visibleCols the number of visible columns
      */
     public void ensureCursorVisible(int visibleRows, int visibleCols) {
+        ensureCursorVisibleClip(visibleRows, visibleCols);
+    }
+
+    /**
+     * Adjusts scroll offsets to keep the cursor visible.
+     * <p>
+     * With {@link Overflow#CLIP}, behaves exactly like {@link #ensureCursorVisible(int, int)}.
+     * With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, {@code scrollRow} is treated as an index
+     * into the wrapped display rows (see {@link #computeDisplayRows}) and {@code scrollCol} is
+     * always {@code 0}, since a wrapped row always fits within {@code visibleCols}.
+     *
+     * @param visibleRows the number of visible rows
+     * @param visibleCols the number of visible columns
+     * @param wrap        the wrap mode
+     */
+    public void ensureCursorVisible(int visibleRows, int visibleCols, Overflow wrap) {
+        if (wrap == null || wrap == Overflow.CLIP) {
+            ensureCursorVisibleClip(visibleRows, visibleCols);
+            return;
+        }
+
+        List<DisplayRow> rows = computeDisplayRows(visibleCols, wrap);
+        int cursorDisplayIndex = findDisplayRowIndex(rows, cursorRow, cursorCol);
+
+        if (cursorDisplayIndex < scrollRow) {
+            scrollRow = cursorDisplayIndex;
+        } else if (cursorDisplayIndex >= scrollRow + visibleRows) {
+            scrollRow = cursorDisplayIndex - visibleRows + 1;
+        }
+        scrollCol = 0;
+    }
+
+    private void ensureCursorVisibleClip(int visibleRows, int visibleCols) {
         // Vertical scrolling
         if (cursorRow < scrollRow) {
             scrollRow = cursorRow;
@@ -273,6 +543,28 @@ public final class TextAreaState {
                 scrollCol = findScrollColForCursor(line, cursorCol, visibleCols);
             }
         }
+    }
+
+    /**
+     * Finds the index within {@code rows} (as returned by {@link #computeDisplayRows}) of the
+     * display row containing the given logical position.
+     *
+     * @param rows       the display rows to search
+     * @param logicalRow the logical (newline-delimited) line index
+     * @param col        the char offset within that logical line
+     * @return the index of the containing display row
+     */
+    public static int findDisplayRowIndex(List<DisplayRow> rows, int logicalRow, int col) {
+        int best = 0;
+        for (int i = 0; i < rows.size(); i++) {
+            DisplayRow row = rows.get(i);
+            if (row.logicalRow() == logicalRow && row.startCol() <= col) {
+                best = i;
+            } else if (row.logicalRow() > logicalRow) {
+                break;
+            }
+        }
+        return best;
     }
 
     private static int findScrollColForCursor(String line, int cursorCol, int visibleCols) {

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextAreaState.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/input/TextAreaState.java
@@ -265,11 +265,11 @@ public final class TextAreaState {
         }
 
         List<DisplayRow> rows = computeDisplayRows(visibleCols, overflow);
-        int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
+        int index = findCursorDisplayRowIndex(rows, visibleCols);
         if (index <= 0) {
             return;
         }
-        moveCursorToDisplayRow(rows.get(index - 1));
+        moveCursorToDisplayRow(rows, index, index - 1, visibleCols);
     }
 
     private void moveCursorUpClip() {
@@ -303,11 +303,11 @@ public final class TextAreaState {
         }
 
         List<DisplayRow> rows = computeDisplayRows(visibleCols, overflow);
-        int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
+        int index = findCursorDisplayRowIndex(rows, visibleCols);
         if (index < 0 || index >= rows.size() - 1) {
             return;
         }
-        moveCursorToDisplayRow(rows.get(index + 1));
+        moveCursorToDisplayRow(rows, index, index + 1, visibleCols);
     }
 
     private void moveCursorDownClip() {
@@ -317,9 +317,38 @@ public final class TextAreaState {
         }
     }
 
-    private void moveCursorToDisplayRow(DisplayRow target) {
+    /**
+     * Moves the cursor from display row {@code fromIndex} (where it is drawn) to display row
+     * {@code toIndex}, keeping it in the same screen column.
+     */
+    private void moveCursorToDisplayRow(List<DisplayRow> rows, int fromIndex, int toIndex, int visibleCols) {
+        DisplayRow from = rows.get(fromIndex);
+        String fromLine = getLine(from.logicalRow());
+        // Same column math as TextArea.renderWithCursor, so the caret moves from where it is seen.
+        int fromCol = Math.max(from.startCol(), Math.min(cursorCol, fromLine.length()));
+        int column = CharWidth.of(fromLine.substring(from.startCol(), fromCol));
+
+        DisplayRow target = rows.get(toIndex);
+        StringBuilder targetLine = lines.get(target.logicalRow());
+        int offset = target.startCol();
+        int width = 0;
+        while (offset < target.endCol()) {
+            int next = GraphemeClusters.clusterEnd(targetLine, offset);
+            int clusterWidth = CharWidth.of(targetLine.substring(offset, next));
+            if (width + clusterWidth > column) {
+                break;
+            }
+            width += clusterWidth;
+            offset = next;
+        }
         cursorRow = target.logicalRow();
-        cursorCol = Math.max(target.startCol(), Math.min(cursorCol, target.endCol()));
+        cursorCol = offset;
+
+        // The end of a row can be drawn on the next one (see findCursorDisplayRowIndex); step
+        // back a cluster so the caret stays on the row it moved to.
+        if (offset > target.startCol() && findCursorDisplayRowIndex(rows, visibleCols) != toIndex) {
+            cursorCol = GraphemeClusters.clusterStart(targetLine, offset);
+        }
     }
 
     /** Moves the cursor to the start of the current line. */
@@ -411,6 +440,10 @@ public final class TextAreaState {
      * value (and a non-positive width) maps each logical line to exactly one display row,
      * matching the unwrapped {@link Overflow#CLIP} behavior. See {@link #isWrapping}.
      * <p>
+     * When wrapping, a line whose last row fills the whole width (or ends in whitespace that a
+     * word break consumed) is followed by an empty row at the end of the line, so a caret placed
+     * there has a cell to be drawn in.
+     * <p>
      * The result is cached and reused until the text, the width, or the mode changes, so
      * calling this several times per frame is cheap.
      *
@@ -426,12 +459,12 @@ public final class TextAreaState {
         List<DisplayRow> result = new ArrayList<>();
         boolean noWrap = !isWrapping(overflow) || visibleWidth <= 0;
         for (int row = 0; row < lines.size(); row++) {
-            String line = lines.get(row).toString();
+            StringBuilder line = lines.get(row);
             if (noWrap) {
                 result.add(new DisplayRow(row, 0, line.length()));
                 continue;
             }
-            if (line.isEmpty()) {
+            if (line.length() == 0) {
                 result.add(new DisplayRow(row, 0, 0));
                 continue;
             }
@@ -440,6 +473,13 @@ public final class TextAreaState {
                 : wrapLineByCharacter(line, visibleWidth);
             for (int[] segment : segments) {
                 result.add(new DisplayRow(row, segment[0], segment[1]));
+            }
+            // A caret at the end of the line needs a cell to be drawn in. When the last row
+            // already fills the width, or a word break consumed trailing whitespace, the end of
+            // the line gets an empty row of its own.
+            int[] last = segments.get(segments.size() - 1);
+            if (last[1] < line.length() || CharWidth.of(line.substring(last[0], last[1])) >= visibleWidth) {
+                result.add(new DisplayRow(row, line.length(), line.length()));
             }
         }
 
@@ -450,22 +490,24 @@ public final class TextAreaState {
         return cachedRows;
     }
 
-    private static List<int[]> wrapLineByCharacter(String line, int maxWidth) {
+    // Both wrap modes step by grapheme cluster, measured as a whole, so a ZWJ sequence or a
+    // flag is never split across rows and is as wide as CharWidth.of(String) says it is.
+
+    private static List<int[]> wrapLineByCharacter(StringBuilder line, int maxWidth) {
         List<int[]> segments = new ArrayList<>();
         int start = 0;
         int width = 0;
         int i = 0;
         int len = line.length();
         while (i < len) {
-            int codePoint = line.codePointAt(i);
-            int codePointWidth = CharWidth.of(codePoint);
-            int charCount = Character.charCount(codePoint);
+            int clusterEnd = GraphemeClusters.clusterEnd(line, i);
+            int clusterWidth = CharWidth.of(line.substring(i, clusterEnd));
 
-            if (width + codePointWidth > maxWidth) {
+            if (width + clusterWidth > maxWidth) {
                 if (width == 0) {
-                    // Single character wider than maxWidth: give it its own row.
-                    segments.add(new int[] {start, i + charCount});
-                    i += charCount;
+                    // Single cluster wider than maxWidth: give it its own row.
+                    segments.add(new int[] {start, clusterEnd});
+                    i = clusterEnd;
                     start = i;
                     width = 0;
                     continue;
@@ -476,35 +518,39 @@ public final class TextAreaState {
                 continue;
             }
 
-            width += codePointWidth;
-            i += charCount;
+            width += clusterWidth;
+            i = clusterEnd;
         }
-        segments.add(new int[] {start, len});
+        // Nothing is left over when the line ended on a cluster that got a row of its own.
+        if (start < len) {
+            segments.add(new int[] {start, len});
+        }
         return segments;
     }
 
-    private static List<int[]> wrapLineByWord(String line, int maxWidth) {
-        List<Integer> cpOffsets = new ArrayList<>();
-        List<Integer> cpWidths = new ArrayList<>();
+    private static List<int[]> wrapLineByWord(StringBuilder line, int maxWidth) {
+        List<Integer> clusterOffsets = new ArrayList<>();
+        List<Integer> clusterWidths = new ArrayList<>();
         int i = 0;
         while (i < line.length()) {
-            int codePoint = line.codePointAt(i);
-            cpOffsets.add(i);
-            cpWidths.add(CharWidth.of(codePoint));
-            i += Character.charCount(codePoint);
+            int clusterEnd = GraphemeClusters.clusterEnd(line, i);
+            clusterOffsets.add(i);
+            clusterWidths.add(CharWidth.of(line.substring(i, clusterEnd)));
+            i = clusterEnd;
         }
-        cpOffsets.add(line.length());
-        int cpCount = cpWidths.size();
+        clusterOffsets.add(line.length());
+        int clusterCount = clusterWidths.size();
 
         List<int[]> segments = new ArrayList<>();
         int pos = 0;
-        while (pos < cpCount) {
-            int lineEnd = findNextWordBreakByWidth(line, cpOffsets, cpWidths, pos, cpCount, maxWidth);
-            segments.add(new int[] {cpOffsets.get(pos), cpOffsets.get(lineEnd)});
+        while (pos < clusterCount) {
+            int lineEnd = findNextWordBreakByWidth(line, clusterOffsets, clusterWidths, pos, clusterCount, maxWidth);
+            segments.add(new int[] {clusterOffsets.get(pos), clusterOffsets.get(lineEnd)});
 
             // Skip whitespace consumed by the break so the next row never starts with it.
             int nextPos = lineEnd;
-            while (nextPos < cpCount && Character.isWhitespace(line.codePointAt(cpOffsets.get(nextPos)))) {
+            while (nextPos < clusterCount
+                && Character.isWhitespace(line.codePointAt(clusterOffsets.get(nextPos)))) {
                 nextPos++;
             }
             pos = nextPos;
@@ -512,42 +558,43 @@ public final class TextAreaState {
         return segments;
     }
 
-    private static int findNextWordBreakByWidth(String text, List<Integer> cpOffsets, List<Integer> cpWidths,
-                                                  int startPos, int cpCount, int maxWidth) {
+    private static int findNextWordBreakByWidth(StringBuilder text, List<Integer> clusterOffsets,
+                                                  List<Integer> clusterWidths, int startPos, int clusterCount,
+                                                  int maxWidth) {
         int width = 0;
         int maxEnd = startPos;
-        while (maxEnd < cpCount) {
-            int codePointWidth = cpWidths.get(maxEnd);
-            if (width + codePointWidth > maxWidth) {
+        while (maxEnd < clusterCount) {
+            int clusterWidth = clusterWidths.get(maxEnd);
+            if (width + clusterWidth > maxWidth) {
                 break;
             }
-            width += codePointWidth;
+            width += clusterWidth;
             maxEnd++;
         }
 
         if (maxEnd == startPos) {
-            // Single code point wider than maxWidth: force progress.
-            maxEnd = Math.min(startPos + 1, cpCount);
+            // Single cluster wider than maxWidth: force progress.
+            maxEnd = Math.min(startPos + 1, clusterCount);
         }
 
-        if (maxEnd >= cpCount) {
-            return cpCount;
+        if (maxEnd >= clusterCount) {
+            return clusterCount;
         }
 
         // The fit already ends exactly at a word boundary; no need to backtrack.
-        if (Character.isWhitespace(text.codePointAt(cpOffsets.get(maxEnd)))) {
+        if (Character.isWhitespace(text.codePointAt(clusterOffsets.get(maxEnd)))) {
             return maxEnd;
         }
 
         for (int idx = maxEnd - 1; idx > startPos; idx--) {
-            int codePoint = text.codePointAt(cpOffsets.get(idx));
+            int codePoint = text.codePointAt(clusterOffsets.get(idx));
             if (Character.isWhitespace(codePoint)) {
                 return idx;
             }
         }
 
         for (int idx = maxEnd - 1; idx > startPos; idx--) {
-            int codePoint = text.codePointAt(cpOffsets.get(idx));
+            int codePoint = text.codePointAt(clusterOffsets.get(idx));
             if (codePoint == '-' || codePoint == '/' || codePoint == '\\') {
                 return idx + 1;
             }
@@ -589,7 +636,7 @@ public final class TextAreaState {
         }
 
         List<DisplayRow> rows = computeDisplayRows(visibleCols, overflow);
-        int cursorDisplayIndex = findCursorDisplayRowIndex(rows, cursorRow, cursorCol);
+        int cursorDisplayIndex = findCursorDisplayRowIndex(rows, visibleCols);
 
         if (cursorDisplayIndex < scrollRow) {
             scrollRow = cursorDisplayIndex;
@@ -648,23 +695,34 @@ public final class TextAreaState {
     }
 
     /**
-     * Like {@link #findDisplayRowIndex}, but resolves where the cursor is actually *drawn*.
+     * Like {@link #findDisplayRowIndex} for the cursor, but resolves the row it is actually
+     * <em>drawn</em> on.
      * <p>
      * A word-wrap break consumes the whitespace between two rows, so {@code "one two three"} at
      * width 7 yields {@code [0,7)} and {@code [8,13)} — leaving char offset 7 (the consumed
-     * space, reachable with Left/Right) inside no display row. Such a position is drawn at the
-     * start of the following row, where the caret visually lands.
+     * space, reachable with Left/Right) inside no display row. The caret at the break itself
+     * (offset 7) is drawn right after the row's text when the row leaves room for it; here
+     * {@code "one two"} fills the width, so it is drawn at the start of the following row
+     * instead, as is any offset further into the consumed whitespace.
      * <p>
-     * Cursor <em>movement</em> deliberately does not snap: {@code moveCursorUp} clamps to offset
-     * 7 as the end of the first visual row, and {@code moveCursorDown} must then return to the
-     * second one.
+     * Up/Down start from this row too, so the caret always moves from where it is seen.
+     *
+     * @param rows         the display rows, as returned by {@link #computeDisplayRows}
+     * @param visibleWidth the width the rows were wrapped to
+     * @return the index of the display row the cursor is drawn on
      */
-    static int findCursorDisplayRowIndex(List<DisplayRow> rows, int logicalRow, int col) {
-        int index = findDisplayRowIndex(rows, logicalRow, col);
-        if (index + 1 >= rows.size() || col < rows.get(index).endCol()) {
+    int findCursorDisplayRowIndex(List<DisplayRow> rows, int visibleWidth) {
+        int index = findDisplayRowIndex(rows, cursorRow, cursorCol);
+        DisplayRow row = rows.get(index);
+        if (index + 1 >= rows.size() || rows.get(index + 1).logicalRow() != cursorRow
+            || cursorCol < row.endCol()) {
             return index;
         }
-        return rows.get(index + 1).logicalRow() == logicalRow ? index + 1 : index;
+        if (cursorCol == row.endCol()
+            && CharWidth.of(getLine(cursorRow).substring(row.startCol(), row.endCol())) < visibleWidth) {
+            return index;
+        }
+        return index + 1;
     }
 
     private static int findScrollColForCursor(String line, int cursorCol, int visibleCols) {
@@ -741,6 +799,29 @@ public final class TextAreaState {
      */
     public void scrollDown(int amount, int visibleRows) {
         int maxScroll = Math.max(0, lines.size() - visibleRows);
+        scrollRow = Math.min(maxScroll, scrollRow + amount);
+    }
+
+    /**
+     * Scrolls down by the given amount of rows.
+     * <p>
+     * With {@code WRAP_WORD}/{@code WRAP_CHARACTER}, {@code scrollRow} indexes the wrapped
+     * display rows (see {@link #computeDisplayRows}), so scrolling is clamped to their count
+     * rather than to the number of logical lines. Every other {@link Overflow} value (including
+     * {@code null}) is treated as {@link Overflow#CLIP} and behaves exactly like
+     * {@link #scrollDown(int, int)}.
+     *
+     * @param amount      the number of rows to scroll down
+     * @param visibleRows the number of visible rows
+     * @param visibleCols the number of visible columns (used to compute wrapped rows)
+     * @param overflow    the overflow mode
+     */
+    public void scrollDown(int amount, int visibleRows, int visibleCols, Overflow overflow) {
+        if (!isWrapping(overflow)) {
+            scrollDown(amount, visibleRows);
+            return;
+        }
+        int maxScroll = Math.max(0, computeDisplayRows(visibleCols, overflow).size() - visibleRows);
         scrollRow = Math.min(maxScroll, scrollRow + amount);
     }
 

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaStateTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaStateTest.java
@@ -4,9 +4,13 @@
  */
 package dev.tamboui.widgets.input;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import dev.tamboui.style.Overflow;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -431,6 +435,178 @@ class TextAreaStateTest {
             state.scrollDown(10, 2); // With 3 lines and 2 visible, max scroll is 1
 
             assertThat(state.scrollRow()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Wrapping")
+    class Wrapping {
+
+        @Test
+        @DisplayName("computeDisplayRows with CLIP returns one row per logical line")
+        void computeDisplayRowsClip() {
+            TextAreaState state = new TextAreaState("Hello\nWorld");
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(80, Overflow.CLIP);
+
+            assertThat(rows).hasSize(2);
+            assertThat(rows.get(0).logicalRow()).isEqualTo(0);
+            assertThat(rows.get(0).startCol()).isEqualTo(0);
+            assertThat(rows.get(0).endCol()).isEqualTo(5);
+            assertThat(rows.get(1).logicalRow()).isEqualTo(1);
+            assertThat(rows.get(1).startCol()).isEqualTo(0);
+            assertThat(rows.get(1).endCol()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows with WRAP_CHARACTER splits a long line by width")
+        void computeDisplayRowsWrapCharacter() {
+            TextAreaState state = new TextAreaState("HelloWorld");
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(4, Overflow.WRAP_CHARACTER);
+
+            assertThat(rows).hasSize(3);
+            assertThat(rows.get(0).logicalRow()).isEqualTo(0);
+            assertThat(rows.get(0).startCol()).isEqualTo(0);
+            assertThat(rows.get(0).endCol()).isEqualTo(4);
+            assertThat(rows.get(1).startCol()).isEqualTo(4);
+            assertThat(rows.get(1).endCol()).isEqualTo(8);
+            assertThat(rows.get(2).startCol()).isEqualTo(8);
+            assertThat(rows.get(2).endCol()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows with WRAP_WORD breaks at word boundaries")
+        void computeDisplayRowsWrapWord() {
+            TextAreaState state = new TextAreaState("one two three");
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(7, Overflow.WRAP_WORD);
+
+            assertThat(rows).hasSize(2);
+            assertThat(state.getLine(0).substring(rows.get(0).startCol(), rows.get(0).endCol()))
+                .isEqualTo("one two");
+            assertThat(state.getLine(0).substring(rows.get(1).startCol(), rows.get(1).endCol()))
+                .isEqualTo("three");
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows with WRAP_CHARACTER splits wide (CJK) characters by display width")
+        void computeDisplayRowsWrapCharacterWideChars() {
+            TextAreaState state = new TextAreaState("世界你好"); // 4 chars * 2 width = 8 cols
+
+            // 5-wide area: "世界" (4 cols) fits, "你" (2 cols) would overflow to 6
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(5, Overflow.WRAP_CHARACTER);
+
+            assertThat(rows).hasSize(2);
+            assertThat(state.getLine(0).substring(rows.get(0).startCol(), rows.get(0).endCol()))
+                .isEqualTo("世界");
+            assertThat(state.getLine(0).substring(rows.get(1).startCol(), rows.get(1).endCol()))
+                .isEqualTo("你好");
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows keeps an empty logical line as a single empty row")
+        void computeDisplayRowsEmptyLine() {
+            TextAreaState state = new TextAreaState("Hello\n\nWorld");
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(3, Overflow.WRAP_WORD);
+
+            assertThat(rows).extracting(TextAreaState.DisplayRow::logicalRow)
+                .containsExactly(0, 0, 1, 2, 2);
+            TextAreaState.DisplayRow emptyLineRow = rows.stream()
+                .filter(r -> r.logicalRow() == 1)
+                .findFirst()
+                .get();
+            assertThat(emptyLineRow.startCol()).isEqualTo(0);
+            assertThat(emptyLineRow.endCol()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("ensureCursorVisible with CLIP behaves exactly as the 2-arg overload")
+        void ensureCursorVisibleClipDelegates() {
+            TextAreaState state = new TextAreaState("Line1\nLine2\nLine3\nLine4\nLine5");
+
+            state.ensureCursorVisible(3, 80, Overflow.CLIP);
+
+            assertThat(state.scrollRow()).isEqualTo(2); // Shows lines 2, 3, 4 - same as existing test
+        }
+
+        @Test
+        @DisplayName("ensureCursorVisible with WRAP_WORD scrolls by display row, not logical row")
+        void ensureCursorVisibleWrapScrollsByDisplayRow() {
+            // "one two three four five" wraps to 5 rows at width 7:
+            // "one two", "three", "four", "five" -- wait, compute precisely in-test via wrap.
+            TextAreaState state = new TextAreaState("one two three four five six seven");
+            state.moveCursorToEnd(); // cursor at the very end (last display row)
+
+            state.ensureCursorVisible(2, 7, Overflow.WRAP_WORD);
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(7, Overflow.WRAP_WORD);
+            int cursorDisplayIndex = rows.size() - 1; // cursor is on the last display row
+            assertThat(state.scrollRow()).isEqualTo(cursorDisplayIndex - 2 + 1);
+            assertThat(state.scrollCol()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("moveCursorDown with WRAP_WORD moves to the next visual row within the same logical line")
+        void moveCursorDownWrapMovesByVisualRow() {
+            // "one two three" wraps at width 7 to "one two" (row0) / "three" (row0, 2nd visual row)
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart(); // row 0, col 0 -> on the first visual row ("one two")
+
+            state.moveCursorDown(7, Overflow.WRAP_WORD);
+
+            assertThat(state.cursorRow()).isEqualTo(0); // still the same logical line
+            assertThat(state.cursorCol()).isEqualTo(8); // start of "three" segment
+        }
+
+        @Test
+        @DisplayName("moveCursorDown with WRAP_WORD at the last visual row does nothing")
+        void moveCursorDownWrapAtLastRowDoesNothing() {
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToEnd(); // last visual row
+
+            state.moveCursorDown(7, Overflow.WRAP_WORD);
+
+            assertThat(state.cursorRow()).isEqualTo(0);
+            assertThat(state.cursorCol()).isEqualTo(13); // unchanged, end of text
+        }
+
+        @Test
+        @DisplayName("moveCursorUp with WRAP_WORD moves to the previous visual row within the same logical line")
+        void moveCursorUpWrapMovesByVisualRow() {
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToEnd(); // on "three" segment (second visual row)
+
+            state.moveCursorUp(7, Overflow.WRAP_WORD);
+
+            assertThat(state.cursorRow()).isEqualTo(0);
+            assertThat(state.cursorCol()).isEqualTo(7); // clamped into "one two" segment [0,7]
+        }
+
+        @Test
+        @DisplayName("moveCursorUp with WRAP_WORD at the first visual row does nothing")
+        void moveCursorUpWrapAtFirstRowDoesNothing() {
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart();
+
+            state.moveCursorUp(7, Overflow.WRAP_WORD);
+
+            assertThat(state.cursorRow()).isEqualTo(0);
+            assertThat(state.cursorCol()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("moveCursorDown with WRAP_WORD crosses into the next logical line's first visual row")
+        void moveCursorDownWrapCrossesLogicalLine() {
+            TextAreaState state = new TextAreaState("one two three\nfour");
+            state.moveCursorToStart();
+            state.moveCursorDown(7, Overflow.WRAP_WORD); // -> "three" segment (row 0)
+
+            state.moveCursorDown(7, Overflow.WRAP_WORD); // -> "four" (row 1, only segment)
+
+            assertThat(state.cursorRow()).isEqualTo(1);
+            assertThat(state.cursorCol()).isEqualTo(4); // clamped into "four" (length 4)
         }
     }
 

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaStateTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaStateTest.java
@@ -608,6 +608,71 @@ class TextAreaStateTest {
             assertThat(state.cursorRow()).isEqualTo(1);
             assertThat(state.cursorCol()).isEqualTo(4); // clamped into "four" (length 4)
         }
+
+        @Test
+        @DisplayName("computeDisplayRows treats the truncating overflow modes as CLIP, not as character wrap")
+        void computeDisplayRowsTruncatingModesDoNotWrap() {
+            TextAreaState state = new TextAreaState("one two three");
+
+            for (Overflow truncating : new Overflow[] {
+                Overflow.ELLIPSIS, Overflow.ELLIPSIS_START, Overflow.ELLIPSIS_MIDDLE}) {
+                // A text area can move the caret into hidden text, so truncation makes no sense;
+                // these must fall back to CLIP rather than silently wrapping by character.
+                assertThat(state.computeDisplayRows(7, truncating))
+                    .as("%s", truncating)
+                    .hasSize(1);
+            }
+        }
+
+        @Test
+        @DisplayName("moveCursorDown with a truncating overflow mode moves by logical line, as with CLIP")
+        void moveCursorDownTruncatingModeMovesByLogicalLine() {
+            TextAreaState state = new TextAreaState("one two three\nfour");
+            state.moveCursorToStart();
+
+            state.moveCursorDown(7, Overflow.ELLIPSIS);
+
+            assertThat(state.cursorRow()).isEqualTo(1); // next logical line, not the "three" segment
+            assertThat(state.cursorCol()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows re-wraps after the text changes")
+        void computeDisplayRowsInvalidatedByTextChange() {
+            TextAreaState state = new TextAreaState("one two");
+
+            assertThat(state.computeDisplayRows(7, Overflow.WRAP_WORD)).hasSize(1);
+
+            state.insert(" three"); // cursor is at the end after construction
+
+            assertThat(state.computeDisplayRows(7, Overflow.WRAP_WORD)).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows re-wraps when the width or the mode changes")
+        void computeDisplayRowsInvalidatedByWidthOrMode() {
+            TextAreaState state = new TextAreaState("one two three");
+
+            assertThat(state.computeDisplayRows(7, Overflow.WRAP_WORD)).hasSize(2);
+            assertThat(state.computeDisplayRows(20, Overflow.WRAP_WORD)).hasSize(1);
+            assertThat(state.computeDisplayRows(7, Overflow.WRAP_CHARACTER)).hasSize(2);
+            assertThat(state.computeDisplayRows(7, Overflow.CLIP)).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("ensureCursorVisible scrolls to the row where a cursor on consumed wrap whitespace is drawn")
+        void ensureCursorVisibleSnapsCursorOnConsumedWrapBreak() {
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToEnd();
+            state.moveCursorUp(7, Overflow.WRAP_WORD); // clamps to offset 7, the consumed space
+            assertThat(state.cursorCol()).isEqualTo(7);
+
+            // Only one row visible: the caret is drawn at the start of "three" (display row 1),
+            // so that row -- not "one two" -- has to be the one scrolled into view.
+            state.ensureCursorVisible(1, 7, Overflow.WRAP_WORD);
+
+            assertThat(state.scrollRow()).isEqualTo(1);
+        }
     }
 
     @Nested

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaStateTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaStateTest.java
@@ -4,6 +4,7 @@
  */
 package dev.tamboui.widgets.input;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -581,7 +582,53 @@ class TextAreaStateTest {
             state.moveCursorUp(7, Overflow.WRAP_WORD);
 
             assertThat(state.cursorRow()).isEqualTo(0);
-            assertThat(state.cursorCol()).isEqualTo(7); // clamped into "one two" segment [0,7]
+            // Same screen column (5, just past "three") in "one two": "one t|wo", not the row end.
+            assertThat(state.cursorCol()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("moveCursorDown with WRAP_WORD keeps the screen column, not the offset in the line")
+        void moveCursorDownWrapKeepsScreenColumn() {
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart();
+            state.moveCursorRight(); // "o|ne two", screen column 1
+
+            state.moveCursorDown(7, Overflow.WRAP_WORD);
+
+            // Column 1 of "three" is offset 9 ("t|hree"). Clamping the old offset 1 into the
+            // target row [8,13) would instead have reset the caret to column 0.
+            assertThat(state.cursorCol()).isEqualTo(9);
+        }
+
+        @Test
+        @DisplayName("moveCursorDown with wrapping keeps the screen column across wide (CJK) characters")
+        void moveCursorDownWrapKeepsScreenColumnAcrossWideChars() {
+            // Width 4: "abcd" / "世界" (each CJK char is 2 columns).
+            TextAreaState state = new TextAreaState("abcd世界");
+            state.moveCursorToStart();
+            state.moveCursorRight();
+            state.moveCursorRight();
+            state.moveCursorRight(); // "abc|d", screen column 3
+
+            state.moveCursorDown(4, Overflow.WRAP_CHARACTER);
+
+            // Column 3 falls inside "界" (columns 2-3), so the caret stops before it, after "世".
+            assertThat(state.cursorCol()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("moveCursorUp onto a short word-wrapped row lands after its text, on that row")
+        void moveCursorUpOntoShortWordWrappedRow() {
+            // Width 6: "ab" [0,2) / "cdefgh" [3,9); the space at offset 2 is consumed by the break.
+            TextAreaState state = new TextAreaState("ab cdefgh");
+            state.moveCursorLeft(); // "cdefg|h", screen column 5 of the second row
+
+            state.moveCursorUp(6, Overflow.WRAP_WORD);
+
+            // "ab|": the end of "ab" leaves room on its row, so the caret is drawn right there.
+            assertThat(state.cursorCol()).isEqualTo(2);
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(6, Overflow.WRAP_WORD);
+            assertThat(state.findCursorDisplayRowIndex(rows, 6)).isEqualTo(0);
         }
 
         @Test
@@ -606,7 +653,7 @@ class TextAreaStateTest {
             state.moveCursorDown(7, Overflow.WRAP_WORD); // -> "four" (row 1, only segment)
 
             assertThat(state.cursorRow()).isEqualTo(1);
-            assertThat(state.cursorCol()).isEqualTo(4); // clamped into "four" (length 4)
+            assertThat(state.cursorCol()).isEqualTo(0); // same screen column 0 as on "three"
         }
 
         @Test
@@ -641,11 +688,11 @@ class TextAreaStateTest {
         void computeDisplayRowsInvalidatedByTextChange() {
             TextAreaState state = new TextAreaState("one two");
 
-            assertThat(state.computeDisplayRows(7, Overflow.WRAP_WORD)).hasSize(1);
+            assertThat(state.computeDisplayRows(8, Overflow.WRAP_WORD)).hasSize(1);
 
             state.insert(" three"); // cursor is at the end after construction
 
-            assertThat(state.computeDisplayRows(7, Overflow.WRAP_WORD)).hasSize(2);
+            assertThat(state.computeDisplayRows(8, Overflow.WRAP_WORD)).hasSize(2);
         }
 
         @Test
@@ -663,15 +710,109 @@ class TextAreaStateTest {
         @DisplayName("ensureCursorVisible scrolls to the row where a cursor on consumed wrap whitespace is drawn")
         void ensureCursorVisibleSnapsCursorOnConsumedWrapBreak() {
             TextAreaState state = new TextAreaState("one two three");
-            state.moveCursorToEnd();
-            state.moveCursorUp(7, Overflow.WRAP_WORD); // clamps to offset 7, the consumed space
-            assertThat(state.cursorCol()).isEqualTo(7);
+            state.moveCursorToStart();
+            for (int i = 0; i < 7; i++) {
+                state.moveCursorRight(); // up to offset 7, the space the wrap consumed
+            }
 
-            // Only one row visible: the caret is drawn at the start of "three" (display row 1),
-            // so that row -- not "one two" -- has to be the one scrolled into view.
+            // Only one row visible: "one two" fills the width, so the caret is drawn at the start
+            // of "three" (display row 1), and that row -- not "one two" -- is scrolled into view.
             state.ensureCursorVisible(1, 7, Overflow.WRAP_WORD);
 
             assertThat(state.scrollRow()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows adds an empty caret row after a line that fills the width")
+        void computeDisplayRowsAddsCaretRowAfterFullLine() {
+            TextAreaState full = new TextAreaState("abcdefg");
+            TextAreaState roomy = new TextAreaState("abc");
+
+            // The caret after "abcdefg" would sit in column 7 of a 7-wide area, outside it, so
+            // the end of the line gets a row of its own. "abc" leaves room and needs none.
+            assertThat(segments(full, 7, Overflow.WRAP_CHARACTER)).containsExactly("abcdefg", "");
+            assertThat(segments(roomy, 7, Overflow.WRAP_CHARACTER)).containsExactly("abc");
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows gives the end of a line a row when the wrap consumed trailing whitespace")
+        void computeDisplayRowsAddsCaretRowAfterConsumedTrailingWhitespace() {
+            TextAreaState state = new TextAreaState("one two "); // cursor at the end, offset 8
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(7, Overflow.WRAP_WORD);
+
+            // Without the trailing row, offset 8 would be drawn in column 8 and vanish.
+            assertThat(rows).hasSize(2);
+            assertThat(rows.get(1).startCol()).isEqualTo(8);
+            assertThat(rows.get(1).endCol()).isEqualTo(8);
+            assertThat(state.findCursorDisplayRowIndex(rows, 7)).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("computeDisplayRows gives a glyph wider than the area one row, plus only the caret row")
+        void computeDisplayRowsOverWideGlyph() {
+            TextAreaState state = new TextAreaState("中"); // 2 columns in a 1-column area
+
+            List<TextAreaState.DisplayRow> rows = state.computeDisplayRows(1, Overflow.WRAP_CHARACTER);
+
+            // The glyph gets a row of its own; the second, empty row exists only so the caret
+            // after the glyph has a cell to be drawn in. There is no third, stray row.
+            assertThat(segments(state, 1, Overflow.WRAP_CHARACTER)).containsExactly("中", "");
+            assertThat(rows.get(1).startCol()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("WRAP_CHARACTER never splits a ZWJ emoji sequence across rows")
+        void computeDisplayRowsWrapCharacterKeepsZwjSequenceWhole() {
+            // "👨‍🦲" is man + ZWJ + bald: one 2-column glyph. Counted per code point it is 4
+            // columns wide, and the bald component would be pushed onto the next row.
+            TextAreaState state = new TextAreaState("a👨‍🦲b");
+
+            assertThat(segments(state, 3, Overflow.WRAP_CHARACTER))
+                .containsExactly("a👨‍🦲", "b");
+        }
+
+        @Test
+        @DisplayName("WRAP_WORD measures a ZWJ emoji sequence inside a word as one glyph")
+        void computeDisplayRowsWrapWordKeepsZwjSequenceWhole() {
+            TextAreaState state = new TextAreaState("x👨‍🦲 y");
+
+            // "x👨‍🦲" is 3 columns and fits in 4; over-counting it as 5 would force a break
+            // inside the emoji.
+            assertThat(segments(state, 4, Overflow.WRAP_WORD))
+                .containsExactly("x👨‍🦲", "y");
+        }
+
+        @Test
+        @DisplayName("scrollDown with wrapping can scroll through the wrapped rows of a single line")
+        void scrollDownWrapClampsToDisplayRows() {
+            // One logical line, six display rows at width 7:
+            // "one two" / "three" / "four" / "five" / "six" / "seven"
+            TextAreaState state = new TextAreaState("one two three four five six seven");
+            state.scrollDown(10, 2); // the logical-line overload cannot move past row 0
+            assertThat(state.scrollRow()).isEqualTo(0);
+
+            state.scrollDown(10, 2, 7, Overflow.WRAP_WORD);
+
+            assertThat(state.scrollRow()).isEqualTo(4); // 6 display rows - 2 visible
+        }
+
+        @Test
+        @DisplayName("scrollDown with a non-wrapping overflow clamps to logical lines, like the 2-arg overload")
+        void scrollDownClipDelegates() {
+            TextAreaState state = new TextAreaState("one two three four five six seven\nL2\nL3");
+
+            state.scrollDown(10, 2, 7, Overflow.CLIP);
+
+            assertThat(state.scrollRow()).isEqualTo(1); // 3 logical lines - 2 visible
+        }
+
+        private List<String> segments(TextAreaState state, int width, Overflow overflow) {
+            List<String> result = new ArrayList<>();
+            for (TextAreaState.DisplayRow row : state.computeDisplayRows(width, overflow)) {
+                result.add(state.getLine(row.logicalRow()).substring(row.startCol(), row.endCol()));
+            }
+            return result;
         }
     }
 

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaTest.java
@@ -92,11 +92,12 @@ class TextAreaTest {
         Style cursorStyle = Style.EMPTY.reversed();
         TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
         TextAreaState state = new TextAreaState("one two three");
-        state.moveCursorToEnd();
-        // Up clamps into the first visual row "one two" [0,7): offset 7 is the space the wrap
-        // consumed, so it belongs to no display row and must be drawn at the start of "three".
-        state.moveCursorUp(7, Overflow.WRAP_WORD);
-        assertThat(state.cursorCol()).isEqualTo(7);
+        state.moveCursorToStart();
+        // Offset 7 is the space the wrap consumed between "one two" [0,7) and "three" [8,13).
+        // "one two" fills the 7-wide area, so the caret must be drawn at the start of "three".
+        for (int i = 0; i < 7; i++) {
+            state.moveCursorRight();
+        }
 
         Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
         Frame frame = Frame.forTesting(buffer);
@@ -104,6 +105,78 @@ class TextAreaTest {
         textArea.renderWithCursor(buffer.area(), buffer, state, frame);
 
         assertThat(buffer.get(0, 1).style()).isEqualTo(cursorStyle);
+    }
+
+    @Test
+    @DisplayName("renderWithCursor draws a cursor at a word-wrap break right after the row's text when it fits")
+    void renderWithCursorAtWordWrapBreakWithRoom() {
+        Style cursorStyle = Style.EMPTY.reversed();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
+        TextAreaState state = new TextAreaState("ab cdefgh"); // "ab" [0,2) / "cdefgh" [3,9) at width 6
+        state.moveCursorToStart();
+        state.moveCursorRight();
+        state.moveCursorRight(); // "ab|"
+
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 6, 3));
+        Frame frame = Frame.forTesting(buffer);
+
+        textArea.renderWithCursor(buffer.area(), buffer, state, frame);
+
+        // "ab" leaves room on its row, so the caret stays there instead of jumping to "cdefgh".
+        assertThat(buffer.get(2, 0).style()).isEqualTo(cursorStyle);
+        assertThat(buffer.get(0, 1).style()).isNotEqualTo(cursorStyle);
+    }
+
+    @Test
+    @DisplayName("renderWithCursor keeps the caret visible after whitespace typed at a full row")
+    void renderWithCursorAfterTrailingWhitespaceAtWrapWidth() {
+        Style cursorStyle = Style.EMPTY.reversed();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
+        TextAreaState state = new TextAreaState("one two "); // cursor at the end, offset 8
+
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
+        Frame frame = Frame.forTesting(buffer);
+
+        textArea.renderWithCursor(buffer.area(), buffer, state, frame);
+
+        // "one two" fills row 0; the caret goes to the start of row 1, where typing continues.
+        assertThat(buffer.get(0, 1).style()).isEqualTo(cursorStyle);
+    }
+
+    @Test
+    @DisplayName("renderWithCursor keeps the caret visible at the end of a line that exactly fills the width")
+    void renderWithCursorAtEndOfFullLine() {
+        Style cursorStyle = Style.EMPTY.reversed();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_CHARACTER).cursorStyle(cursorStyle).build();
+        TextAreaState state = new TextAreaState("abcdefg"); // cursor at the end, offset 7
+
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
+        Frame frame = Frame.forTesting(buffer);
+
+        textArea.renderWithCursor(buffer.area(), buffer, state, frame);
+
+        assertThat(buffer.get(0, 1).style()).isEqualTo(cursorStyle);
+    }
+
+    @Test
+    @DisplayName("preferredHeight counts wrapped rows plus the block, using the render's gutter math")
+    void preferredHeightFitsWrappedText() {
+        TextArea.Builder builder = TextArea.builder()
+            .showLineNumbers(true)
+            .block(Block.builder().borders(Borders.ALL).build());
+        TextAreaState state = new TextAreaState("one two three four five");
+
+        // 20 - 2 (border) - 4 (gutter) = 14 for text: "one two three" / "four five", + 2 border rows.
+        int wrapped = builder.overflow(Overflow.WRAP_WORD).build().preferredHeight(20, state);
+        assertThat(wrapped).isEqualTo(4);
+        // Without wrapping the single logical line is one row, + 2 border rows.
+        assertThat(builder.overflow(Overflow.CLIP).build().preferredHeight(20, state)).isEqualTo(3);
+
+        // Rendering at exactly that height shows the whole text, down to the last word.
+        TextArea textArea = builder.overflow(Overflow.WRAP_WORD).build();
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 20, wrapped));
+        textArea.render(buffer.area(), buffer, state);
+        assertThat(extractRegion(buffer, 2, 5, 14)).isEqualTo("four five");
     }
 
     @Test

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.widgets.input;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.buffer.Buffer;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Overflow;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TextAreaTest {
+
+    @Test
+    @DisplayName("render with WRAP_WORD wraps a long line across multiple screen rows")
+    void renderWrapsAtWordBoundaries() {
+        TextArea textArea = TextArea.builder().wrap(Overflow.WRAP_WORD).build();
+        TextAreaState state = new TextAreaState("one two three");
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
+
+        textArea.render(buffer.area(), buffer, state);
+
+        assertThat(extractLineText(buffer, 0)).isEqualTo("one two");
+        assertThat(extractLineText(buffer, 1)).isEqualTo("three");
+        assertThat(extractLineText(buffer, 2)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("render with WRAP_CHARACTER splits a word longer than the viewport")
+    void renderWrapsAtCharacterBoundaries() {
+        TextArea textArea = TextArea.builder().wrap(Overflow.WRAP_CHARACTER).build();
+        TextAreaState state = new TextAreaState("HelloWorld");
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 4, 3));
+
+        textArea.render(buffer.area(), buffer, state);
+
+        assertThat(extractLineText(buffer, 0)).isEqualTo("Hell");
+        assertThat(extractLineText(buffer, 1)).isEqualTo("oWor");
+        assertThat(extractLineText(buffer, 2)).isEqualTo("ld");
+    }
+
+    @Test
+    @DisplayName("render with wrap and line numbers shows the number only on the first wrapped row")
+    void renderWrapShowsLineNumberOnlyOnFirstRow() {
+        TextArea textArea = TextArea.builder()
+            .wrap(Overflow.WRAP_WORD)
+            .showLineNumbers(true)
+            .build();
+        TextAreaState state = new TextAreaState("one two three");
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 11, 2));
+
+        textArea.render(buffer.area(), buffer, state);
+
+        // gutter is " 1 |" (right-padded digits + space + separator) on row 0, blank on row 1
+        assertThat(buffer.get(1, 0).symbol()).isEqualTo("1");
+        assertThat(buffer.get(3, 0).symbol()).isEqualTo("|");
+        assertThat(buffer.get(1, 1).symbol()).isEqualTo(" ");
+        assertThat(buffer.get(3, 1).symbol()).isEqualTo(" ");
+    }
+
+    @Test
+    @DisplayName("renderWithCursor places the cursor on the correct wrapped row and column")
+    void renderWithCursorOnWrappedRow() {
+        Style cursorStyle = Style.EMPTY.reversed();
+        TextArea textArea = TextArea.builder().wrap(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
+        TextAreaState state = new TextAreaState("one two three");
+        state.moveCursorToEnd(); // end of "three", offset 13 -> wrapped row 1, col 5 ("three".length())
+
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
+        Frame frame = Frame.forTesting(buffer);
+
+        textArea.renderWithCursor(buffer.area(), buffer, state, frame);
+
+        // Cursor row 1 ("three"), column 5 (just past 't','h','r','e','e')
+        assertThat(buffer.get(5, 1).style()).isEqualTo(cursorStyle);
+        assertThat(buffer.get(0, 0).style()).isNotEqualTo(cursorStyle);
+    }
+
+    private String extractLineText(Buffer buffer, int y) {
+        StringBuilder sb = new StringBuilder();
+        for (int x = 0; x < buffer.area().width(); x++) {
+            if (!buffer.get(x, y).isContinuation()) {
+                String sym = buffer.get(x, y).symbol();
+                if (!sym.equals(" ") || sb.length() > 0) {
+                    sb.append(sym);
+                }
+            }
+        }
+        return sb.toString().trim();
+    }
+}

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/input/TextAreaTest.java
@@ -4,6 +4,8 @@
  */
 package dev.tamboui.widgets.input;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +14,8 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Overflow;
 import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.Borders;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,7 +24,7 @@ class TextAreaTest {
     @Test
     @DisplayName("render with WRAP_WORD wraps a long line across multiple screen rows")
     void renderWrapsAtWordBoundaries() {
-        TextArea textArea = TextArea.builder().wrap(Overflow.WRAP_WORD).build();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_WORD).build();
         TextAreaState state = new TextAreaState("one two three");
         Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
 
@@ -34,7 +38,7 @@ class TextAreaTest {
     @Test
     @DisplayName("render with WRAP_CHARACTER splits a word longer than the viewport")
     void renderWrapsAtCharacterBoundaries() {
-        TextArea textArea = TextArea.builder().wrap(Overflow.WRAP_CHARACTER).build();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_CHARACTER).build();
         TextAreaState state = new TextAreaState("HelloWorld");
         Buffer buffer = Buffer.empty(new Rect(0, 0, 4, 3));
 
@@ -49,7 +53,7 @@ class TextAreaTest {
     @DisplayName("render with wrap and line numbers shows the number only on the first wrapped row")
     void renderWrapShowsLineNumberOnlyOnFirstRow() {
         TextArea textArea = TextArea.builder()
-            .wrap(Overflow.WRAP_WORD)
+            .overflow(Overflow.WRAP_WORD)
             .showLineNumbers(true)
             .build();
         TextAreaState state = new TextAreaState("one two three");
@@ -68,7 +72,7 @@ class TextAreaTest {
     @DisplayName("renderWithCursor places the cursor on the correct wrapped row and column")
     void renderWithCursorOnWrappedRow() {
         Style cursorStyle = Style.EMPTY.reversed();
-        TextArea textArea = TextArea.builder().wrap(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
         TextAreaState state = new TextAreaState("one two three");
         state.moveCursorToEnd(); // end of "three", offset 13 -> wrapped row 1, col 5 ("three".length())
 
@@ -80,6 +84,86 @@ class TextAreaTest {
         // Cursor row 1 ("three"), column 5 (just past 't','h','r','e','e')
         assertThat(buffer.get(5, 1).style()).isEqualTo(cursorStyle);
         assertThat(buffer.get(0, 0).style()).isNotEqualTo(cursorStyle);
+    }
+
+    @Test
+    @DisplayName("renderWithCursor draws a cursor on word-wrap break whitespace at the start of the next row")
+    void renderWithCursorOnConsumedWordWrapBreak() {
+        Style cursorStyle = Style.EMPTY.reversed();
+        TextArea textArea = TextArea.builder().overflow(Overflow.WRAP_WORD).cursorStyle(cursorStyle).build();
+        TextAreaState state = new TextAreaState("one two three");
+        state.moveCursorToEnd();
+        // Up clamps into the first visual row "one two" [0,7): offset 7 is the space the wrap
+        // consumed, so it belongs to no display row and must be drawn at the start of "three".
+        state.moveCursorUp(7, Overflow.WRAP_WORD);
+        assertThat(state.cursorCol()).isEqualTo(7);
+
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
+        Frame frame = Frame.forTesting(buffer);
+
+        textArea.renderWithCursor(buffer.area(), buffer, state, frame);
+
+        assertThat(buffer.get(0, 1).style()).isEqualTo(cursorStyle);
+    }
+
+    @Test
+    @DisplayName("render falls back to clipping for truncating overflow modes")
+    void renderTreatsEllipsisAsClip() {
+        for (Overflow truncating : new Overflow[] {
+            Overflow.ELLIPSIS, Overflow.ELLIPSIS_START, Overflow.ELLIPSIS_MIDDLE}) {
+            TextArea textArea = TextArea.builder().overflow(truncating).build();
+            TextAreaState state = new TextAreaState("one two three");
+            state.moveCursorToStart(); // avoid CLIP auto-scrolling to the end-of-text cursor
+            Buffer buffer = Buffer.empty(new Rect(0, 0, 7, 3));
+
+            textArea.render(buffer.area(), buffer, state);
+
+            assertThat(extractLineText(buffer, 0)).as("%s row 0", truncating).isEqualTo("one two");
+            // Not wrapped: "three" must not appear on row 1, and nothing is truncated with "...".
+            assertThat(extractLineText(buffer, 1)).as("%s row 1", truncating).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("render publishes the content width the rows were actually wrapped to")
+    void renderPublishesContentWidth() {
+        TextArea textArea = TextArea.builder()
+            .overflow(Overflow.WRAP_WORD)
+            .showLineNumbers(true)
+            .block(Block.builder().borders(Borders.ALL).build())
+            .build();
+        TextAreaState state = new TextAreaState("one two three four five");
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 20, 5));
+
+        textArea.render(buffer.area(), buffer, state);
+
+        // 20 - 2 (border) - 4 (gutter: max(2, 1 digit) + 2) = 14
+        assertThat(state.lastRenderedWidth()).isEqualTo(14);
+
+        // Guards against the published width drifting from the widget's own layout math:
+        // re-wrapping at lastRenderedWidth must reproduce exactly what was drawn.
+        List<TextAreaState.DisplayRow> rows =
+            state.computeDisplayRows(state.lastRenderedWidth(), Overflow.WRAP_WORD);
+        assertThat(rows).hasSize(2);
+        int textLeft = 1 + 4; // border + gutter
+        for (int i = 0; i < rows.size(); i++) {
+            TextAreaState.DisplayRow row = rows.get(i);
+            String expected = state.getLine(row.logicalRow()).substring(row.startCol(), row.endCol());
+            assertThat(extractRegion(buffer, 1 + i, textLeft, state.lastRenderedWidth()))
+                .as("display row %d", i)
+                .isEqualTo(expected);
+        }
+    }
+
+    /** The rendered text of {@code width} columns starting at {@code fromX}, right-trimmed. */
+    private String extractRegion(Buffer buffer, int y, int fromX, int width) {
+        StringBuilder sb = new StringBuilder();
+        for (int x = fromX; x < fromX + width; x++) {
+            if (!buffer.get(x, y).isContinuation()) {
+                sb.append(buffer.get(x, y).symbol());
+            }
+        }
+        return sb.toString().replaceAll("\\s+$", "");
     }
 
     private String extractLineText(Buffer buffer, int y) {


### PR DESCRIPTION
## Summary
- Add word/character wrapping to `TextArea`/`TextAreaState`, reusing the existing `Overflow` vocabulary (`CLIP`/`WRAP_WORD`/`WRAP_CHARACTER`) that `Paragraph` already exposes via `text-overflow`.
- `TextAreaState` gains a display-row model (`computeDisplayRows`) and wrap-aware overloads of `ensureCursorVisible`/`moveCursorUp`/`moveCursorDown`, so Up/Down move by visual row once wrapping is enabled. `CLIP`-mode behavior (the default) is unchanged.
- `TextAreaElement` exposes `overflow(Overflow)` plus the `wrapWord()`/`wrapCharacter()`/`clip()` shortcuts (and honors the `text-overflow` CSS property), wired through to the widget, to Up/Down key handling, and to its preferred size.

Related to [CAMEL-24395](https://issues.apache.org/jira/browse/CAMEL-24395) (camel-tui unifying its view/edit rendering onto a single `TextArea`-based path) and the gaps captured in `docs/textarea-readonly-and-styling-gaps.md`.

## Test plan
- [x] `./gradlew :tamboui-widgets:test` — 839 tests pass
- [x] `./gradlew :tamboui-toolkit:test` — 913 tests pass
- [x] `./gradlew :tamboui-widgets:check :tamboui-toolkit:check` — spotless clean
- [x] `./gradlew :docs:compileJava` — snippets still compile against the unchanged no-arg/2-arg overloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
