### PR TITLE
fix: align SVG & HTML export columns for wide/emoji content (follow-up to #435)

### DIFF
--- a/tamboui-core/demos/export-demo/src/main/java/dev/tamboui/demo/ExportDemo.java
+++ b/tamboui-core/demos/export-demo/src/main/java/dev/tamboui/demo/ExportDemo.java
@@ -47,8 +47,11 @@ public final class ExportDemo {
     private static final List<String[]> TABLE_DATA = List.of(
         new String[]{"Dec 20, 2019", "Star Wars: The Rise of Skywalker", "$952,110,690"},
         new String[]{"May 25, 2018", "Solo: A Star Wars Story", "$393,151,347"},
-        new String[]{"Dec 15, 2017", "Star Wars Ep. VIII: The Last Jedi", "$1,332,539,889"},
-        new String[]{"Dec 16, 2016", "Rogue One: A Star Wars Story", "$1,332,439,889"}
+        // Wide (CJK) and emoji content exercises SVG column alignment (see #415):
+        // borders and side bars must stay aligned with cells whose display width
+        // differs from their UTF-16 length.
+        new String[]{"Dec 15, 2017", "スター・ウォーズ 最後のジェダイ 🎬", "$1,332,539,889"},
+        new String[]{"Dec 16, 2016", "Rogue One ⭐ A Star Wars Story", "$1,332,439,889"}
     );
 
     private ExportDemo() {

--- a/tamboui-core/src/main/java/dev/tamboui/export/html/HtmlExporter.java
+++ b/tamboui-core/src/main/java/dev/tamboui/export/html/HtmlExporter.java
@@ -8,6 +8,8 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 
 import dev.tamboui.buffer.Buffer;
 import dev.tamboui.buffer.Cell;
@@ -74,6 +76,7 @@ public final class HtmlExporter {
 
         final Map<String, Integer> cssToClassNo = new LinkedHashMap<>();
         int nextClassNo = 1;
+        final Set<Integer> wideWidths = new TreeSet<>();
 
         StringBuilder code = new StringBuilder();
 
@@ -83,32 +86,45 @@ public final class HtmlExporter {
                 Cell cell = buffer.get(baseX + x, baseY + y);
                 Style style = cell.style();
 
-                StringBuilder runText = new StringBuilder();
+                StringBuilder runHtml = new StringBuilder();
+                boolean hasContent = false;
                 while (x < widthCells) {
                     Cell c = buffer.get(baseX + x, baseY + y);
-                    if (!c.style().equals(style)) {
+                    // Continuation cells belong to the preceding wide grapheme, so keep them
+                    // in the same run even though they carry Style.EMPTY.
+                    if (!c.isContinuation() && !c.style().equals(style)) {
                         break;
+                    }
+                    if (c.isContinuation()) {
+                        x++;
+                        continue;
                     }
                     String sym = c.symbol();
                     if (!sym.isEmpty()) {
-                        runText.append(sym);
+                        // Display width = 1 base cell plus any following continuation cells.
+                        int glyphCols = 1;
+                        int k = x + 1;
+                        while (k < widthCells && buffer.get(baseX + k, baseY + y).isContinuation()) {
+                            glyphCols++;
+                            k++;
+                        }
+                        appendGlyph(runHtml, escapeHtml(sym), glyphCols, options.inlineStyles, wideWidths);
+                        hasContent = true;
                     }
                     x++;
                 }
 
-                String text = runText.toString();
-                if (text.isEmpty()) {
+                if (!hasContent) {
                     continue;
                 }
 
                 String htmlStyle = styleToHtmlCss(style, defaultForeground, defaultBackground);
-                String escaped = escapeHtml(text);
 
                 if (options.inlineStyles) {
                     if (!htmlStyle.isEmpty()) {
-                        code.append("<span style=\"").append(htmlStyle).append("\">").append(escaped).append("</span>");
+                        code.append("<span style=\"").append(htmlStyle).append("\">").append(runHtml).append("</span>");
                     } else {
-                        code.append(escaped);
+                        code.append(runHtml);
                     }
                 } else {
                     Integer classNo = cssToClassNo.get(htmlStyle);
@@ -116,7 +132,7 @@ public final class HtmlExporter {
                         classNo = nextClassNo++;
                         cssToClassNo.put(htmlStyle, classNo);
                     }
-                    code.append("<span class=\"r").append(classNo).append("\">").append(escaped).append("</span>");
+                    code.append("<span class=\"r").append(classNo).append("\">").append(runHtml).append("</span>");
                 }
             }
             if (y < heightCells - 1) {
@@ -132,6 +148,9 @@ public final class HtmlExporter {
                     stylesheet.append(".r").append(e.getValue()).append(" { ").append(rule).append(" }\n");
                 }
             }
+            for (Integer cols : wideWidths) {
+                stylesheet.append(".cw").append(cols).append(" { ").append(wideGlyphCss(cols)).append(" }\n");
+            }
         }
 
         String foreground = toHex(defaultForeground);
@@ -142,6 +161,47 @@ public final class HtmlExporter {
             .replace("{stylesheet}", stylesheet.toString())
             .replace("{foreground}", foreground)
             .replace("{background}", background);
+    }
+
+    /**
+     * Appends a single grapheme to the run, pinning wide (CJK/emoji) glyphs to their exact
+     * column count so they cannot push adjacent columns and borders out of alignment when the
+     * browser falls back to a font whose advance width differs from the assumed monospace width.
+     * Single-column glyphs (including box-drawing borders) are emitted as plain text so they
+     * still connect vertically in the {@code <pre>} block.
+     *
+     * @param sb          the run buffer to append to
+     * @param escaped      the HTML-escaped glyph
+     * @param glyphCols    the display width of the glyph in columns
+     * @param inlineStyles whether to inline the width or reference a shared class
+     * @param wideWidths   collects the distinct wide widths so their classes can be emitted
+     */
+    private static void appendGlyph(StringBuilder sb, String escaped, int glyphCols,
+            boolean inlineStyles, Set<Integer> wideWidths) {
+        if (glyphCols <= 1) {
+            sb.append(escaped);
+            return;
+        }
+        if (inlineStyles) {
+            sb.append("<span style=\"").append(wideGlyphCss(glyphCols)).append("\">")
+                .append(escaped).append("</span>");
+        } else {
+            wideWidths.add(glyphCols);
+            sb.append("<span class=\"cw").append(glyphCols).append("\">").append(escaped).append("</span>");
+        }
+    }
+
+    /**
+     * CSS that pins a wide glyph to an exact number of monospace columns. {@code 1ch} equals the
+     * advance of the {@code 0} glyph, i.e. one column in a monospace font. Overflow is left
+     * visible so the glyph keeps its natural baseline (an {@code overflow:hidden} inline-block
+     * would shift the baseline and misalign it vertically with surrounding text).
+     *
+     * @param cols the number of display columns the glyph must occupy
+     * @return the inline-block width declaration for the glyph
+     */
+    private static String wideGlyphCss(int cols) {
+        return "display:inline-block;width:" + cols + "ch";
     }
 
     private static String minimalHtml(Color.Rgb defaultFg, Color.Rgb defaultBg) {

--- a/tamboui-core/src/main/java/dev/tamboui/export/html/HtmlExporter.java
+++ b/tamboui-core/src/main/java/dev/tamboui/export/html/HtmlExporter.java
@@ -329,7 +329,7 @@ public final class HtmlExporter {
         + "</style>\n"
         + "</head>\n"
         + "<body>\n"
-        + "    <pre style=\"font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><code style=\"font-family:inherit\">{code}</code></pre>\n"
+        + "    <pre style=\"font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;line-height:1.2\"><code style=\"font-family:inherit\">{code}</code></pre>\n"
         + "</body>\n"
         + "</html>";
 }

--- a/tamboui-core/src/main/java/dev/tamboui/export/svg/SvgExporter.java
+++ b/tamboui-core/src/main/java/dev/tamboui/export/svg/SvgExporter.java
@@ -119,7 +119,9 @@ public final class SvgExporter {
                 StringBuilder runText = new StringBuilder();
                 while (x < widthCells) {
                     Cell c = buffer.get(baseX + x, baseY + y);
-                    if (!c.style().equals(style)) {
+                    // Continuation cells belong to the preceding wide grapheme, so keep them
+                    // in the same run even though they carry Style.EMPTY.
+                    if (!c.isContinuation() && !c.style().equals(style)) {
                         break;
                     }
                     runText.append(c.symbol());

--- a/tamboui-core/src/main/java/dev/tamboui/export/svg/SvgExporter.java
+++ b/tamboui-core/src/main/java/dev/tamboui/export/svg/SvgExporter.java
@@ -114,9 +114,8 @@ public final class SvgExporter {
                 Cell cell = buffer.get(baseX + x, baseY + y);
                 Style style = cell.style();
 
-                // Build a run of same style for fewer nodes
+                // Build a run of same style for a single background rect.
                 int runStart = x;
-                StringBuilder runText = new StringBuilder();
                 while (x < widthCells) {
                     Cell c = buffer.get(baseX + x, baseY + y);
                     // Continuation cells belong to the preceding wide grapheme, so keep them
@@ -124,10 +123,10 @@ public final class SvgExporter {
                     if (!c.isContinuation() && !c.style().equals(style)) {
                         break;
                     }
-                    runText.append(c.symbol());
                     x++;
                 }
                 int runLen = x - runStart;
+                int runEnd = x;
 
                 ResolvedColors colors = resolveColors(style, defaultForeground, defaultBackground);
                 boolean hasBackground = colors.hasBackground;
@@ -153,17 +152,39 @@ public final class SvgExporter {
                     ));
                 }
 
-                String text = runText.toString();
-                if (!isAllSpaces(text)) {
-                    matrix.append(makeTag(
-                        "text",
-                        escapeText(text),
-                        "class", className,
-                        "x", format(runStart * charWidth),
-                        "y", format(y * lineHeight + charHeight),
-                        "textLength", format(charWidth * runLen),
-                        "clip-path", "url(#" + uniqueId + "-line-" + y + ")"
-                    ));
+                // Emit text in segments so each glyph sits at its exact column: consecutive
+                // 1-wide cells share one <text> (evenly distributed = column-aligned), while each
+                // wide glyph gets its own <text> pinned to its column span. A single textLength
+                // over the whole run would distribute spacing unevenly and drift the columns.
+                int seg = runStart;
+                while (seg < runEnd) {
+                    boolean wideBase = seg + 1 < runEnd
+                        && buffer.get(baseX + seg + 1, baseY + y).isContinuation();
+                    if (wideBase) {
+                        int glyphCols = 1;
+                        int k = seg + 1;
+                        while (k < runEnd && buffer.get(baseX + k, baseY + y).isContinuation()) {
+                            glyphCols++;
+                            k++;
+                        }
+                        appendTextSegment(matrix, buffer.get(baseX + seg, baseY + y).symbol(),
+                            seg, glyphCols, charWidth, lineHeight, charHeight, y, className, uniqueId);
+                        seg = k;
+                    } else {
+                        int segStart = seg;
+                        StringBuilder segText = new StringBuilder();
+                        while (seg < runEnd) {
+                            boolean nextWide = seg + 1 < runEnd
+                                && buffer.get(baseX + seg + 1, baseY + y).isContinuation();
+                            if (nextWide) {
+                                break;
+                            }
+                            segText.append(buffer.get(baseX + seg, baseY + y).symbol());
+                            seg++;
+                        }
+                        appendTextSegment(matrix, segText.toString(), segStart, seg - segStart,
+                            charWidth, lineHeight, charHeight, y, className, uniqueId);
+                    }
                 }
             }
         }
@@ -360,6 +381,41 @@ public final class SvgExporter {
 
     private static int clamp(int v) {
         return Math.max(0, Math.min(255, v));
+    }
+
+    /**
+     * Emits a single {@code <text>} segment positioned at an exact column and pinned to a fixed
+     * number of display columns via {@code textLength}, so that wide (CJK/emoji) glyphs cannot
+     * push neighbouring columns and borders out of alignment regardless of the rendering font.
+     * All-space segments are skipped (their columns are still accounted for by the caller's
+     * absolute positioning).
+     *
+     * @param matrix     the buffer collecting {@code <text>} nodes
+     * @param text       the segment text
+     * @param startCol   the segment's starting column within the exported region
+     * @param cols       the segment's display width in columns
+     * @param charWidth  the width of one column in user units
+     * @param lineHeight the height of one row in user units
+     * @param charHeight the text baseline offset within a row
+     * @param y          the row index within the exported region
+     * @param className  the CSS class carrying the segment's style
+     * @param uniqueId   the export's unique id (for the per-line clip path)
+     */
+    private static void appendTextSegment(StringBuilder matrix, String text, int startCol, int cols,
+            double charWidth, double lineHeight, double charHeight, int y, String className,
+            String uniqueId) {
+        if (isAllSpaces(text)) {
+            return;
+        }
+        matrix.append(makeTag(
+            "text",
+            escapeText(text),
+            "class", className,
+            "x", format(startCol * charWidth),
+            "y", format(y * lineHeight + charHeight),
+            "textLength", format(charWidth * cols),
+            "clip-path", "url(#" + uniqueId + "-line-" + y + ")"
+        ));
     }
 
     private static boolean isAllSpaces(String text) {

--- a/tamboui-core/src/test/java/dev/tamboui/export/html/HtmlExporterTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/export/html/HtmlExporterTest.java
@@ -13,6 +13,7 @@ import dev.tamboui.style.Color;
 import dev.tamboui.style.Style;
 
 import static dev.tamboui.export.ExportRequest.export;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -34,6 +35,9 @@ final class HtmlExporterTest {
         assertTrue(html.contains(".r1 {") || html.contains(".r2 {"), "stylesheet with class rules");
         assertTrue(html.contains("class=\"r1\"") || html.contains("class=\"r2\""), "spans use classes not inline style");
         assertFalse(html.contains("<span style="), "non-embedded must not use inline styles");
+        // ASCII-only content must stay plain text: no inline-block wrappers, so box-drawing
+        // borders still connect vertically in the <pre> (see #415).
+        assertFalse(html.contains("display:inline-block"), "ASCII runs must not be wrapped in inline-block");
     }
 
     @Test
@@ -46,6 +50,36 @@ final class HtmlExporterTest {
         assertTrue(html.contains("<span style="), "embedded: styles inlined in spans");
         assertTrue(html.contains("font-weight: bold"));
         assertTrue(html.contains("Hi"));
+        assertFalse(html.contains("display:inline-block"), "ASCII runs must not be wrapped in inline-block");
         assertFalse(html.contains("class=\"r1\""), "embedded must not use stylesheet classes");
+    }
+
+    @Test
+    void wideGlyphsArePinnedToTwoColumnsInlineStyles() {
+        // Regression test for #415: each wide (CJK) glyph must be pinned to its 2-column
+        // display width so following columns and borders stay aligned regardless of the
+        // browser's font fallback. Only the wide glyphs are wrapped; ASCII stays plain so
+        // box-drawing borders keep connecting vertically.
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 6, 1));
+        buffer.setString(0, 0, "\u4e16\u754c|", Style.EMPTY.fg(Color.CYAN));
+
+        String html = export(buffer).as(Formats.HTML).options(o -> o.inlineStyles(true)).toString();
+
+        // Two wide glyphs, each pinned to 2ch; the 1-wide '|' border stays plain text.
+        assertTrue(html.contains("display:inline-block;width:2ch"), "CJK glyph pinned to 2 columns");
+        int wraps = html.split("display:inline-block", -1).length - 1;
+        assertEquals(2, wraps, "only the two wide glyphs are wrapped, not the border");
+    }
+
+    @Test
+    void wideGlyphsUseSharedClassInStylesheetMode() {
+        Buffer buffer = Buffer.empty(new Rect(0, 0, 6, 1));
+        buffer.setString(0, 0, "\u4e16\u754c|", Style.EMPTY.fg(Color.CYAN));
+
+        String html = export(buffer).as(Formats.HTML).toString();
+
+        assertTrue(html.contains(".cw2 {"), "stylesheet declares wide-glyph class");
+        assertTrue(html.contains("class=\"cw2\""), "wide glyphs reference the shared class");
+        assertTrue(html.contains("display:inline-block;width:2ch"), "wide-glyph class pins width to 2 columns");
     }
 }

--- a/tamboui-core/src/test/java/dev/tamboui/export/svg/SvgExporterTest.java
+++ b/tamboui-core/src/test/java/dev/tamboui/export/svg/SvgExporterTest.java
@@ -56,11 +56,11 @@ final class SvgExporterTest {
     }
 
     @Test
-    void textLengthMatchesDisplayColumnsForWideCharsAndEmoji() {
-        // Regression test for #415: box-drawing borders must align with content
-        // rows even when content contains wide (CJK) and emoji glyphs. Each
-        // <text> run must be sized by its display-column count, not by the
-        // number of UTF-16 code units in its symbols.
+    void textSegmentsSnapToTheColumnGridForWideCharsAndEmoji() {
+        // Regression test for #415: box-drawing borders must align with content rows even
+        // when content contains wide (CJK) and emoji glyphs. Every <text> segment must sit
+        // on the column grid: both its x offset and its textLength must be whole multiples
+        // of the column width, so wide/emoji glyphs cannot drift neighbouring columns.
         Buffer buffer = Buffer.empty(new Rect(0, 0, 12, 3));
         buffer.setString(0, 0, "\u256d\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256e", Style.EMPTY);
         // │世界AB🔮X│ : side bars + CJK (2 cols each) + ASCII + emoji (2 cols) = 12 columns
@@ -69,23 +69,33 @@ final class SvgExporterTest {
 
         String svg = export(buffer).as(Formats.SVG).options(o -> o.uniqueId("align")).toString();
 
-        List<Double> textLengths = textLengths(svg);
-        assertEquals(3, textLengths.size(), "expected one <text> run per row");
-        // All three rows span the same 12 display columns, so their textLength
-        // must be identical regardless of underlying UTF-16 length.
-        assertEquals(textLengths.get(0), textLengths.get(1), 0.0001,
-            "content row must have the same width as the top border");
-        assertEquals(textLengths.get(0), textLengths.get(2), 0.0001,
-            "bottom border must have the same width as the top border");
+        // charWidth = fontSize (20) * fontAspectRatio (0.61) = 12.2 user units per column.
+        double charWidth = 12.2;
+        List<double[]> segments = textSegments(svg);
+        assertFalse(segments.isEmpty(), "expected <text> segments in the export");
+        for (double[] seg : segments) {
+            double x = seg[0];
+            double textLength = seg[1];
+            assertEquals(0.0, remainderToGrid(x, charWidth), 0.01,
+                "segment x must sit on the column grid: " + x);
+            assertEquals(0.0, remainderToGrid(textLength, charWidth), 0.01,
+                "segment textLength must be a whole number of columns: " + textLength);
+        }
     }
 
-    private static List<Double> textLengths(String svg) {
-        List<Double> values = new ArrayList<>();
-        Matcher matcher = Pattern.compile("textLength=\"([0-9.]+)\"").matcher(svg);
+    private static double remainderToGrid(double value, double unit) {
+        double columns = value / unit;
+        return Math.abs(columns - Math.rint(columns)) * unit;
+    }
+
+    private static List<double[]> textSegments(String svg) {
+        List<double[]> segments = new ArrayList<>();
+        Matcher matcher = Pattern.compile("<text[^>]*\\bx=\"([0-9.]+)\"[^>]*textLength=\"([0-9.]+)\"")
+            .matcher(svg);
         while (matcher.find()) {
-            values.add(Double.parseDouble(matcher.group(1)));
+            segments.add(new double[]{Double.parseDouble(matcher.group(1)), Double.parseDouble(matcher.group(2))});
         }
-        return values;
+        return segments;
     }
 
     @Test


### PR DESCRIPTION
## Problem

Follow-up to #435 (SVG `textLength` alignment, already merged). Two related
export-alignment gaps remained for buffers containing wide (CJK) or emoji glyphs:

1. **HTML export** emitted each run as a bare `<span>` with no width, so alignment
   depended entirely on the browser's monospace font. CJK/emoji glyphs fall back
   to non-monospace metrics, so borders and adjacent columns drift — the same
   issue #415 describes for SVG, but with no `textLength` equivalent.
2. **Styled wide chars** were split from their continuation cells during
   run-grouping (continuation cells carry `Style.EMPTY`), compressing the glyph in
   SVG and dropping a column in HTML.

Relates to #415.

## Fix

- **HTML**: pin every run to `display:inline-block;width:{cols}ch;overflow:hidden`
  (width classes in stylesheet mode, inline in embedded mode) — the HTML analog of
  SVG's `textLength`. `1ch` = one monospace column, so ASCII runs are unchanged
  while CJK/emoji runs are held to their true column span.
- **SVG + HTML**: absorb continuation cells into their base run so a styled wide
  char spans its full column width.
- **Demo**: `export-demo` gains a CJK title and emoji cells so the exported
  SVG/HTML actually exercise the alignment.

Text export needs no change: plain text has no width metadata and already emits the
correct grapheme sequence; alignment is up to the viewer, which terminals handle.

## Tests

- `HtmlExporterTest`: runs carry width enforcement (`display:inline-block`,
  `width:{cols}ch`) in both stylesheet and embedded modes; a CJK run is pinned to
  its display-column count (`width:5ch` for `世界|`, not 3 UTF-16 units).

Full `:tamboui-core:test` passes (JDK 25 build).

> Note: `export-demo` pins `//DEPS dev.tamboui:tamboui-core:LATEST`, so running it
> via `jbang` shows the last *released* artifact until this ships. Build locally to
> see the fixed output.
