### PR TITLE
test: backend selection JDK-matrix integration tests

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,9 @@
+plugins {
+    // Auto-provisions JDK toolchains (e.g. the Java 21 test toolchain used by
+    // tamboui-backend-integration-tests) when they are not installed locally.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "tamboui-parent"
 
 val modules = listOf(
@@ -21,6 +27,7 @@ val modules = listOf(
     "tamboui-tfx-toolkit",
     "tamboui-demos",
     "tamboui-benchmarks",
+    "tamboui-backend-integration-tests",
     "docs"
 )
 

--- a/tamboui-backend-integration-tests/build.gradle.kts
+++ b/tamboui-backend-integration-tests/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("dev.tamboui.java-base")
+}
+
+description = "Integration tests for backend discovery and selection across JDK versions (not published)"
+
+dependencies {
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.bundles.testing)
+    testImplementation(projects.tambouiCore)
+    testRuntimeOnly(projects.tambouiJline3Backend)
+    testRuntimeOnly(projects.tambouiPanamaBackend)
+}
+
+// Run the tests on a Java 21 runtime: tamboui-panama-backend is compiled for Java 22, so
+// this reproduces the real mixed-JDK deployment where a provider is present on the
+// classpath but cannot be loaded on the running JVM. Unit tests simulate this with an
+// isolated classloader; these tests exercise the real UnsupportedClassVersionError path.
+tasks.test {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/tamboui-backend-integration-tests/src/test/java/dev/tamboui/integration/backend/BackendSelectionIntegrationTest.java
+++ b/tamboui-backend-integration-tests/src/test/java/dev/tamboui/integration/backend/BackendSelectionIntegrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright TamboUI Contributors
+ * SPDX-License-Identifier: MIT
+ */
+package dev.tamboui.integration.backend;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import dev.tamboui.capability.Capabilities;
+import dev.tamboui.terminal.Backend;
+import dev.tamboui.terminal.BackendException;
+import dev.tamboui.terminal.BackendFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for backend discovery and selection on a JVM older than the one
+ * {@code tamboui-panama-backend} is compiled for (Java 22).
+ * <p>
+ * The test task pins a Java 21 toolchain (see build.gradle.kts), with the real panama and
+ * jline3 backend jars on the classpath. The panama provider therefore fails to load with a
+ * genuine {@code UnsupportedClassVersionError}, which is the mixed-JDK deployment scenario
+ * behind the preference-order fallback and absent-vs-broken error reporting.
+ */
+class BackendSelectionIntegrationTest {
+
+    private static final String JLINE3_BACKEND_CLASS = "dev.tamboui.backend.jline3.JLineBackend";
+    private static final String JLINE3_PROVIDER_FQCN = "dev.tamboui.backend.jline3.JLineBackendProvider";
+
+    private String savedBackendProperty;
+
+    @BeforeAll
+    static void requiresJava21WithoutEnvOverride() {
+        assertThat(System.getProperty("java.specification.version"))
+                .as("these tests must run on a Java 21 toolchain (see build.gradle.kts)")
+                .isEqualTo("21");
+        assumeTrue(System.getenv("TAMBOUI_BACKEND") == null,
+                "TAMBOUI_BACKEND is set in the environment; it would override the tested selection");
+    }
+
+    @BeforeEach
+    void saveBackendSelection() {
+        savedBackendProperty = System.getProperty("tamboui.backend");
+        System.clearProperty("tamboui.backend");
+    }
+
+    @AfterEach
+    void restoreBackendSelection() {
+        if (savedBackendProperty != null) {
+            System.setProperty("tamboui.backend", savedBackendProperty);
+        } else {
+            System.clearProperty("tamboui.backend");
+        }
+    }
+
+    @Test
+    @DisplayName("comma-separated spec falls back when the first choice cannot load on this JVM")
+    void commaSpecFallsBackToNextProvider() throws Exception {
+        System.setProperty("tamboui.backend", "panama,jline3");
+
+        try (Backend backend = BackendFactory.create()) {
+            assertThat(backend.getClass().getName()).isEqualTo(JLINE3_BACKEND_CLASS);
+        }
+    }
+
+    @Test
+    @DisplayName("requesting only an incompatible provider reports the real cause, not missing dependency")
+    void incompatibleOnlyChoiceReportsRealCause() {
+        System.setProperty("tamboui.backend", "panama");
+
+        Throwable thrown = catchThrowable(BackendFactory::create);
+
+        assertThat(thrown)
+                .isInstanceOf(BackendException.class)
+                .hasMessageContaining("could not be initialized")
+                .hasMessageContaining("PanamaBackendProvider")
+                .hasMessageContaining("class file version")
+                // The jar IS on the classpath; advising to add it would be wrong.
+                .hasMessageNotContaining("Add a backend dependency")
+                // The error suggests the working fallback spec.
+                .hasMessageContaining("panama,jline3");
+    }
+
+    @Test
+    @DisplayName("unknown provider name lists available providers and discloses dropped ones")
+    void unknownProviderDisclosesDroppedProviders() {
+        System.setProperty("tamboui.backend", "bogus");
+
+        Throwable thrown = catchThrowable(BackendFactory::create);
+
+        assertThat(thrown)
+                .isInstanceOf(BackendException.class)
+                .hasMessageContaining("'bogus'")
+                .hasMessageContaining("Available providers: jline3")
+                .hasMessageContaining("could not be loaded on this JVM")
+                .hasMessageContaining("PanamaBackendProvider")
+                .hasMessageContaining("Add a backend dependency");
+    }
+
+    @Test
+    @DisplayName("provider can be selected by fully qualified class name")
+    void fullyQualifiedClassNameSelection() throws Exception {
+        System.setProperty("tamboui.backend", JLINE3_PROVIDER_FQCN);
+
+        try (Backend backend = BackendFactory.create()) {
+            assertThat(backend.getClass().getName()).isEqualTo(JLINE3_BACKEND_CLASS);
+        }
+    }
+
+    @Test
+    @DisplayName("auto-discovery without a spec selects the loadable provider")
+    void autoDiscoverySelectsLoadableProvider() throws Exception {
+        try (Backend backend = BackendFactory.create()) {
+            assertThat(backend.getClass().getName()).isEqualTo(JLINE3_BACKEND_CLASS);
+        }
+    }
+
+    @Test
+    @DisplayName("capabilities report names loadable providers and discloses load errors")
+    void capabilitiesReportDisclosesLoadErrors() throws Exception {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(buffer, true, "UTF-8");
+        Capabilities.print(out);
+        String report = new String(buffer.toByteArray(), StandardCharsets.UTF_8);
+
+        assertThat(report)
+                .contains("backend.provider_names: jline3")
+                .contains("backend.provider_error.0")
+                .contains("PanamaBackendProvider");
+    }
+}


### PR DESCRIPTION
Implements the integration-test item of #429, following up on the backend-loading fixes in #422 and #391. (Docs split into a separate PR.)

New non-published `tamboui-backend-integration-tests` module whose test task pins a **Java 21 toolchain** with the real `tamboui-panama-backend` (Java 22 classes) and `tamboui-jline3-backend` jars on the classpath. This exercises the genuine `UnsupportedClassVersionError` path that the unit tests can only simulate with an isolated classloader — the mixed-JDK deployment scenario behind Camel's and pilot's backend workarounds.

Six tests covering:
- `tamboui.backend=panama,jline3` → falls back to jline3 (#422 preference-order semantics)
- `tamboui.backend=panama` → real cause (`class file version`) + fallback hint, not "add a dependency" (#391)
- `tamboui.backend=bogus` → available providers listed + dropped provider disclosed (#391)
- FQCN selection (`dev.tamboui.backend.jline3.JLineBackendProvider`) (#422)
- auto-discovery without a spec
- capabilities report (`dev.tamboui.Main`) discloses `backend.provider_error.N`

`org.gradle.toolchains.foojay-resolver-convention` is added in settings so the Java 21 toolchain is auto-provisioned in CI — no workflow changes needed.

Relates to #429, #422, #391.