### PR TITLE
Fix #420: expose Table viewport height API for accurate scrollbar sizing

### DIFF
--- a/tamboui-widgets/demos/table-demo/src/main/java/dev/tamboui/demo/TableDemo.java
+++ b/tamboui-widgets/demos/table-demo/src/main/java/dev/tamboui/demo/TableDemo.java
@@ -29,6 +29,8 @@ import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Borders;
 import dev.tamboui.widgets.block.Title;
 import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.scrollbar.Scrollbar;
+import dev.tamboui.widgets.scrollbar.ScrollbarState;
 import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
@@ -56,6 +58,7 @@ public class TableDemo {
 
     private boolean running = true;
     private final TableState tableState = new TableState();
+    private final ScrollbarState scrollState = new ScrollbarState(DATA.size());
 
     private TableDemo() {
 
@@ -239,6 +242,17 @@ public class TableDemo {
             .build();
 
         frame.renderStatefulWidget(table, area, tableState);
+
+        // Size the scrollbar with viewportHeight, which accounts for the
+        // block borders and the header row. Overlay it on the right border
+        // beside the data rows (below top border + header).
+        int viewportHeight = table.viewportHeight(area);
+        if (viewportHeight > 0 && DATA.size() > viewportHeight) {
+            scrollState.viewportContentLength(viewportHeight)
+                .position(tableState.offset());
+            Rect scrollbarArea = new Rect(area.right() - 1, area.top() + 2, 1, viewportHeight);
+            frame.renderStatefulWidget(Scrollbar.vertical(), scrollbarArea, scrollState);
+        }
     }
 
     private void renderDetails(Frame frame, Rect area) {

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
@@ -203,14 +203,7 @@ public final class Table implements StatefulWidget<TableState> {
 
         // Ensure selected row is visible
         if (state.selected() != null) {
-            int visibleHeight = tableArea.height();
-            if (header != null) {
-                visibleHeight -= header.totalHeight();
-            }
-            if (footer != null) {
-                visibleHeight -= footer.totalHeight();
-            }
-            state.scrollToSelected(visibleHeight, rows);
+            state.scrollToSelected(viewportHeight(area), rows);
         }
 
         int y = tableArea.top();

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/table/Table.java
@@ -143,6 +143,31 @@ public final class Table implements StatefulWidget<TableState> {
         return rows;
     }
 
+    /**
+     * Computes the number of data rows visible in the given area.
+     * <p>
+     * This accounts for the vertical space consumed by the optional
+     * {@link Block} chrome (borders, titles, padding), the header row,
+     * and the footer row. The result is the height available for data
+     * rows and can be used by consumers that render their own scrollbar.
+     *
+     * @param area the total area the table will be rendered into
+     * @return the number of rows available for data content, never negative
+     */
+    public int viewportHeight(Rect area) {
+        int height = area.height();
+        if (block != null) {
+            height -= block.verticalChrome();
+        }
+        if (header != null) {
+            height -= header.totalHeight();
+        }
+        if (footer != null) {
+            height -= footer.totalHeight();
+        }
+        return Math.max(0, height);
+    }
+
     @Override
     public void render(Rect area, Buffer buffer, TableState state) {
         if (area.isEmpty()) {

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/table/TableTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/table/TableTest.java
@@ -276,6 +276,106 @@ class TableTest {
     }
 
     @Test
+    @DisplayName("viewportHeight returns full area height with no chrome")
+    void viewportHeightNoChrome() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from("Data")))
+            .widths(Constraint.length(10))
+            .build();
+
+        Rect area = new Rect(0, 0, 20, 10);
+        assertThat(table.viewportHeight(area)).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("viewportHeight subtracts block chrome")
+    void viewportHeightWithBlock() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from("Data")))
+            .widths(Constraint.length(10))
+            .block(Block.bordered())
+            .build();
+
+        Rect area = new Rect(0, 0, 20, 10);
+        // Bordered block takes 2 rows (top + bottom border)
+        assertThat(table.viewportHeight(area)).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("viewportHeight subtracts header height")
+    void viewportHeightWithHeader() {
+        Table table = Table.builder()
+            .header(Row.from("Name", "Age"))
+            .rows(Arrays.asList(Row.from("Alice", "30")))
+            .widths(Constraint.length(10), Constraint.length(5))
+            .build();
+
+        Rect area = new Rect(0, 0, 20, 10);
+        // Header takes 1 row
+        assertThat(table.viewportHeight(area)).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("viewportHeight subtracts footer height")
+    void viewportHeightWithFooter() {
+        Table table = Table.builder()
+            .rows(Arrays.asList(Row.from("Data")))
+            .footer(Row.from("Total: 1"))
+            .widths(Constraint.length(15))
+            .build();
+
+        Rect area = new Rect(0, 0, 20, 10);
+        // Footer takes 1 row
+        assertThat(table.viewportHeight(area)).isEqualTo(9);
+    }
+
+    @Test
+    @DisplayName("viewportHeight subtracts block, header, and footer")
+    void viewportHeightWithAll() {
+        Table table = Table.builder()
+            .header(Row.from("Name"))
+            .rows(Arrays.asList(Row.from("Data")))
+            .footer(Row.from("Total"))
+            .widths(Constraint.length(10))
+            .block(Block.bordered())
+            .build();
+
+        Rect area = new Rect(0, 0, 20, 10);
+        // Block: 2, header: 1, footer: 1 -> 10 - 4 = 6
+        assertThat(table.viewportHeight(area)).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("viewportHeight never returns negative")
+    void viewportHeightNeverNegative() {
+        Table table = Table.builder()
+            .header(Row.from("Name"))
+            .rows(Arrays.asList(Row.from("Data")))
+            .footer(Row.from("Total"))
+            .widths(Constraint.length(10))
+            .block(Block.bordered())
+            .build();
+
+        // Area too small to fit any data rows
+        Rect area = new Rect(0, 0, 20, 2);
+        assertThat(table.viewportHeight(area)).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("viewportHeight with header bottom margin")
+    void viewportHeightWithHeaderMargin() {
+        Table table = Table.builder()
+            .header(Row.from("Name").bottomMargin(1))
+            .rows(Arrays.asList(Row.from("Data")))
+            .widths(Constraint.length(10))
+            .build();
+
+        Rect area = new Rect(0, 0, 20, 10);
+        // Header: height 1 + margin 1 = totalHeight 2
+        assertThat(table.viewportHeight(area)).isEqualTo(8);
+    }
+
+    @Test
     @DisplayName("Table uses HIGHLIGHT_COLOR property from StylePropertyResolver")
     void usesHighlightColorProperty() {
         Table table = Table.builder()


### PR DESCRIPTION
## Summary

- Add `Table.viewportHeight(Rect)` method that computes the number of data rows visible in a given area, accounting for block chrome (borders, titles, padding), header row, and footer row heights
- This enables consumers like [pilot's `renderTableWithScrollbar`](https://github.com/maveniverse/pilot/pull/93#discussion_r3195341777) to size scrollbars accurately instead of approximating with `area.height() - 1`
- Note: `Block.verticalChrome()` and `Block.horizontalChrome()` are already public — no visibility change was needed

## Test plan

- [x] Added 7 new test cases covering all viewport height scenarios:
  - No chrome (returns full area height)
  - Block chrome subtracted
  - Header height subtracted
  - Footer height subtracted
  - All three combined (block + header + footer)
  - Never-negative guarantee (tiny area)
  - Header with bottom margin
- [x] All 831 existing tests pass
- [x] Spotless formatting check passes

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)