### PR TITLE
fix: keep SVG and HTML exports aligned for wide/emoji content (#415)

### DIFF
--- a/tamboui-core/src/main/java/dev/tamboui/export/svg/SvgExporter.java
+++ b/tamboui-core/src/main/java/dev/tamboui/export/svg/SvgExporter.java
@@ -159,7 +159,7 @@ public final class SvgExporter {
                         "class", className,
                         "x", format(runStart * charWidth),
                         "y", format(y * lineHeight + charHeight),
-                        "textLength", format(charWidth * text.length()),
+                        "textLength", format(charWidth * runLen),
                         "clip-path", "url(#" + uniqueId + "-line-" + y + ")"
                     ));
                 }

--- a/tamboui-core/src/test/java/dev/tamboui/export/svg/SvgExporterTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/export/svg/SvgExporterTest.java
@@ -4,6 +4,11 @@
  */
 package dev.tamboui.export.svg;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.junit.jupiter.api.Test;
 
 import dev.tamboui.buffer.Buffer;
@@ -13,6 +18,7 @@ import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 
 import static dev.tamboui.export.ExportRequest.export;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,6 +53,39 @@ final class SvgExporterTest {
         assertTrue(svg.contains(">Hello!<") || svg.contains("Hello!"));
         assertTrue(svg.contains(">AB<") || svg.contains("AB"));
         assertTrue(svg.contains(">CD<") || svg.contains("CD"));
+    }
+
+    @Test
+    void textLengthMatchesDisplayColumnsForWideCharsAndEmoji() {
+        // Regression test for #415: box-drawing borders must align with content
+        // rows even when content contains wide (CJK) and emoji glyphs. Each
+        // <text> run must be sized by its display-column count, not by the
+        // number of UTF-16 code units in its symbols.
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 12, 3));
+        buffer.setString(0, 0, "\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e", Style.EMPTY);
+        // │世界AB🔮X│ : side bars + CJK (2 cols each) + ASCII + emoji (2 cols) = 12 columns
+        buffer.setString(0, 1, "\u2502\u4e16\u754cAB\ud83d\udd2eX\u2502", Style.EMPTY);
+        buffer.setString(0, 2, "\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256f", Style.EMPTY);
+
+        String svg = export(buffer).as(Formats.SVG).options(o -> o.uniqueId("align")).toString();
+
+        List<Double> textLengths = textLengths(svg);
+        assertEquals(3, textLengths.size(), "expected one <text> run per row");
+        // All three rows span the same 12 display columns, so their textLength
+        // must be identical regardless of underlying UTF-16 length.
+        assertEquals(textLengths.get(0), textLengths.get(1), 0.0001,
+            "content row must have the same width as the top border");
+        assertEquals(textLengths.get(0), textLengths.get(2), 0.0001,
+            "bottom border must have the same width as the top border");
+    }
+
+    private static List<Double> textLengths(String svg) {
+        List<Double> values = new ArrayList<>();
+        Matcher matcher = Pattern.compile("textLength=\"([0-9.]+)\"").matcher(svg);
+        while (matcher.find()) {
+            values.add(Double.parseDouble(matcher.group(1)));
+        }
+        return values;
     }
 
     @Test


### PR DESCRIPTION
## Problem

Exports of buffers containing wide (CJK) or emoji glyphs misalign box-drawing
borders and columns with the content. This is visible with `Table` widgets using
`Borders.ALL` + `BorderType.ROUNDED`, at wider widths, and whenever the viewer's
font metrics don't match the assumed monospace advance (e.g. Fira Code not
installed, or a browser falling back for CJK/emoji).

Fixes #415.

## Root cause

All exporters iterate the buffer correctly cell-by-cell (one cell per display
column, continuation cells for wide glyphs). The bug was in **width enforcement**:

- **SVG** sized each `<text>` run's `textLength` by `text.length()` (UTF-16 code
  units) instead of display columns, so runs containing wide/emoji glyphs were
  compressed and drifted from the border rows.
- **HTML** emitted each run as a bare `<span>` with no width, so alignment
  depended entirely on the browser's monospace font — CJK/emoji fall back to
  non-monospace metrics and borders drift, with no `textLength` equivalent.
- Continuation cells carry `Style.EMPTY`, so a **styled** wide char was split
  from its continuation during run-grouping, compressing the glyph (SVG) or
  dropping a column (HTML).

Text export needs no change: plain text has no width metadata and already emits
the correct grapheme sequence (verified: every line is the expected display-column
width); alignment is up to the viewer, which terminals handle correctly.

## Fix

- **SVG**: `textLength = charWidth * runLen` (run cell count = display columns);
  `x` stays cell-based.
- **HTML**: pin every run to `display:inline-block;width:{cols}ch;overflow:hidden`
  (width classes in stylesheet mode, inline in embedded mode) — the HTML analog
  of `textLength`.
- **SVG + HTML**: absorb continuation cells into their base run so styled wide
  chars span their full column width.
- **Demo**: `export-demo` gains a CJK title and emoji cells so the exported
  SVG/HTML actually exercise the alignment.

## Tests

- `SvgExporterTest.textLengthMatchesDisplayColumnsForWideCharsAndEmoji`: a
  12-column box (top border / `│世界AB🔮X│` content / bottom border) yields
  identical `textLength` for all three rows (before: `[146.4, 122.0, 146.4]`,
  after: `[146.4, 146.4, 146.4]`).
- `HtmlExporterTest`: runs carry width enforcement (`display:inline-block`,
  `width:{cols}ch`) in both stylesheet and embedded modes; a CJK run is pinned to
  its display-column count (`width:5ch` for `世界|`, not 3 UTF-16 units).

Full `:tamboui-core:test` passes (JDK 25 build).

> Note: `export-demo` pins `//DEPS dev.tamboui:tamboui-core:LATEST`, so running it
> via `jbang` shows the last *released* artifact until this change ships. Build
> locally to see the fixed output.
