### PR TITLE
fix(core): treat comma-separated backend spec as preference order with fallback

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/terminal/BackendFactory.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/BackendFactory.java
@@ -5,6 +5,7 @@
 package dev.tamboui.terminal;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -111,14 +112,15 @@ public final class BackendFactory {
      * @throws BackendException if none of the specified providers were found
      */
     private static List<BackendProvider> resolveProviders(String providerSpec, List<BackendProvider> allProviders) {
-        List<BackendProvider> resolved = new java.util.ArrayList<>();
+        List<BackendProvider> resolved = new ArrayList<>();
         for (String spec : providerSpec.split(",")) {
             String trimmedSpec = spec.trim();
             if (trimmedSpec.isEmpty()) {
                 continue;
             }
             allProviders.stream()
-                    .filter(p -> p.name().equals(trimmedSpec))
+                    .filter(p -> p.name().equals(trimmedSpec)
+                            || p.getClass().getName().equals(trimmedSpec))
                     .findFirst()
                     .ifPresent(resolved::add);
         }

--- a/tamboui-core/src/main/java/dev/tamboui/terminal/BackendFactory.java
+++ b/tamboui-core/src/main/java/dev/tamboui/terminal/BackendFactory.java
@@ -101,11 +101,14 @@ public final class BackendFactory {
 
     /**
      * Resolves providers from a user specification, returning them in the specified order.
+     * Providers that appear in the specification but were not discovered (e.g. because
+     * the backend jar targets a newer Java version) are silently skipped so that subsequent
+     * entries in the comma-separated list can act as fallbacks.
      *
      * @param providerSpec the provider specification (may be comma-separated)
      * @param allProviders all available providers from ServiceLoader
      * @return list of matching providers in the specified order
-     * @throws BackendException if a backend provider is not found
+     * @throws BackendException if none of the specified providers were found
      */
     private static List<BackendProvider> resolveProviders(String providerSpec, List<BackendProvider> allProviders) {
         List<BackendProvider> resolved = new java.util.ArrayList<>();
@@ -114,15 +117,16 @@ public final class BackendFactory {
             if (trimmedSpec.isEmpty()) {
                 continue;
             }
-            BackendProvider provider = allProviders.stream()
+            allProviders.stream()
                     .filter(p -> p.name().equals(trimmedSpec))
                     .findFirst()
-                    .orElseThrow(() -> new BackendException(
-                            "No BackendProvider found on classpath for provider name" +
-                                    " '" + trimmedSpec + "'.\n" +
-                                    "Add a backend dependency such as tamboui-jline3-backend or tamboui-panama-backend."
-                    ));
-            resolved.add(provider);
+                    .ifPresent(resolved::add);
+        }
+        if (resolved.isEmpty()) {
+            throw new BackendException(
+                    "No BackendProvider found on classpath for any of the specified providers: '" + providerSpec + "'.\n"
+                            + "Available providers: " + formatAvailableProviders(allProviders) + "\n"
+                            + "Add a backend dependency such as tamboui-jline3-backend or tamboui-panama-backend.");
         }
         return resolved;
     }

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/BackendFactoryTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/BackendFactoryTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.terminal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for {@link BackendFactory}'s provider resolution logic.
+ * <p>
+ * Uses reflection to test the private {@code resolveProviders} method directly,
+ * verifying that a comma-separated provider specification acts as a preference
+ * order with fallback rather than a mandatory list.
+ */
+class BackendFactoryTest {
+
+    @Test
+    @DisplayName("resolveProviders skips unavailable provider and falls back to next")
+    void resolveProviders_skipsUnavailableProvider() throws Exception {
+        var method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        method.setAccessible(true);
+
+        // Only "beta" is available; "alpha" is not (simulating a provider that
+        // failed to load, e.g. because it targets a newer Java version)
+        List<BackendProvider> available = new ArrayList<>();
+        available.add(new StubBackendProvider("beta"));
+
+        @SuppressWarnings("unchecked")
+        List<BackendProvider> resolved = (List<BackendProvider>) method.invoke(null, "alpha,beta", available);
+
+        assertThat(resolved).hasSize(1);
+        assertThat(resolved.get(0).name()).isEqualTo("beta");
+    }
+
+    @Test
+    @DisplayName("resolveProviders preserves order when all providers are available")
+    void resolveProviders_preservesOrder() throws Exception {
+        var method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        method.setAccessible(true);
+
+        List<BackendProvider> available = new ArrayList<>();
+        available.add(new StubBackendProvider("beta"));
+        available.add(new StubBackendProvider("alpha"));
+
+        @SuppressWarnings("unchecked")
+        List<BackendProvider> resolved = (List<BackendProvider>) method.invoke(null, "alpha,beta", available);
+
+        assertThat(resolved).hasSize(2);
+        assertThat(resolved.get(0).name()).isEqualTo("alpha");
+        assertThat(resolved.get(1).name()).isEqualTo("beta");
+    }
+
+    @Test
+    @DisplayName("resolveProviders throws when no specified provider is available")
+    void resolveProviders_throwsWhenNoneAvailable() throws Exception {
+        var method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        method.setAccessible(true);
+
+        List<BackendProvider> available = new ArrayList<>();
+        available.add(new StubBackendProvider("gamma"));
+
+        assertThatThrownBy(() -> method.invoke(null, "alpha,beta", available))
+                .hasCauseInstanceOf(BackendException.class)
+                .cause()
+                .hasMessageContaining("alpha,beta");
+    }
+
+    /**
+     * Minimal BackendProvider stub for testing provider resolution.
+     */
+    private static class StubBackendProvider implements BackendProvider {
+        private final String providerName;
+
+        StubBackendProvider(String name) {
+            this.providerName = name;
+        }
+
+        @Override
+        public String name() {
+            return providerName;
+        }
+
+        @Override
+        public Backend create() throws IOException {
+            throw new IOException("stub — not a real backend");
+        }
+    }
+}

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/BackendFactoryTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/BackendFactoryTest.java
@@ -61,6 +61,25 @@ class BackendFactoryTest {
     }
 
     @Test
+    @DisplayName("resolveProviders matches a fully qualified provider class name")
+    void resolveProviders_matchesFullyQualifiedClassName() throws Exception {
+        Method method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        method.setAccessible(true);
+
+        // The class JavaDoc documents selection by FQCN, e.g.
+        // tamboui.backend=dev.tamboui.backend.jline.JLineBackendProvider
+        List<BackendProvider> available = new ArrayList<>();
+        available.add(new StubBackendProvider("alpha"));
+
+        @SuppressWarnings("unchecked")
+        List<BackendProvider> resolved = (List<BackendProvider>) method.invoke(
+                null, StubBackendProvider.class.getName(), available);
+
+        assertThat(resolved).hasSize(1);
+        assertThat(resolved.get(0).name()).isEqualTo("alpha");
+    }
+
+    @Test
     @DisplayName("resolveProviders throws when no specified provider is available")
     void resolveProviders_throwsWhenNoneAvailable() throws Exception {
         Method method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);

--- a/tamboui-core/src/test/java/dev/tamboui/terminal/BackendFactoryTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/terminal/BackendFactoryTest.java
@@ -5,6 +5,7 @@
 package dev.tamboui.terminal;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +27,7 @@ class BackendFactoryTest {
     @Test
     @DisplayName("resolveProviders skips unavailable provider and falls back to next")
     void resolveProviders_skipsUnavailableProvider() throws Exception {
-        var method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        Method method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
         method.setAccessible(true);
 
         // Only "beta" is available; "alpha" is not (simulating a provider that
@@ -44,7 +45,7 @@ class BackendFactoryTest {
     @Test
     @DisplayName("resolveProviders preserves order when all providers are available")
     void resolveProviders_preservesOrder() throws Exception {
-        var method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        Method method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
         method.setAccessible(true);
 
         List<BackendProvider> available = new ArrayList<>();
@@ -62,7 +63,7 @@ class BackendFactoryTest {
     @Test
     @DisplayName("resolveProviders throws when no specified provider is available")
     void resolveProviders_throwsWhenNoneAvailable() throws Exception {
-        var method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
+        Method method = BackendFactory.class.getDeclaredMethod("resolveProviders", String.class, List.class);
         method.setAccessible(true);
 
         List<BackendProvider> available = new ArrayList<>();


### PR DESCRIPTION
## Summary

- Fix `BackendFactory.resolveProviders()` to skip unavailable providers instead of throwing immediately
- When `tamboui.backend` is set to `"panama,jline3"` but the panama backend can't load (e.g. its classes are compiled for Java 22 but the runtime is Java 21), the method now falls through to `jline3` instead of throwing `BackendException`
- Only throws if **none** of the specified providers were found — the error message now shows all requested names and the actually available providers

## Problem

`SafeServiceLoader` correctly catches `UnsupportedClassVersionError` (via `LinkageError`) when a backend JAR targets a newer Java version, but `resolveProviders()` then fails because it uses `orElseThrow()` on each entry individually. The comma-separated list was intended as a preference order with fallback (as documented in the Javadoc: *"tries each in order until one succeeds"*), but the implementation treated every entry as mandatory.

## Fix

Replace `orElseThrow()` with `ifPresent(resolved::add)` so unavailable providers are silently skipped, matching the documented behavior. Throw only when the final resolved list is empty.

## Test plan

- [x] Added `BackendFactoryTest` with 3 cases: fallback when first provider missing, order preserved when all available, throws when none available
- [ ] Build and run tests with Java 25+ (build requires Java 25+, not available in CI environment)
- [ ] Verify pilot CLI starts on Java 21 with `tamboui.backend=panama,jline3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)