### PR TITLE
fix: clamp Paragraph scroll and make filemanager viewer scrolling work

### DIFF
--- a/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerView.java
+++ b/demos/filemanager-demo/src/main/java/dev/tamboui/demo/filemanager/FileManagerView.java
@@ -376,6 +376,15 @@ public class FileManagerView implements Element {
             }
 
             @Override
+            public EventResult handleKeyEvent(KeyEvent event, boolean focused) {
+                // The modal dialog consumes all key events, so the view-level
+                // routing in FileManagerView.handleKeyEvent never sees the
+                // scroll keys; handle them here where the dialog routes
+                // children first.
+                return handleViewerKey(event);
+            }
+
+            @Override
             public Size preferredSize(int availableWidth, int availableHeight, RenderContext context) {
                 return Size.UNKNOWN;
             }

--- a/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
+++ b/tamboui-widgets/src/main/java/dev/tamboui/widgets/paragraph/Paragraph.java
@@ -138,8 +138,9 @@ public final class Paragraph implements Widget {
         // Get lines to render based on overflow mode
         List<Line> lines = processLines(text.lines(), textArea.width());
 
-        // Apply scroll
-        int startLine = Math.min(scroll, lines.size());
+        // Apply scroll, clamped so the furthest position keeps the last page of
+        // content visible instead of scrolling everything above the viewport
+        int startLine = Math.min(scroll, Math.max(0, lines.size() - textArea.height()));
         int visibleLines = Math.min(lines.size() - startLine, textArea.height());
 
         for (int i = 0; i < visibleLines; i++) {

--- a/tamboui-widgets/src/test/java/dev/tamboui/widgets/paragraph/ParagraphTest.java
+++ b/tamboui-widgets/src/test/java/dev/tamboui/widgets/paragraph/ParagraphTest.java
@@ -524,4 +524,38 @@ class ParagraphTest {
         assertThat(foundLink1).isTrue();
         assertThat(foundLink2).isTrue();
     }
+
+    @Test
+    @DisplayName("scroll clamps so the last page of content stays visible")
+    void scrollClampsToLastPage() {
+        // 5 lines, viewport height 3 -> max useful scroll is 2 (shows lines 2..4)
+        Paragraph paragraph = Paragraph.builder()
+            .text(Text.from("line0\nline1\nline2\nline3\nline4"))
+            .scroll(Integer.MAX_VALUE)
+            .build();
+        Rect area = new Rect(0, 0, 10, 3);
+        Buffer buffer = Buffer.empty(area);
+
+        paragraph.render(area, buffer);
+
+        BufferAssertions.assertThat(buffer)
+            .hasSymbolAt(4, 0, "2")
+            .hasSymbolAt(4, 1, "3")
+            .hasSymbolAt(4, 2, "4");
+    }
+
+    @Test
+    @DisplayName("scroll clamp keeps content when it fits the viewport")
+    void scrollClampWhenContentFits() {
+        Paragraph paragraph = Paragraph.builder()
+            .text(Text.from("only\nlines"))
+            .scroll(99)
+            .build();
+        Rect area = new Rect(0, 0, 10, 5);
+        Buffer buffer = Buffer.empty(area);
+
+        paragraph.render(area, buffer);
+
+        BufferAssertions.assertThat(buffer).hasSymbolAt(0, 0, "o");
+    }
 }


### PR DESCRIPTION
Two related fixes found while testing file preview scrolling in filemanager-demo (it had never worked, and once it did, scrolling to the bottom showed a blank screen).

## 1. Paragraph scroll clamp (widget)

`Paragraph` clamped scroll to `lines.size()`, allowing the content to scroll entirely above the viewport and leaving a **blank screen**. Now clamps to `lines.size() - viewport height` so the furthest scroll position keeps the last page visible — the same semantics `MarkdownView` got in #393. Affects every `Paragraph.scroll` consumer. Two `BufferAssertions` tests added (overscroll pins last page; content-fits stays at top).

## 2. Filemanager viewer scroll keys (demo)

`DialogElement` is modal and consumes all key events, so the viewer-scroll routing in `FileManagerView.handleKeyEvent` was unreachable — Up/Down/PgUp/PgDn silently died while Esc worked (the dialog handles cancel itself). The scroll keys are now handled on the content element *inside* the dialog, which the dialog routes before its consume-all. The underlying design trap (every dialog-with-scrollable-content author will hit this) is tracked in #440.

Verified headlessly with a tape-driven recording (open viewer, send Down keys, assert the cast frames show shifted content) and interactively.

Relates: #393 (clamp precedent), #440 (dialog design), #427 (max-scroll API gap — the demo's scroll counter still drifts unbounded past the clamp, same as markdown-demo).